### PR TITLE
Update release/change log from tvheadend master

### DIFF
--- a/introduction/release-change-log.md
+++ b/introduction/release-change-log.md
@@ -1,1000 +1,3076 @@
+---
+layout:
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+---
+
 # Release / Change Log
 
 ## Releases, Nightly Builds and Change Log
+* [Update branch reference in workflow for documentation](#user-content-fn-1)[^1] ([2026-04-07 22:55:08](https://github.com/tvheadend/tvheadend/commit/63ae650aa49e8705dad1ad781c3550f32e40f37a))
 
-* [Update online help text](#user-content-fn-1)[^1] ([2025-06-21](https://github.com/tvheadend/tvheadend/commit/61d728e1a4bd3e35653a902bf82e3b57c5564013))
-* [fix memory leak 3 - transcoding](#user-content-fn-2)[^2] ([2025-06-12](https://github.com/tvheadend/tvheadend/commit/730718c2888a121a00b96f3460b2e8f5ca8396d1))
-* Recognise checkbox for feature proposals properly ([2025-06-10](https://github.com/tvheadend/tvheadend/commit/f7edaf48cbe2e068e2126a6b355ae64b2d1b1f6e))
-* User's DVR Configuration profile not used when scheduling recordings via HTSP ([2025-06-10](https://github.com/tvheadend/tvheadend/commit/7bbbe57e9ebb204e1070b219fda611be91bb0ae0))
-* [remove coded\_width and coded\_height from encoding](#user-content-fn-3)[^3] ([2025-06-10](https://github.com/tvheadend/tvheadend/commit/19026f3202fbacb8ddd89b13d358ee64ce7f4929))
-* Fix coverity builds ([2025-06-09](https://github.com/tvheadend/tvheadend/commit/09a06f11acf0d3957b6dfa08f13b48f7bd1262fd))
-* Add missing coverity env ([2025-06-09](https://github.com/tvheadend/tvheadend/commit/42ed6affc42ef06e427fb8b1465532a4489e182c))
-* [intl: docs: change freenode to Libera.Chat](#user-content-fn-4)[^4] ([2025-06-06](https://github.com/tvheadend/tvheadend/commit/6eb00af2fe19cfec2308027251563a16dd4e6004))
-* [intl: js: change freenode to Libera.Chat](#user-content-fn-5)[^5] ([2025-06-06](https://github.com/tvheadend/tvheadend/commit/aadcc3a8d946ad28e33cf721880abe4709bd44bc))
-* repo: cleanup README.md ([2025-06-06](https://github.com/tvheadend/tvheadend/commit/91d107523767bbf311682275c1c604ec420a0166))
-* [repo: cleanup CONTRIBUTING.md](#user-content-fn-6)[^6] ([2025-06-06](https://github.com/tvheadend/tvheadend/commit/c4ce95ab9603e0ceaccf868690aad7414af5cd95))
-* [ci: disable coverity on forks](#user-content-fn-7)[^7] ([2025-06-06](https://github.com/tvheadend/tvheadend/commit/56d23c8725b0563587eda0ccaed93153fa77505c))
-* Coverity CID 552897 ([2025-06-04](https://github.com/tvheadend/tvheadend/commit/0f74b0ab0a3b96d87da04d9c778142ecfb370a1d))
-* [HTSP: Expose is\_new flag in EPG event data](#user-content-fn-8)[^8] ([2025-06-04](https://github.com/tvheadend/tvheadend/commit/808a87a6aa6eeabd4be3a024e4eea023aaf00cf6))
-* Add API call 'status/activity'. ([2025-06-02](https://github.com/tvheadend/tvheadend/commit/8d469350fa67cb1ce923ecaf303d5ba3bf5c1518))
-* [fix for video stream detection](#user-content-fn-9)[^9] ([2025-06-02](https://github.com/tvheadend/tvheadend/commit/1288546386ae775200083ff0788dcdb8d783ce46))
-* [transcode: improve logging of packet transcode errors](#user-content-fn-10)[^10] ([2025-06-02](https://github.com/tvheadend/tvheadend/commit/3f78c11a44a4277048b52d34a3a6ae1a1fb5aced))
-* [transcode: gracefully handle common hardware decoder errors](#user-content-fn-11)[^11] ([2025-06-02](https://github.com/tvheadend/tvheadend/commit/85360924d0e215c2ba0b1b224e3111be712eae0f))
-* [fix dead error condition](#user-content-fn-12)[^12] ([2025-05-27](https://github.com/tvheadend/tvheadend/commit/532c2a71f2f7ad938e6763db2f0f3013863fffc0))
-* [fix memory leak 2 - transcoding](#user-content-fn-13)[^13] ([2025-05-27](https://github.com/tvheadend/tvheadend/commit/c0c55c7838ae505c04e90be16da9919b6d49a146))
-* Fix recording thread freeze when unable to create unique file name. ([2025-05-25](https://github.com/tvheadend/tvheadend/commit/1a3ca885a4706b57cb9326663955176f72804376))
-* [fix memory leak - transcoding](#user-content-fn-14)[^14] ([2025-05-25](https://github.com/tvheadend/tvheadend/commit/27b12a92d04d5120b9e61f16e620d496d18d6f6d))
-* [add mpegts parameters from input stream](#user-content-fn-15)[^15] ([2025-05-25](https://github.com/tvheadend/tvheadend/commit/ede23be0d25fc7d42f144fec551e4742f082a37c))
-* MKV Tags - Change rating label. Add Sub-title and Comment. ([2025-05-23](https://github.com/tvheadend/tvheadend/commit/26a14aa318a631a9f96008215e63efd6d6132727))
-* [fix memory leak](#user-content-fn-16)[^16] ([2025-05-22](https://github.com/tvheadend/tvheadend/commit/7e1f9caa95bf8d3d3e5c3a5eb687e7acf5b9a916))
-* [video hw accel should only be applied for video streams](#user-content-fn-17)[^17] ([2025-05-20](https://github.com/tvheadend/tvheadend/commit/ebac08749e1272e41ac94aadce8a4d716da3a779))
-* [Update VAAPI transcoding as recommended by ffmpeg 6.1.1/doc/examples/… (#1792)](#user-content-fn-18)[^18] ([2025-05-19](https://github.com/tvheadend/tvheadend/commit/75119b6e9640992cefe67cc3b45025367df7071e))
-* Add Sub-Title Processing Options for DVB OTA EPG ([2025-05-19](https://github.com/tvheadend/tvheadend/commit/36ba82848bc1837a9b9ee790219ae38e1228b576))
-* [update audio abuffersink from deprecated channel\_layouts to ch\_layouts and deprecated FF\_PROFILE\_\* --> AV\_PROFILE\_\*](#user-content-fn-19)[^19] ([2025-05-18](https://github.com/tvheadend/tvheadend/commit/7da199b61cb2589d65100d55bb736c378ad7c125))
-* iptv: handle relative key URL ([2025-05-17](https://github.com/tvheadend/tvheadend/commit/221400c9f2d41e974cc8f96269e65c1b2e20dce1))
-* \[Docker]: Tag alpine master as latest ([2025-05-15](https://github.com/tvheadend/tvheadend/commit/03272650dd6cc071163baeb03182bb77c249f024))
-* Show recording file name ([2025-05-14](https://github.com/tvheadend/tvheadend/commit/13804ab50ce41d81b987d97f050942efe49c4792))
-* [allow NVENC, VAAPI and MMAL to coexist in the same build](#user-content-fn-20)[^20] ([2025-05-14](https://github.com/tvheadend/tvheadend/commit/cf29292592756f778024b3f5d8df166dad899285))
-* [fix read/write of PT\_DYN\_INT](#user-content-fn-21)[^21] ([2025-05-14](https://github.com/tvheadend/tvheadend/commit/bdec3c501fe4ef6d5d8c1d94c3ba733ddb7e391c))
-* [lovcombo-all.js: Fix autorec create/edit TypeError with Firefox 134 (#1786)](#user-content-fn-22)[^22] ([2025-05-13](https://github.com/tvheadend/tvheadend/commit/cc07e3471e314469dca3086f134bf3384e06fc83))
-* [httpc.c: Fix HTTPS with OpenSSL 3.5 (#1813)](#user-content-fn-23)[^23] ([2025-05-13](https://github.com/tvheadend/tvheadend/commit/728885fbe3019c6896efc474c8cf336bfadaeea5))
-* [Remove links to old Wiki (#1793)](#user-content-fn-24)[^24] ([2025-05-13](https://github.com/tvheadend/tvheadend/commit/0eea8a59f0834e2a3babdd8028c02509428a097c))
-* Global setting for 'Items per page' ([2025-05-13](https://github.com/tvheadend/tvheadend/commit/da1ac73b92f1b9426bcf08dc7f8d2746cf139bb9))
-* [Translation for 'pl' updated.](#user-content-fn-25)[^25] ([2025-05-13](https://github.com/tvheadend/tvheadend/commit/e838e06bb2bb8eaa99eec2dfff0669092632d2e3))
-* [Translation for 'pl' updated.](#user-content-fn-26)[^26] ([2025-05-13](https://github.com/tvheadend/tvheadend/commit/4e3b56c1c6dc4725e5dcb1a6cbee652f159ce8fd))
-* [Translation for 'en\_GB' updated.](#user-content-fn-27)[^27] ([2025-05-13](https://github.com/tvheadend/tvheadend/commit/cf317a9223629fe5bdb49aa5bd5116bc77a361a7))
-* [Translation for 'en\_US' updated.](#user-content-fn-28)[^28] ([2025-05-13](https://github.com/tvheadend/tvheadend/commit/ba243eaf3eb8b70f765ae6d4ad3f33bd18e50a9a))
-* Fix crash when updating 'disp\_summary' ([2025-05-13](https://github.com/tvheadend/tvheadend/commit/df4eaf8e1913028c5cccd6320e462069382b6720))
-* [wizard: increase buffer size to silence -Wformat-truncation on GCC 15](#user-content-fn-29)[^29] ([2025-05-13](https://github.com/tvheadend/tvheadend/commit/cebe6159042c0782cbe22d26446b141fa07d43b8))
-* [Fix CI Builds 1/2](#user-content-fn-30)[^30] ([2025-05-12](https://github.com/tvheadend/tvheadend/commit/0805edc4b87d60757c9964fd19292e3ad0c33db3))
-* [Fix CI Builds 2/2](#user-content-fn-31)[^31] ([2025-05-12](https://github.com/tvheadend/tvheadend/commit/7ec167ae89bdc85ec8b7a918fbd014c12cfd9783))
-* Fix Cloudsmith uploads ([2025-05-12](https://github.com/tvheadend/tvheadend/commit/ab81dce3ebfef30626a8ddf3f9a68b6bdd4f47ba))
-* Check for hidden fields before reading them. Fixes #1782. ([2024-11-12](https://github.com/tvheadend/tvheadend/commit/653bd0400b4413db96b80c807f0f7524f9248adb))
-* iptv: allow to limit UDP ports for unicast inputs ([2024-10-08](https://github.com/tvheadend/tvheadend/commit/b69dac9299fde5fd43200a9a56c43bba1ce145cf))
-* [Translation for 'en\_GB' updated.](#user-content-fn-32)[^32] ([2024-10-08](https://github.com/tvheadend/tvheadend/commit/06fea47a6fa29f7eaf1ff015f0b095c7be622c1b))
-* [Translation for 'en\_US' updated.](#user-content-fn-33)[^33] ([2024-10-08](https://github.com/tvheadend/tvheadend/commit/26ec161fb3c903f8b0d0be8b54d1b67c596fb829))
-* [update libvpx v.1.14.1](#user-content-fn-34)[^34] ([2024-10-05](https://github.com/tvheadend/tvheadend/commit/eee5cdadf244b80efddedb944a55c9cdbb0ff6c9))
-* [Add start timeout to streaming profile](#user-content-fn-35)[^35] ([2024-09-28](https://github.com/tvheadend/tvheadend/commit/05c3170aef2d28136e34ba6b95afbbb57916e4d7))
-* [Fix - Audio transcoding not working #1663](#user-content-fn-36)[^36] ([2024-09-28](https://github.com/tvheadend/tvheadend/commit/28de5c092c657ffbbffa422c2ca3c07ba513c567))
-* fixes #1733 ([2024-09-23](https://github.com/tvheadend/tvheadend/commit/9dec5b585d8c1b4bb8ae8890985cc5a0148de24f))
-* Remove HTSP client version test for rating labels and string UUIDs ([2024-09-23](https://github.com/tvheadend/tvheadend/commit/55404da6cfd3b0dbbfd5982f87d31dc41f93f509))
-* Add full UUID to channel, chTag and dvrEntry. ([2024-09-06](https://github.com/tvheadend/tvheadend/commit/f9d5e885b307b07be012a9acff276f9e7dd2dbc5))
-* Add country and authority to HTPS messages containing rating labels. ([2024-09-06](https://github.com/tvheadend/tvheadend/commit/18ff23f909d8b5c27e9e209c7e50bc5bddce9da2))
-* HTSP: deliver 'comment' with autorecEntry(Add|Update), timerecEntry(Add|Update). Allow setting 'comment' with 'updateDvrEntry'. ([2024-09-06](https://github.com/tvheadend/tvheadend/commit/4aff543283b88017a59c90ccd7d22aee24b5ee4f))
-* Fixup updating comment in \_dvr\_entry\_update. Only overwrite existing title if comment is not NULL. Follows the same logic now as other updates done in this function. ([2024-09-06](https://github.com/tvheadend/tvheadend/commit/2e92208c3c97672efad3b5d65889a048bbebdea1))
-* bouquet: fix overzealous channel removals in merged multi-network setup ([2024-09-06](https://github.com/tvheadend/tvheadend/commit/9ac57a0c1a4551012260008cfca6bfc2386f6dcf))
-* HTSP: Expose DVR configuration id in 'dvrEntryAdd', 'dvrEntryUpdate', 'autorecEntryAdd', 'autorecEntryUpdate', 'timerecEntryAdd', 'timerecEntryUpdate'. ([2024-08-28](https://github.com/tvheadend/tvheadend/commit/dd82541c4c4c372a5b6af15e3dc0477f75c1b1bd))
-* HTSP: Expose broadcast type in 'autorecEntryAdd' and 'autorecEntryUpdate'. Handle broadcast type in 'addAutorecEntry' and 'updateAutorecEntry'. ([2024-08-25](https://github.com/tvheadend/tvheadend/commit/fc5a1672e083155193f3daf697748780f0d02aa9))
-* Fix mapping HTSP field 'broadcastType' to internal field. Must be 'btype'. ([2024-08-25](https://github.com/tvheadend/tvheadend/commit/266d03527936ea0d65e6edb06010cd91847493ab))
-* [Fix FTBFS introduced by 76d8fc8bc5455322558c764c84755ebbba254ad5](#user-content-fn-37)[^37] ([2024-08-24](https://github.com/tvheadend/tvheadend/commit/facbd4e4b79f6175daa45bfe5d724b8304648c12))
-* [fix bug in AAC channel layout configuration tab](#user-content-fn-38)[^38] ([2024-08-23](https://github.com/tvheadend/tvheadend/commit/3bb78afa456f6f430827450612b67f53f9cd211e))
-* Update Fedora versions for cloudsmith uploads ([2024-08-22](https://github.com/tvheadend/tvheadend/commit/f20e38daeb6a9727b24923eb77da2a35a96d8a3f))
-* HTSP: Expose service provider name with channel information. ([2024-08-22](https://github.com/tvheadend/tvheadend/commit/267aef151ec30fa9c5469500100ab7f59092d39a))
-* [update vaapi - vainfo](#user-content-fn-39)[^39] ([2024-08-12](https://github.com/tvheadend/tvheadend/commit/76d8fc8bc5455322558c764c84755ebbba254ad5))
-* [Update linuxdvb\_satconf.c - lnb poweroff requires power save](#user-content-fn-40)[^40] ([2024-08-12](https://github.com/tvheadend/tvheadend/commit/adef81b8d2a6edb3a665679f394bac05b7dc91c8))
-* Enforce issue templates on GitHub ([2024-08-10](https://github.com/tvheadend/tvheadend/commit/49ac9387186d32b55a399a04155e835eac22c6c1))
-* Fix function passed to avio\_alloc\_context() (ffmpeg 7) ([2024-08-04](https://github.com/tvheadend/tvheadend/commit/3c3a8af8f5f31303e7be91eca29b70b1b8dfad59))
-* Replace deprecated channels/channel\_layout ([2024-08-04](https://github.com/tvheadend/tvheadend/commit/078a822cf548b37bc474475fa57e48e9604090ee))
-* [Translation for 'en\_GB' updated.](#user-content-fn-41)[^41] ([2024-07-21](https://github.com/tvheadend/tvheadend/commit/f5c08ce327d07926aa7876bea48dd2c79dbdf09c))
-* [Translation for 'en\_US' updated.](#user-content-fn-42)[^42] ([2024-07-21](https://github.com/tvheadend/tvheadend/commit/b774bdd25351e51eba0282ccf7c65904dc1b5655))
-* Allow node16 for GitHub Actions ([2024-07-13](https://github.com/tvheadend/tvheadend/commit/652b291a65c059af43c788d19eeb473761402eab))
-* Add dependency for recent Fedora versions ([2024-07-13](https://github.com/tvheadend/tvheadend/commit/457c02d305d92a5036c6d3406f64e03de9ac235a))
-* Rework fullscreen request method detection ([2024-07-13](https://github.com/tvheadend/tvheadend/commit/1dc8ffe781b688f6ba7bacddd518399ea289efa6))
-* Refactor null value handling. ([2024-06-27](https://github.com/tvheadend/tvheadend/commit/1644b6e15738490c337a50d2b46fa4e9eb0a18e5))
-* [Remove tvheadend user on purge](#user-content-fn-43)[^43] ([2024-06-27](https://github.com/tvheadend/tvheadend/commit/d2e41b553e7cc6eb06fd21b42bbed4b3a1f28bc0))
-* Replace deprecated av\_init\_packet() ([2024-06-25](https://github.com/tvheadend/tvheadend/commit/33dc3f38192ccf47a73606c71319abf5604f7ad4))
-* Replace deprecated interlaced\_frame, top\_field\_first and key\_frame ([2024-06-25](https://github.com/tvheadend/tvheadend/commit/128d6861fac67ea6638c2956d092a46e23eb8988))
-* [Remove useless NULL-assignment in http.c](#user-content-fn-44)[^44] ([2024-06-23](https://github.com/tvheadend/tvheadend/commit/fd61453da3118c174cadca9cec1ee1d49f0a1548))
-* Fix potential null-pointer dereference in muxer\_mkv.c ([2024-06-23](https://github.com/tvheadend/tvheadend/commit/cd6bfbb0bb45e7a22690f3d82183125f2b105cfd))
-* [Remove useless NULL-check in ratinglabels.c](#user-content-fn-45)[^45] ([2024-06-23](https://github.com/tvheadend/tvheadend/commit/c8435a0985ca66a9bd12f33703c8f76c95ddea43))
-* [Use safer htsmsg\_add\_str2 when copying de->de\_directory](#user-content-fn-46)[^46] ([2024-06-18](https://github.com/tvheadend/tvheadend/commit/e855f62e6697cf756ad2eed2ed03b8d06ba2019b))
-* XMLTV: Rating Labels: Use 'NONE' when 'system' attribute is missing ([2024-06-15](https://github.com/tvheadend/tvheadend/commit/366e5629057e39de68932a0a0613a8af14076e31))
-* [dvr: Added missing directory to rerecord-entry](#user-content-fn-47)[^47] ([2024-06-06](https://github.com/tvheadend/tvheadend/commit/6c5c8eae494943b7749b3fc9ee58a30ab1983bf4))
-* [Extend CORS origin help/hover message ](#user-content-fn-48)[^48]\([2024-06-06](https://github.com/tvheadend/tvheadend/commit/e6b1d5ffbaa59956aeea7a9ace2410638cbcc211))
-* Make builds parallel and add bookworm and ubuntu 24.04 builds ([2024-06-06](https://github.com/tvheadend/tvheadend/commit/f159f6aec04526c20837fe43c1c7ba9117555955))
-* Update x265 to 3.6 ([2024-06-06](https://github.com/tvheadend/tvheadend/commit/f9910c065b9f080dbfd03728501effa6197dfbbe))
-* Add current pcloud cert ([2024-06-06](https://github.com/tvheadend/tvheadend/commit/ccc0a8e5ff904bf5f06d430378d0be9f3235b39f))
-* Update nasm ([2024-06-06](https://github.com/tvheadend/tvheadend/commit/2eba40c99c974347271b813af488917c17a077d8))
-* Update libx264 ([2024-06-06](https://github.com/tvheadend/tvheadend/commit/504d0328743312e4a15f0f31be1fc4f64239e06a))
-* Update libogg and libfdkaac ([2024-06-06](https://github.com/tvheadend/tvheadend/commit/45033919aeeb10acd9f21a52ed53b89065eaec27))
-* Always compile x265 as PIC ([2024-06-06](https://github.com/tvheadend/tvheadend/commit/552f9414e26f1d1d80440881da44c24db6968b5d))
-* [Allow setting a custom grace period for LinuxDVB adapters](#user-content-fn-49)[^49] ([2024-06-06](https://github.com/tvheadend/tvheadend/commit/f15f05761fb713fb9d754e94fc92253922fc4357))
-* [Docker/Alpine: Remove USB group](#user-content-fn-50)[^50] ([2024-06-05](https://github.com/tvheadend/tvheadend/commit/5432361184cc4afa585bf31914e58c0a0eee66ee))
-* [tvhdhomerun: Add ISDB to type check in tvhdhomerun\_device\_create](#user-content-fn-51)[^51] ([2024-06-05](https://github.com/tvheadend/tvheadend/commit/3ac184725c3d4b58aa6cd15691e6fab6a0d22e07))
-* Correct M3U playlist logo tag ([2024-04-26](https://github.com/tvheadend/tvheadend/commit/c42043188e73057cf9f5db0aefaed38f8384bbe8))
-* [Fix echo target for superuser file in Debian postinst](#user-content-fn-52)[^52] ([2024-04-26](https://github.com/tvheadend/tvheadend/commit/73a6bd00d29421da04be5e1c41b2097fdc9c148b))
-* Properly escape json in setup ([2024-04-25](https://github.com/tvheadend/tvheadend/commit/aba5e60792177d6a2a867445559f4806973b3258))
-* [satip: Ignore additional parameters](#user-content-fn-53)[^53] ([2024-04-24](https://github.com/tvheadend/tvheadend/commit/aaccc147ea0aac385241d038fd7f1bd3f6d32d10))
-* Update WebUI to allow debug/trace subsystem selection from a list. ([2024-04-20](https://github.com/tvheadend/tvheadend/commit/b100585070ef794225397d7b99375a5bef246d46))
-* [configure: fix parsing args if values contain "="](#user-content-fn-54)[^54] ([2024-04-20](https://github.com/tvheadend/tvheadend/commit/a68d340a89a3786c441185698ae999b86d77c777))
-* Add subsystems to JSON API. ([2024-04-13](https://github.com/tvheadend/tvheadend/commit/223f83b6ec616e5c254b97dd52bd49106b09e33a))
-* [Fix detection of unknown version numbers in support/version](#user-content-fn-55)[^55] ([2024-04-08](https://github.com/tvheadend/tvheadend/commit/4874aaa3161fbdd8b9d3abe50fd3fa20b18f8b0b))
-* [webui: Fix year being replaced incorrectly when using custom date format](#user-content-fn-56)[^56] ([2024-03-24](https://github.com/tvheadend/tvheadend/commit/cbaf2b1de79206c311a3967cae5928e65c988daf))
-* [Update manpage](#user-content-fn-57)[^57] ([2024-03-24](https://github.com/tvheadend/tvheadend/commit/ab6ea89b11b1f1a8dcbfd7cfc29d65b3013f2702))
-* [Translation for 'pl' updated.](#user-content-fn-58)[^58] ([2024-03-22](https://github.com/tvheadend/tvheadend/commit/c63115464d8f6556fb4cac93ce8740afea1b00d5))
-* [Translation for 'pl' updated.](#user-content-fn-26)[^26] ([2024-03-18](https://github.com/tvheadend/tvheadend/commit/fb16d716e88cb8cb35fb03056c8c0ca8cddeaaec))
-* [Translation for 'pl' updated.](#user-content-fn-59)[^59] ([2024-03-18](https://github.com/tvheadend/tvheadend/commit/9a74f3f939612e61382ebfd21fcbd8cebab70dca))
-* [Translation for 'pl' updated.](#user-content-fn-59)[^59] ([2024-03-18](https://github.com/tvheadend/tvheadend/commit/2b591b093db66cd130159b1f492d2e112d5eb212))
-* [Translation for 'pl' updated.](#user-content-fn-60)[^60] ([2024-03-18](https://github.com/tvheadend/tvheadend/commit/1f6b8b0e738c4b4aba676d3e1258bc3c4a7901b0))
-* [Translation for 'pl' updated.](#user-content-fn-61)[^61] ([2024-03-18](https://github.com/tvheadend/tvheadend/commit/ccaa407a13cf86ba5bef391963a547219ab74324))
-* [Translation for 'pl' updated.](#user-content-fn-62)[^62] ([2024-03-18](https://github.com/tvheadend/tvheadend/commit/fd0c8bf5d3053b602d96f3c60121302eadc8c157))
-* [Translation for 'pl' updated.](#user-content-fn-63)[^63] ([2024-03-18](https://github.com/tvheadend/tvheadend/commit/1014bb87f7691e6088544156f1fbf207d11ffa54))
-* [Translation for 'pl' updated.](#user-content-fn-64)[^64] ([2024-03-18](https://github.com/tvheadend/tvheadend/commit/433b1e975df93e953fdd933fad7b3a346c60db80))
-* [Translation for 'pl' updated.](#user-content-fn-65)[^65] ([2024-03-18](https://github.com/tvheadend/tvheadend/commit/ed4e48bed955b516acd3d4bc8d9395d3dd4ce5e7))
-* [Translation for 'pl' updated.](#user-content-fn-66)[^66] ([2024-03-18](https://github.com/tvheadend/tvheadend/commit/50ef73a39566f941efefe71ef4c85c377c9156ae))
-* [Translation for 'pl' updated.](#user-content-fn-67)[^67] ([2024-03-18](https://github.com/tvheadend/tvheadend/commit/a2127cc121a4b29ff1fd866cf1ae360208e5f391))
-* [Translation for 'pl' updated.](#user-content-fn-68)[^68] ([2024-03-18](https://github.com/tvheadend/tvheadend/commit/19c502b15a91360470ca8212261acbe3f8f79058))
-* [Update README.md](#user-content-fn-69)[^69] ([2024-03-14](https://github.com/tvheadend/tvheadend/commit/1212b940b584e336da175361d02a5c193a3b65c0))
-* CI: remove NODIRTY option as those builds may be dirty ([2024-03-09](https://github.com/tvheadend/tvheadend/commit/79aaa14346d9d40f3728c4b0fdc7b4240da76364))
-* [Create special tvheadend-armv6l and tvheadend-dbg-armv6l packages](#user-content-fn-70)[^70] ([2024-03-08](https://github.com/tvheadend/tvheadend/commit/ba3b5e56f2f25efb8298a12b5118843de053813d))
-* Improve armv6l-packages and remove various outdated references/commands ([2024-03-08](https://github.com/tvheadend/tvheadend/commit/145efcd4c72d46102d51e06cf9f9c96b6bb40c61))
-* Revert accidental package renaming ([2024-03-08](https://github.com/tvheadend/tvheadend/commit/e287b2fc600c9874e72211a97f2200d4e10ca574))
-* [Translation for 'pl' updated.](#user-content-fn-26)[^26] ([2024-03-07](https://github.com/tvheadend/tvheadend/commit/5e9feb1a9c65f13bacb7378b623ddda00992964f))
-* [Translation for 'pl' updated.](#user-content-fn-25)[^25] ([2024-03-07](https://github.com/tvheadend/tvheadend/commit/0a682e82e1a658c960a9c453fec3fcc2d3d77fd9))
-* [Translation for 'pl' updated.](#user-content-fn-26)[^26] ([2024-03-07](https://github.com/tvheadend/tvheadend/commit/4d5166ca4b98299cff7a3d90e2fe44dc5720ad00))
-* [update to libvpx 1.14.0-patch](#user-content-fn-71)[^71] ([2024-03-03](https://github.com/tvheadend/tvheadend/commit/9ac61d7677feaf1078e2f3752cd8e580e2e61267))
-* [Translation for 'pl' updated.](#user-content-fn-26)[^26] ([2024-03-01](https://github.com/tvheadend/tvheadend/commit/eba8414941efd95435418c6f0fa9b5eaabe1d1b3))
-* [Translation for 'pl' updated.](#user-content-fn-26)[^26] ([2024-03-01](https://github.com/tvheadend/tvheadend/commit/a5bafb26e0d92c3f76e0be791ac62ffcd341ae78))
-* [Translation for 'pl' updated.](#user-content-fn-25)[^25] ([2024-03-01](https://github.com/tvheadend/tvheadend/commit/7e694e3c0b45423769f914d1212e1f32336579ea))
-* ci: added more info logging to cloudsmith.sh ([2024-03-01](https://github.com/tvheadend/tvheadend/commit/ae97d5bc57ae551febf342cca9b0c7c927a29d4d))
-* Improve autorec duplicate handling ([2024-03-01](https://github.com/tvheadend/tvheadend/commit/a9c6db8acbd85297238771b8b4430435b7994928))
-* [Translation for 'cs' updated.](#user-content-fn-72)[^72] ([2024-02-23](https://github.com/tvheadend/tvheadend/commit/80fa520753f2216b4f12fee877511d8fdbbf130d))
-* [Translation for 'de' updated.](#user-content-fn-73)[^73] ([2024-02-23](https://github.com/tvheadend/tvheadend/commit/af8a49376e103699d56b013ccb0781c6510386d0))
-* [Translation for 'fr' updated.](#user-content-fn-74)[^74] ([2024-02-23](https://github.com/tvheadend/tvheadend/commit/657c41b42a3d60f025f44a8a74c4c2fc80aebcf7))
-* [Translation for 'hu' updated.](#user-content-fn-75)[^75] ([2024-02-23](https://github.com/tvheadend/tvheadend/commit/8b04bfec9537d481e279b9617feb13f451076551))
-* [Translation for 'es' updated.](#user-content-fn-76)[^76] ([2024-02-23](https://github.com/tvheadend/tvheadend/commit/dc4150158bb6f3af2a95f91266c1c138b278cfc2))
-* [Translation for 'nl' updated.](#user-content-fn-77)[^77] ([2024-02-23](https://github.com/tvheadend/tvheadend/commit/38c3c281a5c0102aab0a50f2eae16fb1171a02dc))
-* [Translation for 'et' updated.](#user-content-fn-78)[^78] ([2024-02-23](https://github.com/tvheadend/tvheadend/commit/764b582eb96db2f3d06784c0ed95d58a8afbeb08))
-* [Translation for 'en\_GB' updated.](#user-content-fn-79)[^79] ([2024-02-23](https://github.com/tvheadend/tvheadend/commit/64e6a376532e07823ddb42afd935e6b361e89b93))
-* [Translation for 'it' updated.](#user-content-fn-80)[^80] ([2024-02-23](https://github.com/tvheadend/tvheadend/commit/5e59bc8f3cb1ea339fb1dd6475252c06630ab1a7))
-* [Translation for 'en\_US' updated.](#user-content-fn-81)[^81] ([2024-02-23](https://github.com/tvheadend/tvheadend/commit/13b1c04093284675bae7a1d669ad1e113359b4af))
-* [Translation for 'pt' updated.](#user-content-fn-82)[^82] ([2024-02-23](https://github.com/tvheadend/tvheadend/commit/5d9ef4efed72aaa4e7033d28783cc6bf4809b397))
-* [Translation for 'ko' updated.](#user-content-fn-83)[^83] ([2024-02-23](https://github.com/tvheadend/tvheadend/commit/2be93efe3cb7899bd697547239127911e663a562))
-* [Translation for 'pl' updated.](#user-content-fn-26)[^26] ([2024-02-23](https://github.com/tvheadend/tvheadend/commit/8cce99fedbd08c5737d57d8813832d61ac056fa3))
-* [Translation for 'pl' updated.](#user-content-fn-26)[^26] ([2024-02-23](https://github.com/tvheadend/tvheadend/commit/8b429efb72f6da7b62878bbb9ceafd14b8d00732))
-* Replace broken links, update copyright year ([2024-02-23](https://github.com/tvheadend/tvheadend/commit/ae51d24fe1c50a591d4e25ec76076560a6e2e962))
-* [Translation for '(#1655)' updated.](#user-content-fn-84)[^84] ([2024-02-22](https://github.com/tvheadend/tvheadend/commit/9b88c25022f84c886232d60bc62bc6e6bfd47fb8))
-* Add OpenCollective donate link to Wizard ([2024-02-22](https://github.com/tvheadend/tvheadend/commit/60bd9dce6a10f80c09cc30b1be82825e0f1f805b))
-* Give comment-on-labels.yml permissions to write to PRs ([2024-02-22](https://github.com/tvheadend/tvheadend/commit/7acca01c4153adc1dd409c82f27338fdeb353045))
-* ci: change CLOUDSMITH\_OWNER from a var to a secret ([2024-02-21](https://github.com/tvheadend/tvheadend/commit/41a326bcecd80a2d4c6ca50b0e62af4acea894ba))
-* [Make sure we spawn the best matching executable and not the first match](#user-content-fn-85)[^85] ([2024-02-21](https://github.com/tvheadend/tvheadend/commit/e02e812ee550e93cd0aacaa9677036d977c1d94b))
-* Fix Auto-PR comment on squash-label ([2024-02-21](https://github.com/tvheadend/tvheadend/commit/0d26809e39c41bead3aef33fd4a815512aa312ab))
-* Run enforce-pr-rebase whenever a PR is updated ([2024-02-21](https://github.com/tvheadend/tvheadend/commit/a8f525f36ca777345218726269ea2bb8ef1cbd43))
-* Add some ERRNOs for DVR & Config ([2024-02-20](https://github.com/tvheadend/tvheadend/commit/df46dea3524b313bfeffa60dbeb42b4c93d44099))
-* Show SeriesLink for AutoRecs ([2024-02-20](https://github.com/tvheadend/tvheadend/commit/771504eb3ea8540cc3c558e8fa91aa67acd6f350))
-* Replace poison memset by memset\_s to avoid compiler optimising it out ([2024-02-20](https://github.com/tvheadend/tvheadend/commit/c7a63e7e3b7c15d6f2c1048efafbaaa5a854ea7d))
-* [Translation for 'pl' updated.](#user-content-fn-25)[^25] ([2024-02-20](https://github.com/tvheadend/tvheadend/commit/a2c5a039fb4aa8d4c38aa4d1752ed9ebbcd04815))
-* [Translation for 'pl' updated.](#user-content-fn-26)[^26] ([2024-02-20](https://github.com/tvheadend/tvheadend/commit/3cb8f2bf1e21dce5f88ce7a57a8903d99bd36cec))
-* [Translation for 'pl' updated.](#user-content-fn-26)[^26] ([2024-02-20](https://github.com/tvheadend/tvheadend/commit/c723dfa4b927cac9552e544a4e9557767ac17b8f))
-* [Translation for 'pl' updated.](#user-content-fn-25)[^25] ([2024-02-20](https://github.com/tvheadend/tvheadend/commit/76f4d6809ed52e926a78218e817c6422c4a1beac))
-* [Translation for 'pl' updated.](#user-content-fn-25)[^25] ([2024-02-20](https://github.com/tvheadend/tvheadend/commit/06451ae9f32aad87f55c38b09dfa2ff9b20886bb))
-* [Translation for 'pl' updated.](#user-content-fn-26)[^26] ([2024-02-20](https://github.com/tvheadend/tvheadend/commit/b8bd1672686f71ad5027a81e48e41eff8bfb11d8))
-* [ci: Enforce rebasing PRs before merging](#user-content-fn-86)[^86] ([2024-02-19](https://github.com/tvheadend/tvheadend/commit/15e1e3f08026e98047bc7d1ff50aeb306f797234))
-* [Replace single-bit signed integers with unsigned integers](#user-content-fn-87)[^87] ([2024-02-19](https://github.com/tvheadend/tvheadend/commit/2b0b6a4c4c82adeaed9793f574e39247473c43e1))
-* Add missing htmsg\_destroy() call in hdhomerun\_server\_discover ([2024-02-19](https://github.com/tvheadend/tvheadend/commit/4430ee70f2a2888853d944fe7de619e51880f515))
-* Add support for 12-hour custom date formats ([2024-02-19](https://github.com/tvheadend/tvheadend/commit/2ca8a19e4c8761af1a6653fed09af658e9cd5b67))
-* [Add missing tvheadend-prefix in JS file](#user-content-fn-88)[^88] ([2024-02-19](https://github.com/tvheadend/tvheadend/commit/c3a7ce11cec531f8eebaa9f9391e60379533cbe2))
-* Shorten time for stale issues before a warning is applied ([2024-02-19](https://github.com/tvheadend/tvheadend/commit/595bbaad56dba7c19eed54ced143d1c58c362c81))
-* ci: Use correct version of merge commit block action ([2024-02-18](https://github.com/tvheadend/tvheadend/commit/075e6cdf7fe9169a8a862b5d9795c5917a3993a9))
-* [bouquet: Allow merging of services across network bouquet, fixes #5617](#user-content-fn-89)[^89] ([2024-02-18](https://github.com/tvheadend/tvheadend/commit/b0be01cb034f16a59ee449ac365c953165b0c61b))
-* [Translation for 'pl' updated.](#user-content-fn-26)[^26] ([2024-02-18](https://github.com/tvheadend/tvheadend/commit/e4a495486a43e9a4623574e15b6cbb818ae84514))
-* [Translation for 'pl' updated.](#user-content-fn-25)[^25] ([2024-02-18](https://github.com/tvheadend/tvheadend/commit/d98312dac6507746c55216f5a8f23e6bd3ec2d47))
-* [Translation for 'pl' updated.](#user-content-fn-26)[^26] ([2024-02-18](https://github.com/tvheadend/tvheadend/commit/828d43861a991208b4ddbd46c2e0335ddb0dd90c))
-* [Translation for 'pl' updated.](#user-content-fn-25)[^25] ([2024-02-18](https://github.com/tvheadend/tvheadend/commit/2962b4318c29b2aafc5da1fb9ebbddfb1e34aaea))
-* [Translation for 'pl' updated.](#user-content-fn-26)[^26] ([2024-02-18](https://github.com/tvheadend/tvheadend/commit/bdaf0f32397072b0b8c5fdbed21ee9dba5c50005))
-* [Translation for 'pl' updated.](#user-content-fn-25)[^25] ([2024-02-18](https://github.com/tvheadend/tvheadend/commit/6372bd0d753865ae90bcdfa5abd723be3827497a))
-* [Translation for 'pl' updated.](#user-content-fn-90)[^90] ([2024-02-17](https://github.com/tvheadend/tvheadend/commit/6a40d60d8f925f3e14470a5c0cc5a549914d09a1))
-* [Translation for 'pl' updated.](#user-content-fn-90)[^90] ([2024-02-17](https://github.com/tvheadend/tvheadend/commit/7435051aa5ae7ba16a43269dc3788b7d7630b62c))
-* [Translation for 'pl' updated.](#user-content-fn-90)[^90] ([2024-02-17](https://github.com/tvheadend/tvheadend/commit/d37022cf78aae6ab863cca91ba299d582d846a52))
-* [Translation for 'pl' updated.](#user-content-fn-90)[^90] ([2024-02-17](https://github.com/tvheadend/tvheadend/commit/00394f8068fa29a385b991c02570a3b8305a4204))
-* [Translation for 'pl' updated.](#user-content-fn-90)[^90] ([2024-02-17](https://github.com/tvheadend/tvheadend/commit/92ae05a5e1ea7f4724ad77c5c296e0e7e865441e))
-* [Translation for 'pl' updated.](#user-content-fn-90)[^90] ([2024-02-17](https://github.com/tvheadend/tvheadend/commit/abe4081e4264ea49bc7f3571264fb9f8c6fa3458))
-* Remove broken codeball ([2024-02-17](https://github.com/tvheadend/tvheadend/commit/3ca673c8a363d5103d15c72f0573ff47c4c4d222))
-* Add automatic labels to PRs ([2024-02-17](https://github.com/tvheadend/tvheadend/commit/d85be496a68a8e946c8c21754657f407fa52c04e))
-* docs: Fix broken Readme.md badge for builds ([2024-02-17](https://github.com/tvheadend/tvheadend/commit/c53b0f5bb013e1d186988d2b1067c0fb58277034))
-* ci: Block merge or autosquash commits in PRs ([2024-02-17](https://github.com/tvheadend/tvheadend/commit/757eaa92a5ed6d538a08807b1170cb1e5407c354))
-* [intl: update translation templates from code](#user-content-fn-91)[^91] ([2024-02-16](https://github.com/tvheadend/tvheadend/commit/ccb8b5e2d0260ad40f7e7fde4dbe655f7704b96e))
-* ci: use CURL for cloudsmith.sh and enable RPM upload ([2024-02-15](https://github.com/tvheadend/tvheadend/commit/4c1a1d26e786175352c891836a25e16e893d12cc))
-* [CI: Ensure we clone the whole repo](#user-content-fn-92)[^92] ([2024-02-11](https://github.com/tvheadend/tvheadend/commit/6b5defc76d71c184a5a7a5e82f2a9c0eaf3a65f3))
-* [container: Add container support](#user-content-fn-93)[^93] ([2024-02-10](https://github.com/tvheadend/tvheadend/commit/ce429efe9bc48acd31cfb9f2e971fa3094a7f147))
-* [transcoding: access the codec name only when codec pointer is valid](#user-content-fn-94)[^94] ([2024-02-09](https://github.com/tvheadend/tvheadend/commit/a2ddd30661058955dd1ac3ff9e59b49dc4188bb6))
-* [dvr: Fix incorrect usage of `strerror`](#user-content-fn-95)[^95] ([2024-02-08](https://github.com/tvheadend/tvheadend/commit/b91587037c6099e77d233877162e36138c62e5b2))
-* [Add "recordings" to the backup exclude list](#user-content-fn-96)[^96] ([2024-02-07](https://github.com/tvheadend/tvheadend/commit/8bd13ca278f3826826a0eeedf9ab1bce951b4244))
-* [Correct description of Change Parameters flag](#user-content-fn-97)[^97] ([2024-02-06](https://github.com/tvheadend/tvheadend/commit/63c41acc6ec404e202cf0e4f79cbbefd0daae895))
-* [Translation for 'pt' updated.](#user-content-fn-98)[^98] ([2024-02-05](https://github.com/tvheadend/tvheadend/commit/4b70198205232a5e80786b33339cc44f2250f6b4))
-* [Translation for 'pt' updated.](#user-content-fn-98)[^98] ([2024-02-05](https://github.com/tvheadend/tvheadend/commit/5f2e23e2eae9584cdaff2a199c5d0625dccd14ee))
-* [Translation for 'pt' updated.](#user-content-fn-98)[^98] ([2024-02-05](https://github.com/tvheadend/tvheadend/commit/a793cc95323d1b22ff722c71c248897cee4a2af4))
-* [Translation for 'pt' updated.](#user-content-fn-98)[^98] ([2024-02-05](https://github.com/tvheadend/tvheadend/commit/d784d52ef7f0f9bc0881086b0e8c963bda7df2da))
-* [Translation for 'pt' updated.](#user-content-fn-98)[^98] ([2024-02-05](https://github.com/tvheadend/tvheadend/commit/d944d87a0c2f599619b6f1e227da767ff267e9e3))
-* [Translation for 'pt' updated.](#user-content-fn-98)[^98] ([2024-02-05](https://github.com/tvheadend/tvheadend/commit/14bffd8f854fbc3d4664ab704f5cc2c3c6746fb2))
-* [Translation for 'en\_US' updated.](#user-content-fn-99)[^99] ([2024-02-05](https://github.com/tvheadend/tvheadend/commit/154cf25ada0da959e4ca3ab2353fcbf87bcec4cb))
-* descrambler: Fix Sky-UK descrambling ([2024-02-05](https://github.com/tvheadend/tvheadend/commit/6409a6382f1ded18cd6f21649519879c410eb8ab))
-* [satipcli: Rename flag to include client reference](#user-content-fn-100)[^100] ([2024-02-04](https://github.com/tvheadend/tvheadend/commit/9b00888e319c412a2a91008b1f78f4482975b879))
-* Sanitise filename in content-disposition header ([2024-02-03](https://github.com/tvheadend/tvheadend/commit/154b202288701013be926d5c13b205504483db93))
-* Fix audio-only timeshift memory usage ([2024-02-03](https://github.com/tvheadend/tvheadend/commit/990b5a8f41dd9c0c039d4ce551e35809a4acbb22))
-* Automatically comment on PRs needing squash ([2024-02-03](https://github.com/tvheadend/tvheadend/commit/ac4a041e00529ba5325755061cd6caef0e3e8210))
-* Mark PRs needing squashing as stale after a while ([2024-02-03](https://github.com/tvheadend/tvheadend/commit/f12919042c60566e3dd90d58940e3add60550e7a))
-* Remove sweep-ai again as it is not useful at all ([2024-02-03](https://github.com/tvheadend/tvheadend/commit/5acf42462141e26d2c5114c59b672c5f6cec634b))
-* [main: Warn about unexpected configuration location](#user-content-fn-101)[^101] ([2024-02-02](https://github.com/tvheadend/tvheadend/commit/0485cf470b64d3cfcc5a4e62c711789ff316cea8))
-* Add stale-bot for issues/PRs needing more info ([2024-02-02](https://github.com/tvheadend/tvheadend/commit/8ceb72f9307371da3318ac2efea768a683548b2b))
-* [Configure Sweep (#1612)](#user-content-fn-102)[^102] ([2024-02-02](https://github.com/tvheadend/tvheadend/commit/c7f46ec5650ce7dda0b4f60bdb02b6996efff368))
-* [Fix handling of legacy configuration directories in debian/postinst](#user-content-fn-103)[^103] ([2024-02-02](https://github.com/tvheadend/tvheadend/commit/360ece9f140f2498138c3a169363dc9c6cb4add6))
-* [Clean up Debian postinst and postrm scripts](#user-content-fn-104)[^104] ([2024-02-02](https://github.com/tvheadend/tvheadend/commit/b225e4d6ccb966824f453aeabbd311799d24b471))
-* [Use sigaction() instead of signal()](#user-content-fn-105)[^105] ([2024-02-01](https://github.com/tvheadend/tvheadend/commit/717056be02e1d1754bc86948c8523964c5ea0f1c))
-* [templates: add log section to bug\_report.yml](#user-content-fn-106)[^106] ([2024-01-31](https://github.com/tvheadend/tvheadend/commit/af5e2c962a3ac7a170f343ef3beb9bdf18f34a93))
-* Add timeshift support for audio-only channels ([2024-01-31](https://github.com/tvheadend/tvheadend/commit/bcfbe7dbeebb79c08fad22a214ecbfbbd426a3bd))
-* Add missing Lithuanian string template (#1608) ([2024-01-30](https://github.com/tvheadend/tvheadend/commit/6229a74aa08cc41fae2f64864543f961809531f1))
-* ci: fix cloudsmith.sh & add to CI workflow ([2024-01-28](https://github.com/tvheadend/tvheadend/commit/212e85c91e6138af58e9757fdb8893e1685d0cb5))
-* [src: filesystem permission fixes](#user-content-fn-107)[^107] ([2024-01-24](https://github.com/tvheadend/tvheadend/commit/7b762336e1a4f7cfdc154d394fb17b1a26659cf1))
-* ci: fix broken cloudsmith python ([2024-01-23](https://github.com/tvheadend/tvheadend/commit/bebc91b7f349d56536ea94e8a12c0445f9657f41))
-* [templates: add config.yml](#user-content-fn-108)[^108] ([2024-01-23](https://github.com/tvheadend/tvheadend/commit/88e83bb81769c3ad87ed94c15a39a7a94a5160fe))
-* [templates: add bug\_report.yml](#user-content-fn-109)[^109] ([2024-01-23](https://github.com/tvheadend/tvheadend/commit/e1dc30088df8e313f1ba102be79d1658332628bd))
-* [templates: add feature\_proposal.yml](#user-content-fn-110)[^110] ([2024-01-23](https://github.com/tvheadend/tvheadend/commit/5cdc6cb1c3dfbb9f6edc051431e62fa2cf91eef8))
-* ci: fix cloudsmith for python3.5 ([2024-01-22](https://github.com/tvheadend/tvheadend/commit/e954d1661da3b32d4ac52e8a365444453a9b83ed))
-* [update to ffmpeg 6.1.1](#user-content-fn-111)[^111] ([2024-01-21](https://github.com/tvheadend/tvheadend/commit/b7d5a1632f3088368ade07bce7412f46968e9ae9))
-* descrambler: avoid dlopen() ([2024-01-11](https://github.com/tvheadend/tvheadend/commit/b4b1cbd479f3ec3856ed35e5931eab2aff3892fd))
-* descrambler: apply ICAM update from Chris230291 ([2024-01-11](https://github.com/tvheadend/tvheadend/commit/c9b38a81aa3d3a379d8b41cc0ffab1307304da48))
-* linuxdvb: add DVB-S2X parameters ([2024-01-05](https://github.com/tvheadend/tvheadend/commit/2151348f7198061a22de3cfc4f4407634554003b))
-* descrambler: support ICAM if detected in libdvbcsa ([2024-01-04](https://github.com/tvheadend/tvheadend/commit/899b38ae5b960688b600be3e77526d92cecea536))
-* [ci: fix raspios detection in cloudsmith.sh](#user-content-fn-112)[^112] ([2024-01-01](https://github.com/tvheadend/tvheadend/commit/b40a62b31e809523d2fe2f7f3f331cc55dfdbd0f))
-* [ci: rename build.yml to reduce confusion](#user-content-fn-113)[^113] ([2023-12-26](https://github.com/tvheadend/tvheadend/commit/fd8b9e8ba21600d0bf6cdb20a7cc153482a2efa5))
-* [Makefile.ffmpeg nvenc update](#user-content-fn-114)[^114] ([2023-12-18](https://github.com/tvheadend/tvheadend/commit/4825b8414fc276ee74e9d0c3ebf5eaf09825d6b6))
-* Remove references to Tvheadend Foundation. ([2023-12-13](https://github.com/tvheadend/tvheadend/commit/3cf5acdc714dc025b2246d2395478fcfd058afeb))
-* [Transifex updates for project Tvheadend (#1587)](#user-content-fn-115)[^115] ([2023-12-13](https://github.com/tvheadend/tvheadend/commit/0da7fc0b7cf8f0159924d37a8c00b84ca3efdfc2))
-* [tfx: fix URLs in tvheadend/c files](#user-content-fn-116)[^116] ([2023-12-11](https://github.com/tvheadend/tvheadend/commit/e80d86fa0621fd9998192e1f6fdecb23ff095cae))
-* [tfx: fix URLs in tvheadend/docs files](#user-content-fn-117)[^117] ([2023-12-11](https://github.com/tvheadend/tvheadend/commit/e0d1bbca55c1f3db60c89e79c5c100326816a699))
-* [tfx: fix URLs in tvheadend/js files](#user-content-fn-118)[^118] ([2023-12-11](https://github.com/tvheadend/tvheadend/commit/a0bd2b3590a2b059da37439d2445a35cfc796814))
-* [webui: change donation button to opencollective](#user-content-fn-119)[^119] ([2023-12-09](https://github.com/tvheadend/tvheadend/commit/2a23e7f32403aab145efbf701f31e8e2450c1ba1))
-* [webui: remove old doc references to paypal](#user-content-fn-120)[^120] ([2023-12-09](https://github.com/tvheadend/tvheadend/commit/7a5f062e9ace148c02715245ef7ef7cf3e56b705))
-* github: add FUNDING.yml with OpenCollective link ([2023-12-09](https://github.com/tvheadend/tvheadend/commit/b2fac61fa343e78ce08b885dc63d81d5d30670d4))
-* Update copyright year and correct current surname ([2023-12-09](https://github.com/tvheadend/tvheadend/commit/f75cb334612885fdd7e8ff74b183e7d30c628e4d))
-* [hdhomerun: Add HDHomeRun server support for LiveTV only (#4461)](#user-content-fn-121)[^121] ([2023-12-09](https://github.com/tvheadend/tvheadend/commit/3dcb7ecf36666dcb43211a84141b1b645c9ca757))
-* [ci: don't trigger cloudsmith on .github changes](#user-content-fn-122)[^122] ([2023-12-06](https://github.com/tvheadend/tvheadend/commit/433cf8bbf55b28b67c25defe2e81c186f11e4ea8))
-* [ci: remove references to travis](#user-content-fn-123)[^123] ([2023-12-06](https://github.com/tvheadend/tvheadend/commit/2b77517d8e127fda422644c498a28aa361e20662))
-* [ci: remove references to doozer](#user-content-fn-124)[^124] ([2023-12-06](https://github.com/tvheadend/tvheadend/commit/f96ea64930f4d2191f5df79e1331f28213805463))
-* [ci: add concurrency to the main CI workflows](#user-content-fn-125)[^125] ([2023-12-06](https://github.com/tvheadend/tvheadend/commit/8b34c31f25078c985ac473c4843427c361372a2d))
-* [ci: schedule weekly coverity scans](#user-content-fn-126)[^126] ([2023-12-06](https://github.com/tvheadend/tvheadend/commit/b3ac61a01badb40320973cfcec978a97c56e6114))
-* [ci: remove the test-compile workflow](#user-content-fn-127)[^127] ([2023-12-06](https://github.com/tvheadend/tvheadend/commit/49b095e1850435d63c9c2f01f28770fdf46d55dd))
-* WebUI: Update donation string as a test to Transifex feed ([2023-12-06](https://github.com/tvheadend/tvheadend/commit/d85c957aa2b54c83301361f3d6dc7453def3302d))
-* Add Parental Rating Labels ([2023-12-05](https://github.com/tvheadend/tvheadend/commit/b061e641bc4f863d4c91340b691672bedd46b035))
-* ci update build config ([2023-12-01](https://github.com/tvheadend/tvheadend/commit/ae1ffbe576742842c55ca3c685d829dd6df975f3))
-* gitignore: add debian/.debhelper folder ([2023-12-01](https://github.com/tvheadend/tvheadend/commit/583de2330416e5122446920ef441c7e11129f92b))
-* update ffmpeg to 6.0.1 ([2023-11-29](https://github.com/tvheadend/tvheadend/commit/1ac062fbfe6d37cc79f649fe31b46e445b6f695e))
-* update x264 to c196240 ([2023-11-29](https://github.com/tvheadend/tvheadend/commit/752af5f2ab169b280d8fe1e7af372e0266151a15))
-* update libvpx to 1.13.1 ([2023-11-29](https://github.com/tvheadend/tvheadend/commit/dd884b84054ba663a64734aaa7d98c38658a89bc))
-* Fix builds on stretch ([2023-11-28](https://github.com/tvheadend/tvheadend/commit/bdadcb8b2bc07a65818a098b5db550bdbbf3caae))
-* Add rpi-bookworm to targets ([2023-11-21](https://github.com/tvheadend/tvheadend/commit/bc30a74de8ab5efc3605afd68eb6d01d08170316))
-* Update ffmpeg to 5.1.4 ([2023-11-20](https://github.com/tvheadend/tvheadend/commit/2d963dab6289028dd9f252dd41e13d881d6a9f92))
-* [Correct handling of Remove and Ignore settings](#user-content-fn-128)[^128] ([2023-10-26](https://github.com/tvheadend/tvheadend/commit/62adbebfd062d7b97829268274aad92df2033784))
-* [Removed nested function 'appendPidRange' from within function 'tvhdhomerun\_frontend\_update\_pids'](#user-content-fn-129)[^129] ([2023-10-14](https://github.com/tvheadend/tvheadend/commit/3d16edb0f59dd974b3924b463efc58be1cb1fac1))
-* 6310 Set 'okay' default to True ([2023-10-14](https://github.com/tvheadend/tvheadend/commit/2d92f58fadf6b63c0a5a79a52d67f51e85b02be3))
-* [Fix non-admin users not receiving any updates in web UI](#user-content-fn-130)[^130] ([2023-10-01](https://github.com/tvheadend/tvheadend/commit/51adc040429c001820a44c6b26825c1bdc19c779))
-* [Fix htsstr\_argsplit (treat quotes inside an argument correctly)](#user-content-fn-131)[^131] ([2023-09-06](https://github.com/tvheadend/tvheadend/commit/fe4df311d1209ba86d514a34abc0b9c694d53b5f))
-* [webui/dvr: Remove unused & duplicated functions](#user-content-fn-132)[^132] ([2023-08-11](https://github.com/tvheadend/tvheadend/commit/db62c0bd467e800fc6aa1702a94672b6bf7697ce))
-* [webui/dvr: Add age\_rating in recording details dialogs](#user-content-fn-133)[^133] ([2023-08-11](https://github.com/tvheadend/tvheadend/commit/21911b5e37a20b6f2a10ef48a93ccf7bf2dd179c))
-* [support/mkbundle: switch from distutils to setuptools](#user-content-fn-134)[^134] ([2023-08-11](https://github.com/tvheadend/tvheadend/commit/ec56067f4f6cb3fae5a03f0fb492c45413d095bb))
-* Fix bug #6293 – Missing EIT EPG Content Type ([2023-08-09](https://github.com/tvheadend/tvheadend/commit/76ca76761693eb7c1f347e79d271618f08ec3824))
-* Fix some build and add more targets ([2023-08-08](https://github.com/tvheadend/tvheadend/commit/6e352c6c7871d434f9b022f7f203c31e9609121b))
-* [Use explicitly on format warnings for Time test](#user-content-fn-135)[^135] ([2023-08-06](https://github.com/tvheadend/tvheadend/commit/2375a63a118797bb0dbac9d71740a5351dd49f3d))
-* [otamux: Make sure we use PRItime\_t](#user-content-fn-136)[^136] ([2023-08-06](https://github.com/tvheadend/tvheadend/commit/17eebbef5b017352afcded36c27cb0be11ebd4a1))
-* [CI: Run the full build with cloudsmith only on master](#user-content-fn-137)[^137] ([2023-08-05](https://github.com/tvheadend/tvheadend/commit/ac6caf3b1117a80fb30d528767c0d55635ba2cb4))
-* [CI: Build (without cloudsmith) all targets on every merge request](#user-content-fn-138)[^138] ([2023-08-05](https://github.com/tvheadend/tvheadend/commit/1179ce28a530ac48358266e8c46cb9b06e5f71c6))
-* [Fix time for old 32bit systems](#user-content-fn-139)[^139] ([2023-08-04](https://github.com/tvheadend/tvheadend/commit/1c22d866f336d4d38dc0679a0cb03b11237c48fc))
-* Add 'age rating' field to recording metadata ([2023-08-02](https://github.com/tvheadend/tvheadend/commit/d50105999522cc7c35909f7c0f2a504fc40c2e1b))
-* OTA Genre translation squashed v2 ([2023-07-30](https://github.com/tvheadend/tvheadend/commit/23263a54d9bbda2779489c06d3aa909ec618ad63))
-* [Fix time for 32bit systems again](#user-content-fn-140)[^140] ([2023-07-30](https://github.com/tvheadend/tvheadend/commit/fe47ecb5504a521fed9c1ca9705fb0dd2bb8443a))
-* Bug Fix: OTA EIT Parental Rating ([2023-07-19](https://github.com/tvheadend/tvheadend/commit/c531383ca6654639dc112db67fd8dc893c1f5272))
-* Revert non-portable function to previous code ([2023-06-25](https://github.com/tvheadend/tvheadend/commit/14298acb6a8e3a83ed1091fab1f3a924077ddfea))
-* [Fix configuration-loading logic to account for forking operation](#user-content-fn-141)[^141] ([2023-06-23](https://github.com/tvheadend/tvheadend/commit/612b615ffd8adfd33f905cf15b67ff817cc59c20))
-* [Update Debian packaging to use the new configuration directories](#user-content-fn-142)[^142] ([2023-06-23](https://github.com/tvheadend/tvheadend/commit/9958c34210f21b6a7487e3df899230df3a545489))
-* Fix spelling errors encountered during previous work ([2023-06-23](https://github.com/tvheadend/tvheadend/commit/7b5c526977eddfa4535df91ea4e23c8910c69b11))
-* [spawn: Do not close every possible file descriptor](#user-content-fn-143)[^143] ([2023-06-21](https://github.com/tvheadend/tvheadend/commit/85360356660a11e5c7a65274d58e5f4945f83f5f))
-* [config: Fix whitespace errors](#user-content-fn-144)[^144] ([2023-06-21](https://github.com/tvheadend/tvheadend/commit/f28e69a5f1f24da7a973a6ef1dec9f7beece2acc))
-* [Fix portability: Do not use linux/limits.h](#user-content-fn-145)[^145] ([2023-06-21](https://github.com/tvheadend/tvheadend/commit/a9b83afb2d6badaa01ab2b964f0285b7206bf52c))
-* [dvr\_storage: Also support server configurations for recordings](#user-content-fn-146)[^146] ([2023-06-21](https://github.com/tvheadend/tvheadend/commit/335b1255d644d06740758d8a264e4864b6539e55))
-* [config: Deal with configuration before anything else](#user-content-fn-147)[^147] ([2023-06-16](https://github.com/tvheadend/tvheadend/commit/04283a9a4ab81ed435f8ee0d36e271e6f51f8418))
-* [config: Store config directory variable internally](#user-content-fn-148)[^148] ([2023-06-16](https://github.com/tvheadend/tvheadend/commit/cf87a5ddba7b439631d2c105879671422d118638))
-* [config: Add support for XDG config](#user-content-fn-149)[^149] ([2023-06-16](https://github.com/tvheadend/tvheadend/commit/af49e4bd9066bcba873718cf7dab42235de49982))
-* [config: Support server configurations](#user-content-fn-150)[^150] ([2023-06-16](https://github.com/tvheadend/tvheadend/commit/e15c1abe97370b461ed1457b3ac2dc4dff58dbd7))
-* [settings: Add XDG support helper functions](#user-content-fn-151)[^151] ([2023-06-16](https://github.com/tvheadend/tvheadend/commit/c00c4eb71d604112da7cbc58f4aee4a8c5a1f0d9))
-* [dvr\_storage: Use XDG spec directories](#user-content-fn-152)[^152] ([2023-06-16](https://github.com/tvheadend/tvheadend/commit/dbf973307ae34d8a7918b781b9f315ad51ef15a8))
-* Fix Fedora CI build ([2023-06-15](https://github.com/tvheadend/tvheadend/commit/4c1b4dbcee7fd5eeeec8bf27e5ff2d178ee8bfee))
-* Disable broken codeball ([2023-06-12](https://github.com/tvheadend/tvheadend/commit/5f6be407a8e72c45ed4c9178c8b38826bb9a8684))
-* [Add simple 'ping' endpoint for healthchecks](#user-content-fn-153)[^153] ([2023-06-11](https://github.com/tvheadend/tvheadend/commit/1705297c27d76848a87cff34dd6bfe7d9d74c87a))
-* Update config for Fedora 37/38 ([2023-06-07](https://github.com/tvheadend/tvheadend/commit/cd30663793f7155f93a1dd4977ae096718cf9cd6))
-* Add Fedora RPM build to Github Actions ([2023-06-07](https://github.com/tvheadend/tvheadend/commit/9df7d2d6bc37b8aa25ac63be7b0a5d69be10c892))
-* [dvr\_rec: Fix a buffer overflow in filename generation](#user-content-fn-154)[^154] ([2023-06-05](https://github.com/tvheadend/tvheadend/commit/003fd92707531bdf7ad1753ab028db8748ac5ab8))
-* [- fixed bug with \_lang3\_to\_lang2()](#user-content-fn-155)[^155] ([2023-04-19](https://github.com/tvheadend/tvheadend/commit/18effa8ad93e901f3cdaa534123d910f14453d1f))
-* [update to ffmpeg 5.1.3](#user-content-fn-156)[^156] ([2023-04-17](https://github.com/tvheadend/tvheadend/commit/8efac01dccdf11b4b3b196080c085aaa801a62f7))
-* [update pict\_type from AVPacket to AVFrame](#user-content-fn-157)[^157] ([2023-04-17](https://github.com/tvheadend/tvheadend/commit/e10f98601b8bfee4c6b0093012ce45654666f501))
-* [tv\_meta\_tvdb.py: Fix 'language' typo.](#user-content-fn-158)[^158] ([2023-04-08](https://github.com/tvheadend/tvheadend/commit/e0f2d3234a67c6c0c88ac84166ce2626d668e0cf))
-* [update to ffmpeg 5.1.2](#user-content-fn-159)[^159] ([2023-04-08](https://github.com/tvheadend/tvheadend/commit/f32c7c59a19a276648d7b068041738e4e8337638))
-* Remove references to CLA which is no longer available ([2023-04-02](https://github.com/tvheadend/tvheadend/commit/543fbee6344514b57366ce7c4fe2e103d2570e55))
-* [tvhmeta: Fix tvhmeta authentication to the tvheadend API.](#user-content-fn-160)[^160] ([2023-04-02](https://github.com/tvheadend/tvheadend/commit/a10f7ea4408e5ba2b0f04cc9db970873eafa883c))
-* [updated 'AVCodec' to 'const AVCodec'](#user-content-fn-161)[^161] ([2023-04-01](https://github.com/tvheadend/tvheadend/commit/8acd83df2335469216c3f8d07424a3e06486da0b))
-* [remove deprecate struct vaapi\_context and the vaapi.h](#user-content-fn-162)[^162] ([2023-03-30](https://github.com/tvheadend/tvheadend/commit/247d3d032ce3f609254b3782aa95143eb5dd99f5))
-* Remove deprecated get\_best\_effort\_timestamp() call ([2023-03-25](https://github.com/tvheadend/tvheadend/commit/a1cb8cffb1d5af17c9bce2b3ef65319ab984854f))
-* [remove ffmpeg component avresample](#user-content-fn-163)[^163] ([2023-03-24](https://github.com/tvheadend/tvheadend/commit/ef13a600afb35905ddfa84447073c016d320c185))
-* [update to ffmpeg codecpar](#user-content-fn-164)[^164] ([2023-03-23](https://github.com/tvheadend/tvheadend/commit/933ae5f767ea4ddd08656f59b8cc973756b59342))
-* [remove unused function and migrate from AVBitStreamFilterContext to AVBSFContext](#user-content-fn-165)[^165] ([2023-03-23](https://github.com/tvheadend/tvheadend/commit/0acb338a762afbd46658fadc55ae3e6827c5b73a))
-* [iconv: Allow using GNU libiconv](#user-content-fn-166)[^166] ([2023-03-23](https://github.com/tvheadend/tvheadend/commit/21a5c6399aaba600886f1bc1ad0ce79d454b8ba8))
-* [Revert "fix for 64bit time\_t on 32bit systems"](#user-content-fn-167)[^167] ([2023-03-14](https://github.com/tvheadend/tvheadend/commit/9e1eb89be731ffb4687327c09b2de3bf58f548cf))
-* fix for 64bit time\_t on 32bit systems ([2023-03-08](https://github.com/tvheadend/tvheadend/commit/76a6263f1be4e3ccff968b47155b050fcc15f042))
-* Don't attempt to approve PRs automatically ([2023-03-06](https://github.com/tvheadend/tvheadend/commit/508de087216e8918cdc45fbcf30a9efeb5fe5654))
-* [update vaapi](#user-content-fn-168)[^168] ([2023-03-06](https://github.com/tvheadend/tvheadend/commit/cfb20ca688995e690f58528379619827263bbce2))
-* [update NASM to 2.16.01](#user-content-fn-169)[^169] ([2023-03-06](https://github.com/tvheadend/tvheadend/commit/5aa50b12fc4bab29855edba8557f0ad8fe26e2d1))
-* Codeball should also label PRs that need review ([2023-03-05](https://github.com/tvheadend/tvheadend/commit/39df64bb8e8888db0817e133b50b7f4823a69489))
-* RTSP redirect support fix and moved to http client ([2023-02-24](https://github.com/tvheadend/tvheadend/commit/061cf95b148680cc01689f1f49d10d3977bda15d))
-* Fix for DVB Grabber and IPTV Stream ([2023-02-24](https://github.com/tvheadend/tvheadend/commit/d1366a0669c785141a128678a671c008abd1fb5a))
-* Use codeball for PRs ([2023-02-21](https://github.com/tvheadend/tvheadend/commit/44bf691ac3c4abe3b11dc284ace84d863db376e3))
-* [update to ffmpeg codecpar](#user-content-fn-164)[^164] ([2023-02-20](https://github.com/tvheadend/tvheadend/commit/2f3e53380bff7fb7a571de438d3fc541139259cc))
-* [update ffmpeg from 4.4.1 to 4.4.3](#user-content-fn-170)[^170] ([2023-02-12](https://github.com/tvheadend/tvheadend/commit/02987438db97e54a39491853099db7ead4d50eb3))
-* [update vaapi](#user-content-fn-171)[^171] ([2023-02-10](https://github.com/tvheadend/tvheadend/commit/470f02fb3f00d3f88e61303cd5db7ec303d0145d))
-* [update vaapi](#user-content-fn-172)[^172] ([2023-02-05](https://github.com/tvheadend/tvheadend/commit/becc74b2874a43007709952950e03fd137e0d8bb))
-* [Revert "Update debian/compat to version 10"](#user-content-fn-173)[^173] ([2023-01-28](https://github.com/tvheadend/tvheadend/commit/bed37ea208b8acaf914b4fb14498d143a1fbbd93))
-* [Fix Coverity-Build (#1499)](#user-content-fn-174)[^174] ([2023-01-28](https://github.com/tvheadend/tvheadend/commit/060df517c16537da69fd0717f52254ff7477398f))
-* [Ignore title mismatch if dup checking by CRID](#user-content-fn-175)[^175] ([2023-01-27](https://github.com/tvheadend/tvheadend/commit/905b4f0d0387818cbbf7012bf4dffb25e9893748))
-* Add descriptions to the existing Unicable configuration fields ([2023-01-24](https://github.com/tvheadend/tvheadend/commit/377c108194292abdaf71ff26b7527412c4f7a0aa))
-* Unify names and order of Unicable-specific configuration fields ([2023-01-24](https://github.com/tvheadend/tvheadend/commit/dde8856982c4293a1f9c8686b08f752e6e504dcc))
-* [Add configurable delays after Unicable operations](#user-content-fn-176)[^176] ([2023-01-24](https://github.com/tvheadend/tvheadend/commit/b70f3b3f12b4398cfdf18fb311e9e57abcf86260))
-* [Unify power up time range to 10-500 ms](#user-content-fn-177)[^177] ([2023-01-24](https://github.com/tvheadend/tvheadend/commit/1620218ed01600bbc1784528a10f0723a998a741))
-* [Unify command time range to 10-300 ms](#user-content-fn-178)[^178] ([2023-01-24](https://github.com/tvheadend/tvheadend/commit/5948200c7e04ebeab28efb3285d3f13e11df20ca))
-* [Update debian/compat to version 10](#user-content-fn-179)[^179] ([2023-01-24](https://github.com/tvheadend/tvheadend/commit/2a370dd17fcac7e587d45fd9971e346536379ea3))
-* [descrambler: cosmetic cleanups, more CAID logs](#user-content-fn-180)[^180] ([2023-01-23](https://github.com/tvheadend/tvheadend/commit/c32ace5a81e86856b3ecb29fa5e0abc170d13182))
-* [descrambler: cclient: optimisation for multiple key clients](#user-content-fn-181)[^181] ([2023-01-23](https://github.com/tvheadend/tvheadend/commit/d3cd3d66795df59ca41294a8008b751782f2b948))
-* [descrambler: cccam - simplify cccam\_handle\_keys()](#user-content-fn-182)[^182] ([2023-01-23](https://github.com/tvheadend/tvheadend/commit/b8b6d5eba112a9ace28db4ebee12c4b6154327c7))
-* [descrambler: cccam: move send keepalive message to traces](#user-content-fn-183)[^183] ([2023-01-23](https://github.com/tvheadend/tvheadend/commit/8082b104aecd7f2bbac3b16b853be50c902cefb3))
-* [update vaapi](#user-content-fn-184)[^184] ([2023-01-23](https://github.com/tvheadend/tvheadend/commit/0adacbdf18f018c9167bbceacc2d5ebb756688e2))
-* [descrambler: cwc: Fix the additional card registration (mgclient option in &#x6F;_&#x73;_&#x63;_&#x61;_&#x6D;)](#user-content-fn-185)[^185] ([2023-01-22](https://github.com/tvheadend/tvheadend/commit/36c1d65d9d3d6319cde25c76cb3340ed065e8e94))
-* [descrambler: cwc: do not register bad provider numbers for betacrypt and irdeto](#user-content-fn-186)[^186] ([2023-01-22](https://github.com/tvheadend/tvheadend/commit/3a12b3f99bc31a3217e3e2de96f3a62dac137735))
-* [Preserve existing Unicable idnode during the set operation](#user-content-fn-187)[^187] ([2023-01-17](https://github.com/tvheadend/tvheadend/commit/11358ba2537c988c940a46500434417b7cf98f0f))
-* grammar: Replace "then" with "than" ([2023-01-17](https://github.com/tvheadend/tvheadend/commit/760f32bf531e15346a40cef864f87edd5bae9681))
-* [profile video resize improvements](#user-content-fn-188)[^188] ([2023-01-14](https://github.com/tvheadend/tvheadend/commit/1eeb608033804c3b5b35c842389f276cde299600))
-* [updated function \_video\_filters\_get\_filters()](#user-content-fn-189)[^189] ([2023-01-14](https://github.com/tvheadend/tvheadend/commit/576ae16a1c4db90db262c671df5f703ff5d23d0b))
-* remove libavresample from build scripts ([2023-01-10](https://github.com/tvheadend/tvheadend/commit/17a357fee8bccacd931476411200b05f2b06f47c))
-* [update vaapi](#user-content-fn-190)[^190] ([2023-01-10](https://github.com/tvheadend/tvheadend/commit/6a6c9b7240ae4d19a8d57dd7e4a9428c326a68de))
-* [Add autorec duplicate handling default to dvr config.](#user-content-fn-191)[^191] ([2023-01-10](https://github.com/tvheadend/tvheadend/commit/cc602833684953fc3e6f1c89d4f08f6dfef179e3))
-* Add amd64 jammy to builds ([2023-01-04](https://github.com/tvheadend/tvheadend/commit/2beb6c9c889d840f232379db52cd3363e23a5b1f))
-* Build for kinetic instead of impish ([2022-12-21](https://github.com/tvheadend/tvheadend/commit/44a202b9232f141bd36e617c138d6efb653d7fd3))
-* Allow old builds to pass ([2022-12-21](https://github.com/tvheadend/tvheadend/commit/cdd2af4bd30d8f873fb3f66c2543bd6d3f758719))
-* Fix a few more builds, add kinetic support ([2022-12-21](https://github.com/tvheadend/tvheadend/commit/c9a156a25a07f1f84c2f48a1b03b481430c8257d))
-* Don't fail on strict aliasing violations ([2022-12-17](https://github.com/tvheadend/tvheadend/commit/b45571d42e9a08f45d18e368a754d4d82d047d29))
-* Remove variable declaration from for-loop ([2022-12-17](https://github.com/tvheadend/tvheadend/commit/81c986d553277e0275b8ce47749a7fb0388b455d))
-* [Don't confuse GCC with zero-length array](#user-content-fn-192)[^192] ([2022-12-10](https://github.com/tvheadend/tvheadend/commit/abcb0ea676e7b7e822be990aae7df1aa8ff5b990))
-* [Add South Africa to Countries list.](#user-content-fn-193)[^193] ([2022-11-28](https://github.com/tvheadend/tvheadend/commit/eb844deb40cf9a4331c7071e56964f58910c3509))
-* [dvb\_psi\_pmt: Recognise AC-4 audio descriptor](#user-content-fn-194)[^194] ([2022-11-28](https://github.com/tvheadend/tvheadend/commit/765d3ed4fd0cc87f8b8594b296833f490ae86ebd))
-* [config: Enable HbbTV parser by default](#user-content-fn-195)[^195] ([2022-11-28](https://github.com/tvheadend/tvheadend/commit/d8854960361b0fb6846f0912f509dfad61f3ccbf))
-* [Build various targets and prepare new repository (#1476)](#user-content-fn-196)[^196] ([2022-11-27](https://github.com/tvheadend/tvheadend/commit/cd8491a5ba3c75c349997357d7751cf0fd83fb53))
-* [Avoid breaking strict aliasing in IP\_AS\_V{4,6}](#user-content-fn-197)[^197] ([2022-11-24](https://github.com/tvheadend/tvheadend/commit/7b95ba4cf9113ae8808b3e4a9425010b607dbaca))
-* [Use application/json instead of text/x-json as mimetype](#user-content-fn-198)[^198] ([2022-11-21](https://github.com/tvheadend/tvheadend/commit/b881ca6e1d15db012f3470b5412241273a0ebdfe))
-* Serve static html files with mimetype text/html ([2022-11-21](https://github.com/tvheadend/tvheadend/commit/f3376c764c3015279ec1b687bb017292a12d2d82))
-* [Don't crash the wizard if tvh has no inputs](#user-content-fn-199)[^199] ([2022-11-21](https://github.com/tvheadend/tvheadend/commit/0b8df3e2d55240d4b21ec5bdf20cc89b4a5e73b2))
-* Don't call epg\_broadcast\_set\_description twice ([2022-11-21](https://github.com/tvheadend/tvheadend/commit/fed1eeb4d120ac2b0f3728bd63280c27ad94834d))
-* [Simplify IPv6 compare functions to unconfuse gcc compiler](#user-content-fn-200)[^200] ([2022-11-21](https://github.com/tvheadend/tvheadend/commit/c0f616e56bc4df70978a060b72f8c6a7ca487d3f))
-* Reduce ADTS header size for better compatibility ([2022-11-21](https://github.com/tvheadend/tvheadend/commit/19c3b87c23fe92a5dc8f4b2bf3ccd69111de0d09))
-* Remove always-true checks ([2022-11-21](https://github.com/tvheadend/tvheadend/commit/5543ce518faaeeb0677fd7c2fca26f8ae0d265d3))
-* [epgdb: Resolve symlinks before using file location](#user-content-fn-201)[^201] ([2022-11-20](https://github.com/tvheadend/tvheadend/commit/0ff96106aa2e0f9a384c3a2662ca005797a6b399))
-* Increase maximum ADTS packet size to match FFMPEG ([2022-11-10](https://github.com/tvheadend/tvheadend/commit/52c3ed3ef17eeccddc6a4cf7c0d7151c2823438f))
-* [iptv\_auto: Add support for m3u "channel-number" tag](#user-content-fn-202)[^202] ([2022-10-31](https://github.com/tvheadend/tvheadend/commit/1a437c88ea35d28e235b76bf890b227d60e84db4))
-* [Attempt to fix profile sharer memory leak](#user-content-fn-203)[^203] ([2022-10-27](https://github.com/tvheadend/tvheadend/commit/fc3759a58dd9dc914166262c8b59c2d4f0ed3f53))
-* Fix bad mono2sec usage ([2022-10-27](https://github.com/tvheadend/tvheadend/commit/c616fcc0136f79e8b1d502707c451645560520f9))
-* Fix race condition/data corruption in imagecache ([2022-10-27](https://github.com/tvheadend/tvheadend/commit/185013382c1d9a2aee8425746b65b7415802fc29))
-* Fixed typo ([2022-10-26](https://github.com/tvheadend/tvheadend/commit/7a3a88cf7a2e15f1bbe3c68b5b6e3fd12a461831))
-* Close FDs even if no UDP connection is used ([2022-10-26](https://github.com/tvheadend/tvheadend/commit/a2b6a1db5740c174a92fe77292ff5431d2c7782b))
-* [Revert 4355488b8e1e868cb434bf95676c0944b44e88b3](#user-content-fn-204)[^204] ([2022-10-26](https://github.com/tvheadend/tvheadend/commit/7eb08ba14ca00df3588adffecdaa11b6f6e1e588))
-* Fix typo ([2022-10-26](https://github.com/tvheadend/tvheadend/commit/e1d4ab791db3845873eb1e906d2a61660b573f55))
-* Attempt to fix HBBTV memory leak ([2022-10-26](https://github.com/tvheadend/tvheadend/commit/a2a702b1001828f49e884bcdd81817e21d79eaf8))
-* Update regexps for the finnish EIT scraping ([2022-10-16](https://github.com/tvheadend/tvheadend/commit/604d81a29f88b37189b49cf6a2dfe73b1ca546da))
-* mpegts dvb: Add support for LCN for provider DigiTV ([2022-10-14](https://github.com/tvheadend/tvheadend/commit/3edbd57246129c99b079cfd6269688430591e0d1))
-* Avoid leaking iptv fd's ([2022-10-07](https://github.com/tvheadend/tvheadend/commit/4355488b8e1e868cb434bf95676c0944b44e88b3))
-* [Ignore PCRE2 illegal accesses](#user-content-fn-205)[^205] ([2022-10-07](https://github.com/tvheadend/tvheadend/commit/81838dbb6cbfcb42cb63dc38aef824c2cabf6817))
-* Fix potential memory leak ([2022-10-07](https://github.com/tvheadend/tvheadend/commit/d9b76b57e1826240c98dd4b63c3b294bca143486))
-* output: UDP streaming ([2022-10-07](https://github.com/tvheadend/tvheadend/commit/5f9404117f59ad1f5aa7ca542ce39d9e064e8209))
-* [Added support for ATSC text mode == 0x3F](#user-content-fn-206)[^206] ([2022-10-03](https://github.com/tvheadend/tvheadend/commit/8f8877430cfcc9e2bca6d5066241600a8742c1ac))
-* [Added more 'text modes' to the ATSC Multiple String Structure decoder and convert text to UTF-8. (Fixes #5162)](#user-content-fn-207)[^207] ([2022-09-15](https://github.com/tvheadend/tvheadend/commit/d25c19d673136fbf8572e901ed3c3e871e8b6dd4))
-* Fix crash when mpegts\_service\_refresh tries to open the CAT again ([2022-09-15](https://github.com/tvheadend/tvheadend/commit/86f3617c8972c5362e51cee7d34cc2d69d799126))
-* Fix FTBFS introduced by 86f3617c8972c5362e51cee7d34cc2d69d799126 ([2022-09-15](https://github.com/tvheadend/tvheadend/commit/4741b3c1901d4c998b1c5ef7c777728b4827e828))
-* [Allow network scan to modify muxes](#user-content-fn-208)[^208] ([2022-09-03](https://github.com/tvheadend/tvheadend/commit/ca756e3f7aa8a778fe7a4e69be66b428d3f5afb5))
-* [Fixed and cleanup the "PSIP: ATSC Grabber" module (Fixes #5610)](#user-content-fn-209)[^209] ([2022-08-28](https://github.com/tvheadend/tvheadend/commit/1fa49afbca482999a3d32d8da73b01963efe3ff1))
-* [Regexps for the finnish EIT scraping](#user-content-fn-210)[^210] ([2022-07-17](https://github.com/tvheadend/tvheadend/commit/1c65e8b0f03384a5ca5b5fc7635ecad4fd85b415))
-* extending the regexps for the italian EIT scraping ([2022-07-08](https://github.com/tvheadend/tvheadend/commit/e3f4f222ec86cb5e46576ac97fcb404ffbafc317))
-* [Fix use-after-free](#user-content-fn-211)[^211] ([2022-07-04](https://github.com/tvheadend/tvheadend/commit/351b5b4158e4201b3567371f80775aca182cbb0e))
-* No longer use git-protocol ([2022-06-17](https://github.com/tvheadend/tvheadend/commit/fbc94aee8bfdd25baba87ab62a39234da20e8dd2))
-* add Access-Control-Allow-Headers content-length ([2022-04-22](https://github.com/tvheadend/tvheadend/commit/420786927eea22b7a009f03b0b867058d0818e99))
-* Update Copyright year ([2022-04-14](https://github.com/tvheadend/tvheadend/commit/26713c1e451a74dbcc7aaec8427c0356cc2c546f))
-* Add HMF\_UUID to htsmsg\_binary\_write ([2022-04-11](https://github.com/tvheadend/tvheadend/commit/efe613d2ee28d050db3e9c8ecd75e92a9b222a79))
-* Use GitHubs CI for Building ([2022-04-11](https://github.com/tvheadend/tvheadend/commit/70bcfbe376804ad44a06d12fd9c03d1bef58853c))
-* GitHub actions improvements ([2022-04-11](https://github.com/tvheadend/tvheadend/commit/9208984d7917a1f2f8999a620fec0ec9755e1b79))
-* Travis CI is dead, use GitHub actions for badge ([2022-04-11](https://github.com/tvheadend/tvheadend/commit/9a51cea492e4a5579ca3ddf9233fecfa419de078))
-* Fix potential null-pointer-dereference ([2022-04-08](https://github.com/tvheadend/tvheadend/commit/6be740c79340510abb8309d151bb455aacc0b31f))
-* Remove useless null-check on an array ([2022-04-08](https://github.com/tvheadend/tvheadend/commit/04998bd54be27e76062b424eb4bab7419f9ff4d2))
-* Prevent deadlock-detector leaking memory ([2022-04-08](https://github.com/tvheadend/tvheadend/commit/58df4bf5142a7628b3994ec6c0c4b8e1d8d27694))
-* [Fix FTBFS in utils.c](#user-content-fn-212)[^212] ([2022-04-07](https://github.com/tvheadend/tvheadend/commit/fd01737270d98c28465c86a688bd7d1c640486c5))
-* [fix build with libressl](#user-content-fn-213)[^213] ([2022-04-06](https://github.com/tvheadend/tvheadend/commit/ea65f8025a9124cd7353b21f167968bdb897306f))
-* [dvr\_disk\_space\_cleanup() - do not return error if called again too soon (#1)](#user-content-fn-214)[^214] ([2022-04-05](https://github.com/tvheadend/tvheadend/commit/a1f0b41b7e4eaf36e91f410141a473a2a9738bed))
-* [Always parse 'src' in RTSP-requests](#user-content-fn-215)[^215] ([2022-04-05](https://github.com/tvheadend/tvheadend/commit/90ba8b1c1ec01021da032813eae14007d753fc91))
-* [Update for VAAPI transcoding](#user-content-fn-216)[^216] ([2022-03-30](https://github.com/tvheadend/tvheadend/commit/2bf1629280bcd7d33e93df165985f3f6253c4b70))
-* [SAT>IP client: UPnP header field names are case insensitive](#user-content-fn-217)[^217] ([2022-03-15](https://github.com/tvheadend/tvheadend/commit/3b1d7a928a8632d8c59e1fc6bb1a0a25dde9d5af))
-* Update Python shebangs to python3 ([2022-02-14](https://github.com/tvheadend/tvheadend/commit/72bfa4d32c7a556facd8e580f0892e090ea3a01d))
-* Fix sid doozer build ([2022-02-14](https://github.com/tvheadend/tvheadend/commit/0893a31010c15b46de06233a372d832fe48e6706))
-* Fix doozer CentOS build ([2022-02-14](https://github.com/tvheadend/tvheadend/commit/e2ae8f4ebe0ac2c85d0acccc6f31d1a22bb9e802))
-* More doozer build fixes ([2022-02-14](https://github.com/tvheadend/tvheadend/commit/1295dd2be863f5beb764290fce9317b24193dfc0))
-* Add --nowerror to build for RPM packages ([2022-02-13](https://github.com/tvheadend/tvheadend/commit/e8f8ddfc05af14fc3fdc89e2db97c6b063f86790))
-* Fix some failing builds ([2022-02-13](https://github.com/tvheadend/tvheadend/commit/a09fe2acf33949860e83a97bc56a668850f676f2))
-* Fix doozer builds ([2022-02-13](https://github.com/tvheadend/tvheadend/commit/025eac1a5e07907e455dd0feb3857de54f9c79a4))
-* Doozer fixes ([2022-02-13](https://github.com/tvheadend/tvheadend/commit/718b5b3e879580b73b8423e42bb1dfb8895d4a0d))
-* Update RPM to python3 ([2022-02-13](https://github.com/tvheadend/tvheadend/commit/a0bbcc055e7d1743aa311d488a25bcfdbd7b4e82))
-* [httpc: Fix multi-value "Connection" header checks](#user-content-fn-218)[^218] ([2022-02-12](https://github.com/tvheadend/tvheadend/commit/d9989cc761c977fa0689c3f0cfccf9913499e0e5))
-* epg: ignore past events when matching on eid ([2022-02-12](https://github.com/tvheadend/tvheadend/commit/a402f07f7c68c9d5498ac7dbc1591320a9d4c81b))
-* [Changed debian package version to 7](#user-content-fn-219)[^219] ([2022-02-12](https://github.com/tvheadend/tvheadend/commit/39b93710b5b88b1681516f4cf56d22804d5a6766))
-* [Update buffer size for h264 and hevc](#user-content-fn-220)[^220] ([2022-02-12](https://github.com/tvheadend/tvheadend/commit/f90831c015889b5430602b34ba224358243540b5))
-* doozer: Migrate to Fedora 34 and 35 ([2022-02-12](https://github.com/tvheadend/tvheadend/commit/f9a55af89df3eb96e342b24540fca2194a2313ca))
-* Fix failing builds again ([2022-02-12](https://github.com/tvheadend/tvheadend/commit/462c76ec16ccd75042375542496171bfb2773923))
-* [Episode number regexp](#user-content-fn-221)[^221] ([2022-01-12](https://github.com/tvheadend/tvheadend/commit/c7b713edb0ae4fee6acbd65c27017cb01c12348a))
-* Fix some issues introduced in #0165f365cd58bbcc3734e4ec9ce696b42870ff8e ([2022-01-10](https://github.com/tvheadend/tvheadend/commit/1b19167c3f627d53109f8d642bd755c97b9d4bc2))
-* Fix "as: invalid option" during libvpx compilation ([2022-01-09](https://github.com/tvheadend/tvheadend/commit/07b3d405f85731abe5b6310b787074e1f8233d5f))
-* [configure: add execinfo option](#user-content-fn-222)[^222] ([2022-01-02](https://github.com/tvheadend/tvheadend/commit/fb7b24114685a7e38d842168dce4c613360cd330))
-* Update Makefile.ffmpeg ([2022-01-02](https://github.com/tvheadend/tvheadend/commit/4deae00a11e92e6c19da4fd1bae48ef7f124c67b))
-* [some changes to nvenc](#user-content-fn-223)[^223] ([2022-01-02](https://github.com/tvheadend/tvheadend/commit/0165f365cd58bbcc3734e4ec9ce696b42870ff8e))
-* [nvenc: Fix Werror=misleading-indentation FTBFS](#user-content-fn-224)[^224] ([2022-01-02](https://github.com/tvheadend/tvheadend/commit/067b662ef7479af2b830b95fbd7b2e6c1cb9e7a1))
-* [nvenc: Fix Werror=int-conversion FTBFS (and likely bug)](#user-content-fn-225)[^225] ([2022-01-02](https://github.com/tvheadend/tvheadend/commit/3ed76138a768d8ce0b9028806273610a92a5617f))
-* [Use clock\_gettime() instead of time() in epggrab.c](#user-content-fn-226)[^226] ([2021-12-12](https://github.com/tvheadend/tvheadend/commit/9ed7d10ac2e895080d08587048ac5a24a2f9fae3))
-* [Check the return code of snprintf in utils.c:rmtree](#user-content-fn-227)[^227] ([2021-12-12](https://github.com/tvheadend/tvheadend/commit/6f3b31043d89324c6b406286c1561ca0a213ba48))
-* [iptv: Fix stream limit starting a new input on a running mux](#user-content-fn-228)[^228] ([2021-12-12](https://github.com/tvheadend/tvheadend/commit/09a2c71abb01db8735437f233b8a54a0bb4939fc))
-* [Improve the performance of updating the pid filter table in hdhomerun digital tuners.](#user-content-fn-229)[^229] ([2021-11-21](https://github.com/tvheadend/tvheadend/commit/b8710206eb073c72b142bce95846b77a0ffa34a6))
-* Fixed parsing w\_scan format ([2021-11-15](https://github.com/tvheadend/tvheadend/commit/2efe90cdcf74fdc4179692d283cf46c85e1cf681))
-* [opentv: fix missing summary data on rescrape, #5995](#user-content-fn-230)[^230] ([2021-10-21](https://github.com/tvheadend/tvheadend/commit/c6bb43d8554643a772aa40c5e56904717b55a95f))
-* [opentv: fix incorrect summaries for skyuk epg, fixes #5995](#user-content-fn-231)[^231] ([2021-10-17](https://github.com/tvheadend/tvheadend/commit/1ee9c5b9cc516d37cb55a9d924a4ca854a64f720))
-* [Revert "Remove unnecessary conversion"](#user-content-fn-232)[^232] ([2021-09-07](https://github.com/tvheadend/tvheadend/commit/8fc2dfa7e1b1b3b1e8ba6f78cd4a81f77fa6a736))
-* Add support for SCT\_RDS ([2021-09-06](https://github.com/tvheadend/tvheadend/commit/dd7b010afd6e25893712bf8bdfc1c235b9077d7b))
-* Expose RDS flag via HTSP. ([2021-09-06](https://github.com/tvheadend/tvheadend/commit/814036346418386144756400ada2bb9200540893))
-* [Remove unnecessary conversion](#user-content-fn-233)[^233] ([2021-09-06](https://github.com/tvheadend/tvheadend/commit/7757f066582bdb244c56e658c4a99f8e1d5832cd))
-* [Upgrade to libhdhomerun\_20210624](#user-content-fn-234)[^234] ([2021-07-29](https://github.com/tvheadend/tvheadend/commit/23754f9a63dad8540214d549b4baec2464e5d33a))
-* Fix ffmpeg jessie build error ([2021-07-24](https://github.com/tvheadend/tvheadend/commit/6efa411648cee0b9ca0ce5ab39ee847035c88566))
-* Doozer.io: Add build targets for Debian, Bullseye & Sid ([2021-07-23](https://github.com/tvheadend/tvheadend/commit/c685f3eab6d1fcc2df5a64de38bf0e6e84b06676))
-* [Autobuild: Add arm64, armhf and armel for bullseye and buster.](#user-content-fn-235)[^235] ([2021-07-23](https://github.com/tvheadend/tvheadend/commit/711592186757f8f0dc64f30b38cd9671dd3b6349))
-* Attempt to fix trusty and centos builds ([2021-07-23](https://github.com/tvheadend/tvheadend/commit/40c48203511cca2d0f1723b8764ca53035db28e5))
-* Attempt to fix jessie build ([2021-07-23](https://github.com/tvheadend/tvheadend/commit/1979ea7e4e517fd21f7091547bd1bcb9163d069e))
-* Attempt to fix jessie build ([2021-07-23](https://github.com/tvheadend/tvheadend/commit/0778a348e0d2614eb7d586f50ad92bf6631ef8f3))
-* Fix slow loading bandwidth monitor graph in status tab ([2021-07-21](https://github.com/tvheadend/tvheadend/commit/129df4ff3591ce144e7467e93c3f1a3a194bb583))
-* As we no longer have access to #hts on freenode swap to using libera - see https://tvheadend.org/issues/6054 ([2021-06-12](https://github.com/tvheadend/tvheadend/commit/eb59284b8527e3c51eadfeca94ec1e9174cdbdb0))
-* Add NVIDIA Hardware accelerated decoding for transcoding ([2021-06-09](https://github.com/tvheadend/tvheadend/commit/04853f0dad2282226ec40bf7a95714b722edf66b))
-* Fix EN50211 size for large messages ([2021-05-31](https://github.com/tvheadend/tvheadend/commit/9476680f88d3c2363f86bdb1d4ea93dd3c7d2c95))
-* [Allow PMT Parsing when PMT shares a PID with another table](#user-content-fn-236)[^236] ([2021-05-05](https://github.com/tvheadend/tvheadend/commit/3038059db8b16f85ca23387c5ccdb6d8f40414ae))
-* Fix missing } from previous commit ([2021-05-05](https://github.com/tvheadend/tvheadend/commit/97d33e8f2a9021d49928529434ab4bcadd16807c))
-* Update ffmpeg to 4.4 ([2021-05-05](https://github.com/tvheadend/tvheadend/commit/637844055c186e981495da711e4887806f656c98))
-* [else is missing](#user-content-fn-237)[^237] ([2021-05-04](https://github.com/tvheadend/tvheadend/commit/e66581e730d83e134320529087472d73956f19f3))
-* [seen is a unsigned type](#user-content-fn-238)[^238] ([2021-05-04](https://github.com/tvheadend/tvheadend/commit/3d19cd20e87350db7e0d1dd6bd382ec9ee2853b3))
-* SAT>IP-Client: Add option for 16, 24 and 32-channel DVB-C tuners ([2021-05-04](https://github.com/tvheadend/tvheadend/commit/2c0d0a52d516efc9100d1ef110f11b737892c1c3))
-* [Update profile.c](#user-content-fn-239)[^239] ([2021-05-01](https://github.com/tvheadend/tvheadend/commit/123ae50a58835fbeb57f3d9667f62c3994c820b6))
-* specified the value on each line ([2021-05-01](https://github.com/tvheadend/tvheadend/commit/d2299aba0f1746b5c5b71d0356f3c1e1108426f5))
-* Delete .DS\_Store ([2021-05-01](https://github.com/tvheadend/tvheadend/commit/d843dd2710b5179c373f34a8b273c0eba3391a6c))
-* Delete .DS\_Store ([2021-05-01](https://github.com/tvheadend/tvheadend/commit/fd3316469933fc51e2921ceee65561fcb7606d36))
-* Delete .DS\_Store ([2021-05-01](https://github.com/tvheadend/tvheadend/commit/9d9dffd6248369ad31c2fa18701817a355389387))
-* Update .gitignore ([2021-05-01](https://github.com/tvheadend/tvheadend/commit/fdc3f945f2b759a743a595b134786b881538f52e))
-* Improve Readme.md file with a more visual approach ([2021-04-21](https://github.com/tvheadend/tvheadend/commit/b824e237e9450ab73273f5bfc41630cc8339bde7))
-* Move travis builds from trusty to bionic ([2021-04-20](https://github.com/tvheadend/tvheadend/commit/10d117e6ed912759db59633ea426bed5ceb6819a))
-* Fix possible deadlock ([2021-04-02](https://github.com/tvheadend/tvheadend/commit/967c038dc0db18e84ca536583a8b22dc00e926f5))
-* Update libssl-dependency information ([2021-04-02](https://github.com/tvheadend/tvheadend/commit/69bfa71a8eb5db7bfaf2291e03ef010d5c42ab87))
-* [Add pid file hint for systemd-sysv-generator](#user-content-fn-240)[^240] ([2021-04-02](https://github.com/tvheadend/tvheadend/commit/98a7c6cfd9fc72a37e59b358ae326815b0913ab5))
-* remote timeshift: fix compilation with IPTV disabled ([2021-03-19](https://github.com/tvheadend/tvheadend/commit/dbaa0f850394af8ab845df802f5f781ac0218ec4))
-* [Upgrade to libhdhomerun\_20210224](#user-content-fn-241)[^241] ([2021-03-17](https://github.com/tvheadend/tvheadend/commit/d003145d7b8c2f28ea238fbfbbac7833ea542857))
-* remote timeshift: fix crash on multiple subscriptions and cleanup ([2021-03-16](https://github.com/tvheadend/tvheadend/commit/2ea441d668a3c010f32519201dd02901076d2e19))
-* Reset error counters for IPTV on start, issue #5760 ([2021-03-16](https://github.com/tvheadend/tvheadend/commit/6c537b1fddc40ce84eb032a06e2a846a366aa30b))
-* Try to fix error during compilation ([2021-03-16](https://github.com/tvheadend/tvheadend/commit/b3a98ae7e948e76d25c1610105a86f2790994062))
-* Fix possible NULL-Pointer-reference ([2021-03-12](https://github.com/tvheadend/tvheadend/commit/817a8d4e48414cca0c21c58bfdccf6fc01e56109))
-* [iptv: new features for multicast, rtsp & rtcp](#user-content-fn-242)[^242] ([2021-03-12](https://github.com/tvheadend/tvheadend/commit/d67fff914417955e4ab8e9fbc091576855425ae2))
-* [EMM patch](#user-content-fn-243)[^243] ([2021-02-24](https://github.com/tvheadend/tvheadend/commit/052c629c530574f96018dd15efaa3384e9fe8a4d))
-* Fix issues identified by coverity ([2021-02-24](https://github.com/tvheadend/tvheadend/commit/fe0e5f1f9c8fa175183cede9b3182fb25de2d367))
-* [Several coverity fixes, year updated, map muxes between DVB Types](#user-content-fn-244)[^244] ([2021-02-21](https://github.com/tvheadend/tvheadend/commit/2f0c4f298b1e176cf995b8bcd10fd05c425d3a4f))
-* Attempt to fix nvenc encoding ([2021-02-21](https://github.com/tvheadend/tvheadend/commit/00b35ec7803388eb08e4835a1df821283ddef4a9))
-* [Several enhancements](#user-content-fn-245)[^245] ([2021-02-20](https://github.com/tvheadend/tvheadend/commit/b863e339033b5fffe4ab956663b814fa5896b725))
-* Rewrite scanfile.c for dynamic memory allocation (#1387) ([2021-02-20](https://github.com/tvheadend/tvheadend/commit/0046c96d8d17f455caa8251c569355b77fe9f104))
-* [Fix uninitialised memory access for several ioctl commands (#1382)](#user-content-fn-246)[^246] ([2021-02-18](https://github.com/tvheadend/tvheadend/commit/71a597df3e8a2f1c075c21e5786a2f88e334e20d))
-* Add accidentally deleted line again ([2021-02-18](https://github.com/tvheadend/tvheadend/commit/9660b9c5ff8f7f3976975939f79b9ef8cd463d6e))
-* Enable LIBX265\_DIFFS again ([2021-02-18](https://github.com/tvheadend/tvheadend/commit/4105972735abda7ca955305dd7fac098edd0aaa1))
-* Silence more x265 warnings ([2021-02-18](https://github.com/tvheadend/tvheadend/commit/d002eedb9a57b43c4e4b20a0d2583a7c03027802))
-* Move from travis-ci.org to travis-ci.com and update date ([2021-02-18](https://github.com/tvheadend/tvheadend/commit/d6eff494c5f1329959d435513071dcd2f80cf0fb))
-* Remove link to bintray as they will shutdown in 2 weeks ([2021-02-18](https://github.com/tvheadend/tvheadend/commit/bbf76ca96b274d0e007ee32b371d94d750217653))
-* Fix several issues discovered by coverity ([2021-02-18](https://github.com/tvheadend/tvheadend/commit/c5d4d7dea487770dd8b7e4722f0c7fcc7d5315eb))
-* More coverity fixes ([2021-02-18](https://github.com/tvheadend/tvheadend/commit/d3faccf5568ff4de789b65cc2b23dd9b8a9c4067))
-* Fix crash when using matroska profile ([2021-02-18](https://github.com/tvheadend/tvheadend/commit/a477a3b39d42cf9af1394fbdf5b3ee7cb2699da6))
-* Fix more issues identified by coverity ([2021-02-18](https://github.com/tvheadend/tvheadend/commit/1619f9e44678dba5467e4ac94b3e47ea92b72f3e))
-* Fix too small memory allocation ([2021-02-17](https://github.com/tvheadend/tvheadend/commit/8e2ac3ac8dd804f2d6c892644948b8178b5f285b))
-* [Upgrade to libhdhomerun\_20200907](#user-content-fn-247)[^247] ([2020-12-29](https://github.com/tvheadend/tvheadend/commit/38c0445a4bb1870532d5feb65e2151aa8bae611d))
-* Added ISDB-T SATIP Support ([2020-12-29](https://github.com/tvheadend/tvheadend/commit/f0dfae1bcfa7e26a07422a42b05c6e261a098579))
-* [fix vaapi-profiles (#1366)](#user-content-fn-248)[^248] ([2020-12-29](https://github.com/tvheadend/tvheadend/commit/4d91bca9af0ee05b3dd6182549f83cba252ac867))
-* Add ISDB-T in hdhomerun ([2020-12-29](https://github.com/tvheadend/tvheadend/commit/aaca05cc1087e0786eb2b41f050ee8fd3e66c728))
-* [Fix possible deadlock when using tvh\_mutex\_trylock()](#user-content-fn-249)[^249] ([2020-12-16](https://github.com/tvheadend/tvheadend/commit/52b255940f9eb71904b9ac01c733cad090cd061a))
-* Sat>IP clear old signal info when opening new stream ([2020-12-14](https://github.com/tvheadend/tvheadend/commit/bd88f3db6a7ed43dc0dca5ed832da13bf627feaf))
-* Remove libva-x11 dependency ([2020-12-06](https://github.com/tvheadend/tvheadend/commit/ecd05a21de3075466476df97cf37ffd42c787e58))
-* [docs: fix simple typo, separately -> separately](#user-content-fn-250)[^250] ([2020-11-27](https://github.com/tvheadend/tvheadend/commit/1884300f016027cc3427e3f84c1acfbace5561da))
-* [in python 3, dict.has\_key() has been removed](#user-content-fn-251)[^251] ([2020-11-14](https://github.com/tvheadend/tvheadend/commit/febcf9818d7c37fec8a98d424934edcb3243d5e4))
-* Correct Environment variable name. ([2020-10-28](https://github.com/tvheadend/tvheadend/commit/9a51036e86375103039d38b9c70030c681d06425))
-* [Changed shebang of tvhmeta to python](#user-content-fn-252)[^252] ([2020-10-28](https://github.com/tvheadend/tvheadend/commit/214a14f2968857331dc746609e15c9ad46b5f13e))
-* Use https for downloading ffmpeg and update nv-codec-headers ([2020-10-27](https://github.com/tvheadend/tvheadend/commit/cd0f33b148028330c5d6b2c4021934e2cdef271f))
-* Add removed checksum ([2020-10-27](https://github.com/tvheadend/tvheadend/commit/11cda04ab15d269d4bf3597d0f1398f49f5fac08))
-* [Silence x265 warnings (#1368)](#user-content-fn-253)[^253] ([2020-10-27](https://github.com/tvheadend/tvheadend/commit/04dd1143ff23ddad5b67d95515a906fa070a5410))
-* Change no\_sanitize("thread") attributes ([2020-10-22](https://github.com/tvheadend/tvheadend/commit/c66e3bc7db52c1e1bcae9de86d8c6fe8ccb46aa4))
-* Adding polish scraper for DVBC ([2020-10-21](https://github.com/tvheadend/tvheadend/commit/ba94ccf283594e6195ab6c598a4bd972a3c2d4f6))
-* Fix #5962 ([2020-10-19](https://github.com/tvheadend/tvheadend/commit/c1552692e030ea245d4bf091537ba94b8864a07f))
-* Attempt to fix focal build in doozer ([2020-10-14](https://github.com/tvheadend/tvheadend/commit/d0fb31c67cbd6285e1310ff06064fa96aa524a73))
-* Make focal use python3 for upload ([2020-10-14](https://github.com/tvheadend/tvheadend/commit/7e1dac82261dba52900e8d6def943d6149102875))
-* Fix vaapi patch ([2020-10-12](https://github.com/tvheadend/tvheadend/commit/9ed76c0a176b055a57b6e8bd2e0b6e29409269a9))
-* Fix cut & paste error in api/epg. (#1360) ([2020-10-08](https://github.com/tvheadend/tvheadend/commit/736ac427b1934832aab23391f5ce35f687c999c6))
-* [update Makefile.ffmpeg (#1359)](#user-content-fn-254)[^254] ([2020-10-08](https://github.com/tvheadend/tvheadend/commit/ce92e8c8f2842416018b29b2fc8571e5ddaa09b6))
-* [Fix NVENC](#user-content-fn-255)[^255] ([2020-10-08](https://github.com/tvheadend/tvheadend/commit/627c17ae86119f87038ef76d0c02377adbfd5a84))
-* [Remove wrong test in nvenc.c](#user-content-fn-256)[^256] ([2020-10-08](https://github.com/tvheadend/tvheadend/commit/c4d086cc098e5d44a5ab9f2c7c1e0afedb0a4106))
-* [Fix scraping 'new' flag from UK EIT.](#user-content-fn-257)[^257] ([2020-09-28](https://github.com/tvheadend/tvheadend/commit/04ccb9fd99e526a60355ee908a8ad30cf009b996))
-* [Revert dca46eedd9653b90d2722e67281eed0b35740730](#user-content-fn-258)[^258] ([2020-09-28](https://github.com/tvheadend/tvheadend/commit/c3204bc6ff87deed26a3bd8ef7a8224a50606dc3))
-* Upgrade to libhdhomerun\_20200521 ([2020-09-13](https://github.com/tvheadend/tvheadend/commit/6b8f014c39703640a1fe8af9c2b7663588ed2b56))
-* Fix TheTVDB Query ([2020-07-13](https://github.com/tvheadend/tvheadend/commit/ce09077056f9c6558c188d135cec3be85cc9c200))
-* [Fix escape code '\&quote;' should be '"'. (#1355)](#user-content-fn-259)[^259] ([2020-07-12](https://github.com/tvheadend/tvheadend/commit/d492091de8231ca25ac4b4f682da7d32f3d6f44f))
-* [Revert "HTSP v35: Add support for recording file size" (#1352)](#user-content-fn-260)[^260] ([2020-07-11](https://github.com/tvheadend/tvheadend/commit/313803bb69245abc4199130a71748b61d05581bc))
-* [HTSP v35: Add support for recording file size](#user-content-fn-261)[^261] ([2020-07-11](https://github.com/tvheadend/tvheadend/commit/8066d559ec12cec0ab1fa366b54286d706f9b5a9))
-* Attempt to fix doozer build/python2/3 detection ([2020-07-07](https://github.com/tvheadend/tvheadend/commit/0f13f5912921321a7061ffde760ec41c32d99e77))
-* Replace long by int64\_t in json parser, fixes #5844 (#1349) ([2020-07-06](https://github.com/tvheadend/tvheadend/commit/fa07b19a0011b76029d54f094f00fcbe39f714bd))
-* [Handle bad UTF-8 in xmltv (#5909)](#user-content-fn-262)[^262] ([2020-07-06](https://github.com/tvheadend/tvheadend/commit/f0b21875cf5f3c6ccc735d9c9613122946188628))
-* see https://tvheadend.org/issues/5722 ([2020-07-06](https://github.com/tvheadend/tvheadend/commit/25e9c0600b6090335cebee2854bea1f9b2fecaa4))
-* Report AAC and AAC-LATM correctly. Always raw stream AAC audio as audio/aac. ([2020-07-06](https://github.com/tvheadend/tvheadend/commit/34234b2ed6014da2937852492eba8ac8e4814848))
-* Additional sanity check ([2020-07-06](https://github.com/tvheadend/tvheadend/commit/f77c77d11cdab4aad14bae3e1d269176031f9f0b))
-* Fix memory leak ([2020-06-10](https://github.com/tvheadend/tvheadend/commit/51a4c5bec7b6fc69dab7b8d559f9b1b881f0eb8e))
-* xmltv: add program icon to exported xmltv. Fixes: #5685 ([2020-06-08](https://github.com/tvheadend/tvheadend/commit/ec39f08b0df1bcc1598eb329001c574140df4fe6))
-* Allocate space for buf on heap (modified PR #1324) ([2020-06-08](https://github.com/tvheadend/tvheadend/commit/8bd059550c641fcaae3a360c527ada6ec74ce9e7))
-* Allocate space for buf on heap (modified PR #1324) ([2020-06-08](https://github.com/tvheadend/tvheadend/commit/e1031ce5d55275e1606643133b8168adcbe5f231))
-* Fix infinite loop when parsing invalid EIT CRID data ([2020-06-05](https://github.com/tvheadend/tvheadend/commit/749f51914c7ffe68ddec4e9272481110d753324d))
-* Fix building with -fno-common (default from GCC 10) ([2020-06-03](https://github.com/tvheadend/tvheadend/commit/8a2942a361e95ccdbd30c1edc7627df3862cdbbe))
-* Add python3 requests dependency ([2020-05-22](https://github.com/tvheadend/tvheadend/commit/32500be3898005137b510e187969979cb6c0f85e))
-* Change nv-codec-headers path, fixes #5901 ([2020-05-22](https://github.com/tvheadend/tvheadend/commit/2af3b9e2e4ae15b2bbfd61ed1077a44782ed32cd))
-* Update Copyright date on UI 'About' screen. ([2020-05-21](https://github.com/tvheadend/tvheadend/commit/ddf17f736a07c03d48cb575acba16ad588c1758a))
-* dvbpsi: Fix build when DVB is not enabled at all ([2020-05-21](https://github.com/tvheadend/tvheadend/commit/4b3b33086438fce199a557fe32e6b6aa086c0714))
-* Changed default .pid path from /var/run/tvheadend.pid to /run/tvheadend.pid to follow "new" FSH 3 standard ([2020-05-21](https://github.com/tvheadend/tvheadend/commit/e59b92e9f317b758e69fe5e0d0037d44d2d0a33a))
-* Fix doozer builds ([2020-05-19](https://github.com/tvheadend/tvheadend/commit/38fdee98f48c203362af0c87a4fed24b52bd4ffb))
-* Fix doozer builds ([2020-05-19](https://github.com/tvheadend/tvheadend/commit/b293369b475315fce38ffd2caa5e5435a1edc6bd))
-* Drop focal i386 support ([2020-05-19](https://github.com/tvheadend/tvheadend/commit/1c67c04c8b2ef454fc8bd9265098b903fc6c45e7))
-* [CSS: general improvements](#user-content-fn-263)[^263] ([2020-05-18](https://github.com/tvheadend/tvheadend/commit/07be334e92072bad19beada9c111f1bb2e0aae16))
-* [Makefile.ffmpeg: update almost all upstream packages](#user-content-fn-264)[^264] ([2020-05-18](https://github.com/tvheadend/tvheadend/commit/f28f7d2a66ccb96cbfac59b29049f9f332f79c55))
-* Use python3 if available ([2020-05-18](https://github.com/tvheadend/tvheadend/commit/eb57b2277cdcd0b25584997534dd018061f2ec5f))
-* [Attempt to fix doozer builds (#1340)](#user-content-fn-265)[^265] ([2020-05-18](https://github.com/tvheadend/tvheadend/commit/11f5d6c83b1f69ea105b4d69475d73e438eecc98))
-* Deprecate python2, add support for python3 (#1338) ([2020-05-17](https://github.com/tvheadend/tvheadend/commit/d7c707467f3f4794cf786806ea479fdad6e516c2))
-* Move forward from cosmic to focal ([2020-05-15](https://github.com/tvheadend/tvheadend/commit/c310da9541135af9532017bb7f1f14a90f37dbfe))
-* Prevent buffer overflow, fixes #5896 ([2020-05-15](https://github.com/tvheadend/tvheadend/commit/2780cd37dc415dae2be1926a6a338d8f4a59b44f))
-* Fix buffer overflow ([2020-05-15](https://github.com/tvheadend/tvheadend/commit/6be200b02265b968c24656259eef0f66194d405c))
-* Use python3 on focal ([2020-05-15](https://github.com/tvheadend/tvheadend/commit/c82e00409b4f7110e4743cf62d67990f6e6cdca3))
-* Update copyright and packages link ([2020-05-15](https://github.com/tvheadend/tvheadend/commit/465050d436843893fc9814cbd608b4c4854c4cd3))
-* Move from cosmic to focal (#1337) ([2020-05-15](https://github.com/tvheadend/tvheadend/commit/f2f6c867f1ac15bbae9ed2e297375e27181fdd49))
-* Upgrade to libhdhomerun\_20200225 ([2020-05-15](https://github.com/tvheadend/tvheadend/commit/fe5eea266938f21e273e4af6593a80d28f287b81))
-* Use HTTPS for libhdhomerun download ([2020-05-15](https://github.com/tvheadend/tvheadend/commit/2a7cb68bcd8e43504d5dbeb5d8785a57cd8769cf))
-* Fix the query URL for IMDB website. (#1327) ([2020-05-14](https://github.com/tvheadend/tvheadend/commit/d8a31e57a492be6628b685488fcc7f1d9d262679))
-* HTSP v35: Add support for recording file size ([2020-05-14](https://github.com/tvheadend/tvheadend/commit/8d43c6600cf8fec2879a9d1f9633d7f70ba90bed))
-* esstream: fix NULL dereference in elementary\_set\_filter\_build(), fixes #5787 ([2019-11-28](https://github.com/tvheadend/tvheadend/commit/4db926ebe9b77b8da9f6b3f8d62eca5103017f2c))
-* Fix #5782 ([2019-11-28](https://github.com/tvheadend/tvheadend/commit/221c29b40b1e53ae09a69d9458442dd4fea665f5))
-* capmt: fix the input filter ([2019-11-15](https://github.com/tvheadend/tvheadend/commit/d453f5bef392981c8b14025e2446e4012f72f422))
-* service: fix the default return value for service\_get\_source() ([2019-11-04](https://github.com/tvheadend/tvheadend/commit/e225c55e0e927787f6b055fa0d0e0fcd7c145b0c))
-* mpegts service: fix the build without mpegts\_dvb (see PR#1321) ([2019-11-04](https://github.com/tvheadend/tvheadend/commit/fda89e85e0b6ae796d8a09e178d3937aa7869270))
-* satip client: try to fix the missing poll file descriptor removal, issue #5496 ([2019-11-01](https://github.com/tvheadend/tvheadend/commit/25a50f75a07b656e380b4e9e2d61cbc6c7740e4b))
-* docs: add hint on shell redirections (#5761) ([2019-11-01](https://github.com/tvheadend/tvheadend/commit/dea96e4418eec37aa75592fee2a9dd7672a9c108))
-* htsstr: add htsstr\_argsplit() test ([2019-10-31](https://github.com/tvheadend/tvheadend/commit/a9eaf6dc13227f712c3abc5e4987476fd83d5226))
-* htsstr: fix the wrong argument parsing, fixes #5761 ([2019-10-31](https://github.com/tvheadend/tvheadend/commit/0afdc9d3aea7b6037f1f9886945116557b6787da))
-* tvhpoll: add event helpers, code cleanups ([2019-10-31](https://github.com/tvheadend/tvheadend/commit/912078267423fd54d52ee31e645cc778323fdd2b))
-* [Remove dead assignment](#user-content-fn-266)[^266] ([2019-10-28](https://github.com/tvheadend/tvheadend/commit/24ff5a612628c2e52886456ea429148b59151448))
-* tvhpoll: add tvhpoll\_set\_trace() ([2019-10-28](https://github.com/tvheadend/tvheadend/commit/4eac68f52a132de8313f2c1fcdcc227df540b2b2))
-* xmltv: Fix xmltv\_ns typo, fixes #5720 ([2019-10-27](https://github.com/tvheadend/tvheadend/commit/1fd019c82e8dd21d51d8f96d9843e1cdcaff568f))
-* [Webui: minimal reworks for access theme](#user-content-fn-267)[^267] ([2019-10-27](https://github.com/tvheadend/tvheadend/commit/02cae0f3da19a95b37f2a75e02f22c18961da418))
-* webui: m3u playlist - mark tag playlists with type=playlist, fixes #5663 ([2019-10-24](https://github.com/tvheadend/tvheadend/commit/91fac103174bb1cc46b4368fd1aa96dffe6090a9))
-* access.h: reorder access\_t (format members) ([2019-10-21](https://github.com/tvheadend/tvheadend/commit/895d747cc4f5bf8f655288c3397b6d2db4f08099))
-* access: allow to change/set xmltv/htsp output format per matched entry ([2019-10-21](https://github.com/tvheadend/tvheadend/commit/0424fc0e30d07ba364fcf35daf34a0a72739f334))
-* dvr: fix the DVR limit per user condition (subtract self) ([2019-10-21](https://github.com/tvheadend/tvheadend/commit/fb23c42a9e398d83a76ad49d07553ddaf4c6e8d5))
-* [access: added missing break for connection limit type](#user-content-fn-268)[^268] ([2019-10-21](https://github.com/tvheadend/tvheadend/commit/729651ce96cfd181fac127024267dbe8abedc924))
-* satip client: SATIP Kathrein & Triax: Avoid mandatory rolloff on DVBS2, fixes #5517 ([2019-10-21](https://github.com/tvheadend/tvheadend/commit/6c6e0e5103b874fdd926b0f1bcdaed4d7e8b464e))
-* satip client: allow to set the rolloff to all possible combinations ([2019-10-21](https://github.com/tvheadend/tvheadend/commit/fb06654aea29c13d883314c03573ddcf6a77c954))
-* api: return EPERM for the empty arguments, fixes #5755 ([2019-10-21](https://github.com/tvheadend/tvheadend/commit/707b82b9c95519e9f3eb22f1e3d2a6cbe14f9b5c))
-* tvhdhomerun: fix the cablecard access in tvhdhomerun\_frontend\_monitor\_cb() ([2019-10-21](https://github.com/tvheadend/tvheadend/commit/6540ff23747499bfa28ba04cc76347a9209f4a1e))
-* Fix division by 0, fixes #5754 ([2019-10-20](https://github.com/tvheadend/tvheadend/commit/d066577c4f663222fe83e00a09e15b28666b5a23))
-* dvb psi: fix the removed MPEG2VIDEO assignment, fixes #5752 ([2019-10-19](https://github.com/tvheadend/tvheadend/commit/6fbb30d039c763268b3e9017e062b0c9ec6bebeb))
-* mux grid: enable 'hide: parent disabled' ([2019-10-18](https://github.com/tvheadend/tvheadend/commit/84c989e1557843b0acabb1bd8f10c72d9e7327a0))
-* dvb psi: add 0x87 estype as EAC3 (ATSC), fixes #5684 ([2019-10-17](https://github.com/tvheadend/tvheadend/commit/7f090c9829a98427692e06a907c3197ea7230071))
-* [bugfix for autorecs duplicate episode number detection in autorecs](#user-content-fn-269)[^269] ([2019-10-15](https://github.com/tvheadend/tvheadend/commit/a3a631404a5ba1c4e7a2751040c122c0098cf61a))
-* autobuild: add build target for raspbian-buster ([2019-10-15](https://github.com/tvheadend/tvheadend/commit/5d112de19c2ddfde470c647686e44a42c3e95cb4))
-* channels: Make const-correct. ([2019-10-15](https://github.com/tvheadend/tvheadend/commit/dd2eddadcf0206094fd7b2ebf77f088026298a72))
-* [xmltv: Allow sending basic xmltv format, fixes #5630](#user-content-fn-270)[^270] ([2019-10-15](https://github.com/tvheadend/tvheadend/commit/dca55a1d393686c9ab1619f3c2e891685d40d428))
-* [htsp: Allow basic htsp format, fixes #5630](#user-content-fn-271)[^271] ([2019-10-15](https://github.com/tvheadend/tvheadend/commit/64f20b5ef8b2d1938b6aa10fb4014475a81474e1))
-* [xmltv: Avoid outputting lang tags in xmltv for only one language, fixes #5630](#user-content-fn-272)[^272] ([2019-10-15](https://github.com/tvheadend/tvheadend/commit/f249f6ac9c42b6b37c84edaaab24476ade90522a))
-* Added patch to HDHomerun library to allow cross-compilation ([2019-10-15](https://github.com/tvheadend/tvheadend/commit/4a059579ec18132ebf2950ee6c14c098400c0ff8))
-* [tvhcsa.c: include stdio.h](#user-content-fn-273)[^273] ([2019-10-15](https://github.com/tvheadend/tvheadend/commit/d1fc95a8ad4320054b5f1aa0d4398d193eba246e))
-* tvhcsa: shift the standard headers to top ([2019-10-15](https://github.com/tvheadend/tvheadend/commit/76626a94646223f8e73c2168fa4b7a28c5bb8046))
-* Mux scan: Log correction ([2019-10-15](https://github.com/tvheadend/tvheadend/commit/a433a00802eb7d65868acc47e851fbd6988588b6))
-* Upgrade to libhdhomerun\_20190621 ([2019-10-15](https://github.com/tvheadend/tvheadend/commit/971a6e88f4a6fd78763dfdb1ade1d1583d0592a6))
-* [systemd service file: remove wildcard mounts preventing startup - replace with a note](#user-content-fn-274)[^274] ([2019-10-15](https://github.com/tvheadend/tvheadend/commit/6ac41a512410889d2b14a19ae6fc5693772b495d))
-* Fixed bad quality for vaapi transcoding h264 and hevc with bitrate ([2019-10-15](https://github.com/tvheadend/tvheadend/commit/c767042262eeeac2b416bad2905cdd3697b5378e))
-* packaging: add missing DEBHELPER placeholder to postrm script ([2019-10-15](https://github.com/tvheadend/tvheadend/commit/7767ab4272906b253daa6a1cd61703e1073a2404))
-* [Avoid configure checks being optimised away with LTO](#user-content-fn-275)[^275] ([2019-10-15](https://github.com/tvheadend/tvheadend/commit/cde6e98aabf30741069321f01dbb044f32b97552))
-* linuxdvb: fix integer overflow on 32-bit platforms ([2019-10-15](https://github.com/tvheadend/tvheadend/commit/0243112a5d6e348d226403f3e91f1a9b91dd35df))
-* iptv: fix integer overflow on 32-bit platforms ([2019-10-15](https://github.com/tvheadend/tvheadend/commit/baf746bc1d420e7d628994922df0ddcb665f698f))
-* linuxdvb: take in account similar dmx for the exclusive tuner access, fixes #5744 ([2019-10-14](https://github.com/tvheadend/tvheadend/commit/ac8095e9883173ced48c223b2d53d7e91d9e6671))
-* api: fix the wrong negative error codes, fixes #5743 ([2019-10-14](https://github.com/tvheadend/tvheadend/commit/c67ba3ce1ba445cf2aea28315bdf97477f43198b))
-* satip client: add ATSC- string parsing, issue #5728 ([2019-10-06](https://github.com/tvheadend/tvheadend/commit/45bfbd9217d49c1d45ce9da1fabc51adc12de8aa))
-* linuxdvb: do not mix DVBv3/v5 stats, it causes trouble to drivers, fixes #5625 ([2019-10-06](https://github.com/tvheadend/tvheadend/commit/c8794d3aeaff7e99b30aa368e10dbea0f4a227c1))
-* add FHD quality support ([2019-10-06](https://github.com/tvheadend/tvheadend/commit/3a98ebc0556ba6724673772d7e41383bcf0ec913))
-* service: correct fhdtv/uhdtv height checks ([2019-10-06](https://github.com/tvheadend/tvheadend/commit/691cce4a76177e14e30da6beaca28b9011a529f1))
-* [bouquet: fix overflow when building for 32-bit system On 32-bit system hash value from service can be truncated.](#user-content-fn-276)[^276] ([2019-10-06](https://github.com/tvheadend/tvheadend/commit/e372db0667a0072e51eb21a0b933d3b3bb8e095d))
-* man page: Correct default values for http and htsp port ([2019-10-06](https://github.com/tvheadend/tvheadend/commit/cb0a61e959065b321d91244d5558968a6cdcb4ad))
-* linuxdvb: compilation fix, fixes #5739 ([2019-10-06](https://github.com/tvheadend/tvheadend/commit/e1fb5c0254e28e6f19d0163e7add8b29c59c1d93))
-* cclient: more ECM PID fixes, reorder code to be more readable, fixes #5659 ([2019-08-02](https://github.com/tvheadend/tvheadend/commit/ebb0968047b6a3aecd61b48792ab8b48a50ecb0d))
-* cclient: mark correctly ECM PID for close, fixes #5659 ([2019-07-29](https://github.com/tvheadend/tvheadend/commit/9874ab0b1d4a6752840a9a23bf7502c3e623825f))
-* cclient: fix the ECM PID flag for newcamd and cccam, fixes #5659 ([2019-07-06](https://github.com/tvheadend/tvheadend/commit/6be300c430ab614aa527ef34e34f007f34a68ee0))
-* [Include stdio.h before tvheadend headers](#user-content-fn-277)[^277] ([2019-07-02](https://github.com/tvheadend/tvheadend/commit/8f1de1621d78c91431238176bf4f6290870a031a))
-* [Makefile: fix -pie linking according to --disable-pie](#user-content-fn-278)[^278] ([2019-06-30](https://github.com/tvheadend/tvheadend/commit/7a71536ec80a3dc03e83dd87ccd67f6a66ecc573))
-* [Fix compilation with libhdhomerun 20190621](#user-content-fn-279)[^279] ([2019-06-30](https://github.com/tvheadend/tvheadend/commit/13cd23c371e3377973502f8dc65654b6a0ff372b))
-* linuxdvb: fix signal status monitor ([2019-06-30](https://github.com/tvheadend/tvheadend/commit/92dffe6976416ee3363ab558dbddba101c7d474f))
-* mpegts: use 32-bit tsid/onid to define the NONE /unset/ state properly ([2019-06-30](https://github.com/tvheadend/tvheadend/commit/bf7532d2c8548ae2b1519a014d619547a81508c5))
-* [revert bogus ONID and TSID remapping](#user-content-fn-280)[^280] ([2019-06-30](https://github.com/tvheadend/tvheadend/commit/dcc50db45b322da22241c01807643160c16ccfc2))
-* capmt: another compilation fix, fixes #5661 ([2019-06-18](https://github.com/tvheadend/tvheadend/commit/771dfd6bea7bd4035ed991eccbe735dc00d3f800))
-* capmt: fix compilation with recent gcc, fixes #5657 ([2019-06-17](https://github.com/tvheadend/tvheadend/commit/4036e249c365b7840e2c5f9ce7e9b2edbecf3184))
-* [capmt: fix for the oscam r11520+, fixes #5649](#user-content-fn-281)[^281] ([2019-06-12](https://github.com/tvheadend/tvheadend/commit/bc769bfa9260bad6e1caa0c95591b70ae25f47bf))
-* [fanart: Fix decode error.](#user-content-fn-282)[^282] ([2019-05-20](https://github.com/tvheadend/tvheadend/commit/e0fad819003f67d4569ea189f2f48a53367c1bd5))
-* [en50221: fix invalid htsmsg manipulation](#user-content-fn-283)[^283] ([2019-05-20](https://github.com/tvheadend/tvheadend/commit/f033b21316cf7185e6189f4a751ba382117d13ed))
-* [en50221: fix menu text decoding](#user-content-fn-284)[^284] ([2019-05-20](https://github.com/tvheadend/tvheadend/commit/466a0143195a0a0f15c58d4bbd93c57b13caaccd))
-* dvbpsi: fix the freesat bouquet update (inverted condition), fixes #5572 ([2019-03-24](https://github.com/tvheadend/tvheadend/commit/6bfeca6c03dbd73fa73b1b0dde383ddab29ba91c))
-* api: return an error when incomplete query is passed, fixes #5568 ([2019-03-21](https://github.com/tvheadend/tvheadend/commit/14d22c3797f2077bc31dfdd03cd1cc5e94511b00))
-* linuxdvb: create the mux instances also for the slave tuners, issue #5128 ([2019-03-20](https://github.com/tvheadend/tvheadend/commit/937a5fb78552f067f889279a7c20a418c39e283e))
-* linuxdvb: use the right configuration root for the slave tuners (loading), issue #5128 ([2019-03-20](https://github.com/tvheadend/tvheadend/commit/453ee8dfd80b240e1005502c002bdc6de3f121c8))
-* [Freesat\_huffman: Suppress characters < 0x20 except \n.](#user-content-fn-285)[^285] ([2019-03-15](https://github.com/tvheadend/tvheadend/commit/1383eab65a93763b8780e5011d592d9f249031b6))
-* [Update to newest ffmpeg to fix libX11 compile issue "DSO missing from commandline"](#user-content-fn-286)[^286] ([2019-03-13](https://github.com/tvheadend/tvheadend/commit/d250c1844798791a1354254a60545d4be5ada197))
-* Add sat longitude and usals angle as parameters to the rotor external command ([2019-03-13](https://github.com/tvheadend/tvheadend/commit/ec90d317ea5b5b0a18eb543ee90d1c41c30bf849))
-* http server: fix digest MD5 authorization, fixes #5573 ([2019-03-13](https://github.com/tvheadend/tvheadend/commit/3f0c6b1e28fc5bae5c3e8934c8a79400236a1ac8))
-* utils: sbuf - use correct format character, fixes #5565 ([2019-03-07](https://github.com/tvheadend/tvheadend/commit/811fd889e9da762d04977f3531aa1aae8ff37329))
-* SAT>IP: fix done - close sessions only when server is active ([2019-03-06](https://github.com/tvheadend/tvheadend/commit/ff7893d8fee713673d0f7662d3753b4d0de4c706))
-* eit: fix the possible NULL dereference ([2019-03-06](https://github.com/tvheadend/tvheadend/commit/a3c5e751b05018a2cb3764627c3a77b4a5d9e7ce))
-* utils: cosmetic fix for sbuf\_alloc\_fail ([2019-03-06](https://github.com/tvheadend/tvheadend/commit/68ae28cc4a7e969e918e6fd5c5212fa272a86c2e))
-* freesat bouquet parser: fix endless loop (double list insert), fixes #4851 ([2019-03-06](https://github.com/tvheadend/tvheadend/commit/726e6e65441a9802b6678b05e5f78d82c8cad5f5))
-* tvh thread: increase the default watchdog timeout to 15 seconds ([2019-03-02](https://github.com/tvheadend/tvheadend/commit/7aeece632a06891c4a15cc286e199697c59e5a9a))
-* mpegts: fix the idle scan (use another idle scan queue - fixes #5548) ([2019-03-02](https://github.com/tvheadend/tvheadend/commit/717030bca5b8087d073a40f45092bc1eb7fdb8bb))
-* systemd: service/unit should not be started until after file-systems are mounted - this avoids "file missing" errors ([2019-03-01](https://github.com/tvheadend/tvheadend/commit/b988b54beaad0583ac36831d05609269ff139a3a))
-* Prevent rebinding when refreshing SAT-IP Server settings and not changing port, fixes #5539 ([2019-03-01](https://github.com/tvheadend/tvheadend/commit/6edc4dab9138cac99f10c42b1dfc0fc475743c46))
-* tvh-json.py: the list is returned instead dictionary ([2019-03-01](https://github.com/tvheadend/tvheadend/commit/0122ccb22369305f1ccfa91da8022493ff163f3e))
-* iptv: another improvement in the thread exit procedure, fixes #5550 ([2019-02-28](https://github.com/tvheadend/tvheadend/commit/d2405f2988ab06d2bafba2b5397cacdac26c0d70))
-* iptv: improve the thread exit procedure, issue #5550 ([2019-02-27](https://github.com/tvheadend/tvheadend/commit/d0f3d09d853759f4e6bff95e706d9b9526fb4bcf))
-* iptv: improve the thread exit procedure - use pipe, fixes #5550 ([2019-02-27](https://github.com/tvheadend/tvheadend/commit/65c63116c23df8ea72ba6caa63fb70c94d3b106e))
-* satip client: fix the compilation, fixes #5547 ([2019-02-16](https://github.com/tvheadend/tvheadend/commit/143e5b1239d7e3ce5f92ef57ad1861e38fa9f148))
-* satip client: initialise variable \_w correctly for the PIDs split rewrite, fixes #5544, issue #5549 ([2019-02-16](https://github.com/tvheadend/tvheadend/commit/22eeadd11f8d323355ee3ab6e9068b5e443884ef))
-* satip client: improve the PIDs split for the PLAY RTSP command, fixes #5544 ([2019-02-15](https://github.com/tvheadend/tvheadend/commit/cc70226210f9888d58a205cf903d89c9b499ab97))
-* Triax & Kathrein: Increase pid length, issue #5544 ([2019-02-15](https://github.com/tvheadend/tvheadend/commit/7ff49818e6ac5d0c46995f60f33248e1b2e172b0))
-* satip client: fix for the PIDs split - missing delpids, issue #5544 ([2019-02-15](https://github.com/tvheadend/tvheadend/commit/bc6ef3491e0f4bbbaf0de166abf6a44904c48df8))
-* mpegts: pid subscription - fix wrong mps\_type mpegts\_mps\_cmp(), fixes #5492 ([2019-02-14](https://github.com/tvheadend/tvheadend/commit/57b766ab7e8ab3dbec2476cc269eaf8101d48b64))
-* http server: fix the new digest hashes (apparently firefox nor chrome do support them) ([2019-02-14](https://github.com/tvheadend/tvheadend/commit/a08a525bd754d57555ed8f5a9ac1bb0ad4e11d84))
-* mpegts input: fix the compilation error, fixes #5492 ([2019-02-14](https://github.com/tvheadend/tvheadend/commit/ec573f1f410de862d667122e37537807f925b6a4))
-* http: digest - show the SHA hash as an authentication alternative (tested with curl) ([2019-02-14](https://github.com/tvheadend/tvheadend/commit/10eb0614352ebd8669c27d1b94ad72d70784b2f3))
-* http: digest - return back MD5 as only digest hash (multiple login dialogs for firefox/chrome) ([2019-02-14](https://github.com/tvheadend/tvheadend/commit/0af25951debe4da57b94b28265930902535610ab))
-* http: digest - do not use EVP\_sha512\_256() for nonce, check openssl version ([2019-02-14](https://github.com/tvheadend/tvheadend/commit/fd6f880e31b551a5c6b05c7d4b16e0a76d8810d0))
-* satip client: workaround for FritzBox 6490/6590 (status string parsing), rewritten PR#1256 ([2019-02-14](https://github.com/tvheadend/tvheadend/commit/5caf8b8a445797a176376c9b28ce9f12cd28cf46))
-* Fix description of RTP/AVP/TCP Mode ([2019-02-14](https://github.com/tvheadend/tvheadend/commit/363e0eb6e82f3f46ffa6d3ec13899539993f409b))
-* Added compatibility mode for SAT-IP tuners that mess up tuner numbers, for example FritzBox 6490/6590 ([2019-02-14](https://github.com/tvheadend/tvheadend/commit/39db47829b65f140f337d4af3110a8906fed6ff8))
-* http server: add support for SHA-256 and SHA-512/256 digest hashes ([2019-02-13](https://github.com/tvheadend/tvheadend/commit/e61acb8ad4a3411f4e7acfd8133d222299f6d47e))
-* esfilter: fix the wrong other mask (hbbtv), fixes #5531 ([2019-02-12](https://github.com/tvheadend/tvheadend/commit/797af7c7873ab5cbc63bbb6ff4c518433b8d521d))
-* esfilter: cosmetic fix ([2019-02-12](https://github.com/tvheadend/tvheadend/commit/ca6a3f2f7d79e04ad12cf34f78e0f71784eaaa0f))
-* channel: get number - select the lowest service number, fixes #5441 ([2019-02-11](https://github.com/tvheadend/tvheadend/commit/419b0a143c439b50f7d2d979945f5e8d2f6769d1))
-* descrambler: simplify some destroy sequences ([2019-02-11](https://github.com/tvheadend/tvheadend/commit/c54f303c6e23c0abbb14635b9dd8291393c76a53))
-* dvb psi: fix hbbtv parsing, fixes #5531 ([2019-02-09](https://github.com/tvheadend/tvheadend/commit/e4e96ff3f7e28eb71a3f077f59e8ba756c3470ab))
-* m3u: fix the NULL dereference if the input string cannot be converted to utf-8, fixes #5525 ([2019-02-04](https://github.com/tvheadend/tvheadend/commit/6e4cc564cc8ce0b2cfaa55e94e1ee81fa4c6ff9d))
-* WebUI: Update copyright year ([2019-02-04](https://github.com/tvheadend/tvheadend/commit/3aba4ad47b5272938f7e7b1aabb73a97c6728865))
-* CSS: Fixes ([2019-02-04](https://github.com/tvheadend/tvheadend/commit/3fcb0844eb5d2e5a28fe323f7ffcfd5e51382ce9))
-* Update posix.mk ([2019-02-04](https://github.com/tvheadend/tvheadend/commit/e175897d21f5e7c95b3e5b1df0f52a6f97502a59))
-* Kathrein EXIP: Add default config (SATIP) ([2019-02-04](https://github.com/tvheadend/tvheadend/commit/d7e975f75caabb6abcaa9dbf075c118682c5cbd7))
-* [dvr: Only check minseason/maxseason/minyear/maxyear if EPG has these values, fixes #5479](#user-content-fn-287)[^287] ([2019-02-04](https://github.com/tvheadend/tvheadend/commit/145082b658816ff916982c36abed42b6d298ae16))
-* dvr: Add {min,max}season and {min,max}year to autorec UI, fixes #5479 ([2019-02-04](https://github.com/tvheadend/tvheadend/commit/4374948b4328fea952ee0e3b56f816b735d79476))
-* [dvr: New fmt spec for per-dir seasons and one movie per dir. (#4667)](#user-content-fn-288)[^288] ([2019-02-04](https://github.com/tvheadend/tvheadend/commit/b106250c98af2244ca9d011cd0c5081f42eb9630))
-* Changes to make tvheadend work in a container while talking to HDHomerun ([2019-02-04](https://github.com/tvheadend/tvheadend/commit/1fa1c1cb997d12ea128919c4b125a8097fee847c))
-* Assign a different port number for each frontend thread ([2019-02-04](https://github.com/tvheadend/tvheadend/commit/03f40731a6b8ea95d113268eda63929f63decac9))
-* Avoid caching HDHomeRun's IP address ([2019-02-04](https://github.com/tvheadend/tvheadend/commit/a68b343df404f209886035aee479b80a6336cf9c))
-* Move HDHomeRun config fields into their own group in the UI ([2019-02-04](https://github.com/tvheadend/tvheadend/commit/b625b36741c2703e4b90fcf95f849226c5970e37))
-* Log an error message if the configured IP address is invalid ([2019-02-04](https://github.com/tvheadend/tvheadend/commit/b253613ef6feab9da3fe46bb726f0c2dbec3e8b5))
-* Corrected local\_ip description text ([2019-02-04](https://github.com/tvheadend/tvheadend/commit/b1805bc705207e95ecf4ebc13633ae247e06e85e))
-* satip server: parse destination for RTP/AVP transfer ([2019-01-24](https://github.com/tvheadend/tvheadend/commit/baadf28f70d443b803fe0ef157e6543633fc86b0))
-* satip client: fix the network limit/group description ([2019-01-23](https://github.com/tvheadend/tvheadend/commit/7d3aa11940ac7aec1238a16264c73b366970b27b))
-* satip server: add icon files, fixes #5268 ([2019-01-21](https://github.com/tvheadend/tvheadend/commit/10ed59ce33f6c08b01216bf58f1ed6e48b608651))
-* eit: fix UK Cable Virgin configuration, fixes #5499 ([2019-01-18](https://github.com/tvheadend/tvheadend/commit/8818b5220c218e548556aaac8b727491ef0ab152))
-* eit: config - fix the json syntax error, fixes #5503 ([2019-01-18](https://github.com/tvheadend/tvheadend/commit/ceb82fc6961a725d7a77f5e8de1ffd4aefbde7e8))
-* mpegts dvb network: fix create mux - wrong class used for comparison (since commit dbee3d2049faa7d5e15374ddef37a91e86768b26), fixes #5486 ([2019-01-17](https://github.com/tvheadend/tvheadend/commit/717a4d5c5091cb83a3c865636f6a1c38c0fb6459))
-* server.h: cleanups for TSS\_ flags ([2019-01-15](https://github.com/tvheadend/tvheadend/commit/ec9cb00079b6a84794a32deb29fffc2a66351b65))
-* mpegts input: change mpegts\_input\_tuning\_error() to more universal mpegts\_input\_error() ([2019-01-15](https://github.com/tvheadend/tvheadend/commit/6621db64e23c5a77d7973ae39be17a76135e18dd))
-* mpegts network: stop all running muxes when the network was disabled by the user, fixes #5497 ([2019-01-15](https://github.com/tvheadend/tvheadend/commit/098318644802bfee4baa7eeeeafac4f81ecd9578))
-* http: CORS - add Access-Control-Allow-Credentials header for cookies ([2019-01-14](https://github.com/tvheadend/tvheadend/commit/4bf32134bb31a564ad8ad34402442cd6efd1433e))
-* http: CORS - small optimisation ([2019-01-14](https://github.com/tvheadend/tvheadend/commit/f44e2e58ef360e7fb9f8ab7aacf042e0de725af3))
-* mpegts: add possibility to enable/disable network ([2019-01-14](https://github.com/tvheadend/tvheadend/commit/1413e342daecff36ee22d3b75831599bbb66c7be))
-* otamux: fix the 15 seconds delay for the initial scan ([2019-01-14](https://github.com/tvheadend/tvheadend/commit/757e2a90936a92773209c1867f14583e34b14558))
-* service: enlist - use also is\_enabled callback to check the network/mux enable state ([2019-01-14](https://github.com/tvheadend/tvheadend/commit/97b71ef9e40064c94f17593547f7c80b1833b45a))
-* iptv auto network: check the network enabled flag for the auto download ([2019-01-14](https://github.com/tvheadend/tvheadend/commit/9a6007c20609805a985e98591eb99c0f7729d282))
-* parse\_ac3: avoid the endless loop for the AC3/EAC3 auto-detection, issue #5353 ([2019-01-13](https://github.com/tvheadend/tvheadend/commit/bd662457daea904eb2d4f5ccc76e0e5ae2e24cd1))
-* Makefile.ffmpeg: upgrade ffmpeg to 4.1, x264 to 20190108, x265 to 2.9 ([2019-01-09](https://github.com/tvheadend/tvheadend/commit/6d57bb6192c679bc9f82847e387c31972f28d838))
-* doozer: remove OOL Fedora 27 ([2019-01-09](https://github.com/tvheadend/tvheadend/commit/851a6a196d6ee805e36b9adba22158639b282e19))
-* otamux: fix NULL dereference, fixes #5488 ([2019-01-09](https://github.com/tvheadend/tvheadend/commit/8e0dd2bee6373156907bde8da7b659948a915e12))
-* epggrab: reimplement the OTA grabber selection per mux ([2019-01-08](https://github.com/tvheadend/tvheadend/commit/cb01c36843aca863049350da192fac0740155ae5))
-* epg: add auto-ota-module detection ([2019-01-08](https://github.com/tvheadend/tvheadend/commit/ceb6f1da66b881988f3a74595c8ff5462b635de5))
-* DVR: add utf8 validator for title/subtitle when cut ([2019-01-08](https://github.com/tvheadend/tvheadend/commit/4e8925fe785064be3947e11888638f20e9e7ab50))
-* avahi: try to fix double free, fixes #5484 ([2019-01-08](https://github.com/tvheadend/tvheadend/commit/fdafda55c5b9be93abb6df1f61cfeed5d8e19dff))
-* eit: always prefer master rather than slave for the config, issue #5247 ([2019-01-02](https://github.com/tvheadend/tvheadend/commit/640703e83d293bf5e5fb1c8fcdcfd80ffd396937))
-* [main: Replace deprecated ERR\_remove\_state](#user-content-fn-289)[^289] ([2019-01-02](https://github.com/tvheadend/tvheadend/commit/62808322c0e2d96f59a4a9b5b43fbb89f8d9ae98))
-* CSS: Fix height % ([2019-01-02](https://github.com/tvheadend/tvheadend/commit/8d02a266030c17c319bb1a8372184dba3ee1cc27))
-* Add missing !DOCTYPE html ([2019-01-02](https://github.com/tvheadend/tvheadend/commit/5c8f76d998fe2a265905ca31fe259c5c5d3e1e88))
-* [Fix several errors detected by w3c css validator](#user-content-fn-290)[^290] ([2019-01-02](https://github.com/tvheadend/tvheadend/commit/6ee3575c819cec2daa71af3d02c973b343ce87ab))
-* [api: Alternative showings match on title if no series link, fixes #5402](#user-content-fn-291)[^291] ([2019-01-02](https://github.com/tvheadend/tvheadend/commit/12e4858014fb022cf71d882e4302d9942fbb0747))
-* [ui: Make dialogs slightly bigger.](#user-content-fn-292)[^292] ([2019-01-02](https://github.com/tvheadend/tvheadend/commit/adc90275c4e19f7beeffda9612b0ac63e1791dcf))
-* xmltv export: add LCN to the display-name attribute, fixes #5471 ([2019-01-01](https://github.com/tvheadend/tvheadend/commit/bb8a25ca8b2e2e48b6b76f833f0bf96dde37c896))
-* cosmetic fixes and optimisations ([2019-01-01](https://github.com/tvheadend/tvheadend/commit/dbee3d2049faa7d5e15374ddef37a91e86768b26))
-* satip client: fix the ATSC-C (Annex B) parameters, fixes #5447 ([2019-01-01](https://github.com/tvheadend/tvheadend/commit/833b61c4d14511ef20ac55a918a7fdc1c231fb0e))
-* satip client: remove the dual condition for Annex B ([2019-01-01](https://github.com/tvheadend/tvheadend/commit/d2cb8bad332ca9455750566e8f84e0af33225aaf))
-* xmltv: add support for the lcn tag, fixes #5471 ([2019-01-01](https://github.com/tvheadend/tvheadend/commit/7da43a563fe75368769fde33064d17810d9f2909))
-* eit: try to fix the freesat issue, fixes #5247 ([2019-01-01](https://github.com/tvheadend/tvheadend/commit/e61adb3441b6ea8e9a25b1f4fd39d22d925fb588))
-* eit: another attempt to fix the freesat issue (slave eit), fixes #5247 ([2019-01-01](https://github.com/tvheadend/tvheadend/commit/cfb4b6efd924e8391c7102f37bd57aa9fea745f9))
-* eit config: fix the uk\_freesat\_eit description, issue #5247 ([2019-01-01](https://github.com/tvheadend/tvheadend/commit/c60b62b427d31e4348176bc6bea935b9beef0b35))
-* pass muxer: fix the incorrect section length for EIT table, fixes #5418, issue #5062 ([2018-12-30](https://github.com/tvheadend/tvheadend/commit/fb11090346c06ffd20323bc97d0e32d9855fe50f))
-* htsp server: use HTTP image URLs for image cache for older clients (pvr.hts), fixes #5455 ([2018-12-28](https://github.com/tvheadend/tvheadend/commit/d3d0249bce84425e94e4bee399b7f2236f77b6bf))
-* teletext: fix the subtitle parser (wrong SCT\_ type match), issue #5422 ([2018-12-28](https://github.com/tvheadend/tvheadend/commit/b17dcf91490c38df678472bef3a117b4c6e2996c))
-* imagecache: fix the missing ref initialisation, fixes #5458 ([2018-12-26](https://github.com/tvheadend/tvheadend/commit/112e06dfdc0a713e97a040eb7c443a31fb2ac46e))
-* hdhomerun: auto detect DVB\_T devices ([2018-12-26](https://github.com/tvheadend/tvheadend/commit/88f2634af1bacd5f4768a994562d909f756ab7fb))
-* imagecache: the timer function is already called inside imagecache\_lock (sorry), fixes #5458 ([2018-12-26](https://github.com/tvheadend/tvheadend/commit/fee0b53e969da78a70229d53f9e1331511b5f237))
-* [Revert "dvr: move dvr\_notify() call to the global\_lock using timers, fixes #5437"](#user-content-fn-293)[^293] ([2018-12-25](https://github.com/tvheadend/tvheadend/commit/312dce6e22e2d3ab21475a08e1f44dae4859173c))
-* imagecache: do not use global lock, fixes #5453 ([2018-12-25](https://github.com/tvheadend/tvheadend/commit/33901bb1edd3f9859d1190a352ea7c383ebb58ab))
-* Fix mpegts packet length in descrambler\_data\_key\_check ([2018-12-25](https://github.com/tvheadend/tvheadend/commit/b3899e3fddad1431269183fd42eba54ec16fdc22))
-* caclient: handle correctly connection close / read error, fixes #5445 ([2018-12-22](https://github.com/tvheadend/tvheadend/commit/cc8f139f80507c2fd737fd6e2620401c0f35ea75))
-* mpegts: fix mpegts\_service\_find\_e2() for atsc-t ([2018-12-22](https://github.com/tvheadend/tvheadend/commit/42e368ede940f275791a9d9c4a8f3707d42714e0))
-* cclient: check keep-alive also when no poll event occurs, fixes #5445 ([2018-12-22](https://github.com/tvheadend/tvheadend/commit/7fdc6f0549147ba0c25d652c5efe1bdaed6e7543))
-* satip server: fix ATSC-T / Annex B cable frequency parsing, fixes #5447 ([2018-12-20](https://github.com/tvheadend/tvheadend/commit/833821fc6e556a455e3f6cfcb935e50dd82632bf))
-* api: add id=all for the connections/cancel, issue #4937 ([2018-12-19](https://github.com/tvheadend/tvheadend/commit/9a7b56a269319397de30976bccb8f48f8b5b6911))
-* webui: add "drop all connections", fixes #4937 (original request only) ([2018-12-19](https://github.com/tvheadend/tvheadend/commit/bc4873d75b906254b7c6255b9cced4e6ac13f533))
-* webui: status - drop all connections - use new id=all call, fixes #4937 ([2018-12-19](https://github.com/tvheadend/tvheadend/commit/faa5176b250572fb6e35f4ce95919b4800b94d3b))
-* [webui, htsbuf: Content-Disposition escape chars are not correct.](#user-content-fn-294)[^294] ([2018-12-19](https://github.com/tvheadend/tvheadend/commit/a11733fed0f74da5cb309aa624a7039918b21126))
-* added linudvb\_rotor\_external to control an actuator by spawning an external command ([2018-12-19](https://github.com/tvheadend/tvheadend/commit/0a1d52cb71cd1037cbe8c9f2926b2e3634349f48))
-* linuxdvb: satconf - cleanups for the rotor external command ([2018-12-19](https://github.com/tvheadend/tvheadend/commit/dd37467c8ccac8e0bef1210ae148d630b206605d))
-* xmltv import: fix the wrong end-of-string mark (off-by-one), fixes #5443 ([2018-12-17](https://github.com/tvheadend/tvheadend/commit/99461b8cb35989af7e5e08106446d0b24a2bd7fc))
-* dvr: move dvr\_notify() call to the global\_lock using timers, fixes #5437 ([2018-12-16](https://github.com/tvheadend/tvheadend/commit/91f6de4437f13d51a854ffe999cca63ff2ef503c))
-* tvh thread: do not crash when mutex==NULL (magic check failed), fixes #5435 ([2018-12-15](https://github.com/tvheadend/tvheadend/commit/efd99b34d4f1dedaa54f1bd357c6f82e6f75d3da))
-* satip server: use strempty() function for the uuid check, fixes #5434 ([2018-12-15](https://github.com/tvheadend/tvheadend/commit/a1f303d01d061325f1cf145e87ee3341e771dbae))
-* dvb psi pmt: change the teletext subtitle handling for multiple teletext descriptors, issue #5422 ([2018-12-15](https://github.com/tvheadend/tvheadend/commit/d07a12e013c8bff2e59accb9d948fddd8488389d))
-* iptv: remove double pcr: from traces ([2018-12-14](https://github.com/tvheadend/tvheadend/commit/b157d126be4b9224f8496006dabde066aa61f295))
-* htsp server: fix the wrong htsmsg destroy introduced in the imagecache patch, fixes #5430, fixes #5431, fixes #5429 ([2018-12-14](https://github.com/tvheadend/tvheadend/commit/abfc7c92d5151046bd47e0b36dc67797158bd6b8))
-* tvh thread: remove wrong commit code ([2018-12-14](https://github.com/tvheadend/tvheadend/commit/e61b126ef5b75dca7b0a0f0a0575d650a5c400e6))
-* dvr: fix the real\_start variable misuse, fixes #5426 ([2018-12-14](https://github.com/tvheadend/tvheadend/commit/e37c696ded59fe7c2fbaf3a42944bfeb2dd7ff92))
-* [epggrab: run internal grabbers only when wanted, fixes #5421](#user-content-fn-295)[^295] ([2018-12-14](https://github.com/tvheadend/tvheadend/commit/d1ddcdc82731b3750d9b2f7b458e1deb6d17256f))
-* satip client: fix the double (and wrong) sf\_last\_data\_tstamp update, fixes #5374 ([2018-12-14](https://github.com/tvheadend/tvheadend/commit/0db0890a4b4d1a2521009b8b5cbf058b964d9608))
-* iptv http: call iptv\_input\_mux\_started(), move recv\_flush to http-header back ([2018-12-13](https://github.com/tvheadend/tvheadend/commit/cfdfeb6cc15f8f09de02ffeab8158caf5e676df0))
-* mpegts input: add CC restart for tables, too ([2018-12-13](https://github.com/tvheadend/tvheadend/commit/55e5b982d9989c146525cfb8c53b2cb56d6fe0ba))
-* sbuf: add sbuf\_replace() ([2018-12-13](https://github.com/tvheadend/tvheadend/commit/279f689bdf798992ee0bd43dcedb34ef831d6c71))
-* iptv http: remove the wrong si rewrite code, cleanup the free sequence ([2018-12-12](https://github.com/tvheadend/tvheadend/commit/2059cafb8337756a211ad958cf30a94ddfe36c49))
-* dvb psi lib: add dvb\_table\_parse\_reinit functions ([2018-12-12](https://github.com/tvheadend/tvheadend/commit/a5d03e4ba5ce96115fef1d5599735a670150a3d8))
-* remove debug code (added by mistake) ([2018-12-12](https://github.com/tvheadend/tvheadend/commit/3769d01fb9a9253817ecd16d949977813583b328))
-* [imagecache: big cleanups](#user-content-fn-296)[^296] ([2018-12-12](https://github.com/tvheadend/tvheadend/commit/da682c4507a1b11ceaf714675f833d56c2084157))
-* imagecache: do not update the accessed field too much ([2018-12-12](https://github.com/tvheadend/tvheadend/commit/1bf4b4c84c58e52b813b3e681444d46cdbe8904c))
-* profile: add more doc to the pass rewrite fields ([2018-12-12](https://github.com/tvheadend/tvheadend/commit/d3fc1487bba0b7093222e06fdde2decab85347f2))
-* imagecache: increase the save access threshold again ([2018-12-12](https://github.com/tvheadend/tvheadend/commit/552cea0fc189f389ce02100bc49026ac1aae1715))
-* iptv: add missing lock to the iptv\_http\_kick\_cb, fixes #5415, issue #5353 ([2018-12-11](https://github.com/tvheadend/tvheadend/commit/7ce391fc7f9a8643cce7e83cd495ca872e752e93))
-* iptv: correction for the previous patch, fixes #5415, issue #5353 ([2018-12-11](https://github.com/tvheadend/tvheadend/commit/fb4410ad712a32e27e6665012998395f87959522))
-* iptv: http - do not clear the input sbuf in the kick callback ([2018-12-11](https://github.com/tvheadend/tvheadend/commit/9776f3044bbe021141dae1a3e956335aa395b966))
-* iptv: http - fix the compilation problem with the previous patch ([2018-12-11](https://github.com/tvheadend/tvheadend/commit/2c35dca60d373f685fad040b993450ed5505a546))
-* mpegts: do not set wrong pls code for bouquet rescan ([2018-12-11](https://github.com/tvheadend/tvheadend/commit/f259e7bd8bec9771a13089bf3e017440c3f788ff))
-* main: fix compilation without traces ([2018-12-11](https://github.com/tvheadend/tvheadend/commit/62aa19730078c62ab0a3b3bffd21deb4bc3a5c13))
-* http: add auth type detection ([2018-12-11](https://github.com/tvheadend/tvheadend/commit/beec9c1133647f94e42d43b6ee3d3672794eee19))
-* http server: remove wrong aa\_auth check from page\_srvid2, fixes #5416 ([2018-12-11](https://github.com/tvheadend/tvheadend/commit/f3d57ee05ce55584545334cb44f7a5f0a3d2bfd9))
-* http: fix the wrong return value (previous patch) ([2018-12-11](https://github.com/tvheadend/tvheadend/commit/d7669cf060d02ecba702bc12b0632068113d67cf))
-* tvh thread: fix print other mutexes for abort ([2018-12-11](https://github.com/tvheadend/tvheadend/commit/19d3e32644366528497ab328bb2a2c0ed4c6560b))
-* Makefile.ffmpeg: add crypto protocol for crypto+http (hls) ([2018-12-11](https://github.com/tvheadend/tvheadend/commit/1d40f21ca2222b3d0fcc2ffc89f5c25884ac2ad8))
-* tprofile: fix possible division by zero ([2018-12-10](https://github.com/tvheadend/tvheadend/commit/cfc8315a1018a32678ce6aab6023d3bda737a3fe))
-* timers - change locking schema, fixes #5413, issue #5353 ([2018-12-10](https://github.com/tvheadend/tvheadend/commit/bceba08524069c012c26302b06790f1e1099541b))
-* timers: little fixes ([2018-12-10](https://github.com/tvheadend/tvheadend/commit/b32c76e24063f988eec7deb415df9c739004f84a))
-* tvh\_thread: print filename/lineno for the magic failure when appropriate ([2018-12-10](https://github.com/tvheadend/tvheadend/commit/5dbd8280746fcd802903c28eab22383c2d046499))
-* profile: do init for all profile sharer members, issue #5409 ([2018-12-10](https://github.com/tvheadend/tvheadend/commit/2e4aa820afe5030c15d4c4a039ff5753dbc17026))
-* [ui: Enable scrollbar for dialog info, fixes #5405](#user-content-fn-297)[^297] ([2018-12-10](https://github.com/tvheadend/tvheadend/commit/55f7bf00f826e816a1bf12e21bf33152cc7c809f))
-* ui: Fix background image to not accept clicks (#5405). ([2018-12-10](https://github.com/tvheadend/tvheadend/commit/401821cf141bd0f2c2c1d1c5db19b892c66f4178))
-* htsp\_server: init htsp\_out\_mutex ([2018-12-09](https://github.com/tvheadend/tvheadend/commit/1c8a40f663eb0407498b3f0c05a5ed7246624728))
-* Don't warn on packets with small/no payload. ([2018-12-09](https://github.com/tvheadend/tvheadend/commit/f7d4b7c48f7a69b1628b75f7c27f6c6c274cf202))
-* fix some problems detected by cppcheck, issue #5353 ([2018-12-09](https://github.com/tvheadend/tvheadend/commit/11f6531a09bac850edefbd8df950173abbe3ad45))
-* iptv http input: play with the locking, issue #5353 ([2018-12-09](https://github.com/tvheadend/tvheadend/commit/f0524db407764aeaad4229aa7301babf05a6de79))
-* tvh thread: add mutex magic check routines ([2018-12-08](https://github.com/tvheadend/tvheadend/commit/f69b3a9fdcdad2031d38337782c05e1c5b74208b))
-* main: add gtimer/mtimer magic checks ([2018-12-08](https://github.com/tvheadend/tvheadend/commit/1b41c315d8919a264f3de57989805e6ffc227070))
-* [dvr: move the initial dvr\_autorec\_purge\_obsolete\_timers() call to better place, fixes #5406](#user-content-fn-298)[^298] ([2018-12-07](https://github.com/tvheadend/tvheadend/commit/30332f8b3e733fc7fccaa6574a977da487499c0a))
-* freebsd: Fixup header files for socket definitions. Make thread owner conditional on Linux. ([2018-12-06](https://github.com/tvheadend/tvheadend/commit/652dbc3c8a58eab427f27ca79065d1e880098f63))
-* Maximize use of libdvbcsa's batch processing. ([2018-12-06](https://github.com/tvheadend/tvheadend/commit/531dc8893abfe8995f4c3ed39e47e62c1e99cdab))
-* wizard: spruce it up a bit ([2018-12-06](https://github.com/tvheadend/tvheadend/commit/27c00888475f27ef21a1b58805804fa6ebdf3e99))
-* [dvr: Autorec rules must still match event after update. (#4760).](#user-content-fn-299)[^299] ([2018-12-06](https://github.com/tvheadend/tvheadend/commit/113dfd6b56ee2b485a142f70879a194ae4d99423))
-* Reduce DESCRAMBLER\_MAX\_KEYS from 64 to 8, fixes #5400 ([2018-12-06](https://github.com/tvheadend/tvheadend/commit/ccf6c6ec7e5d34b1279a591794e421b63f3dc5ac))
-* tvh\_thread: show also waiters ([2018-12-06](https://github.com/tvheadend/tvheadend/commit/bc14d7f7cd2bae3a9759822570a652c504fce249))
-* tvhcsa: fix log offset type ([2018-12-06](https://github.com/tvheadend/tvheadend/commit/259156312d1852e83b9f9f328979ef92ad2fba94))
-* htsmsg: check the field/key name length (max 255 characters), issue #5359 ([2018-12-05](https://github.com/tvheadend/tvheadend/commit/42fd13d4c822edfc269e6b527333ab5666211f9d))
-* xmltv: split names in credits, fixes #5359 ([2018-12-05](https://github.com/tvheadend/tvheadend/commit/5bea43b1a4e0f623a9fa22529aec2478d688cab9))
-* Fix compilation error: 'saveptr' may be used uninitialised in this function \[-Werror=maybe-uninitialised] ([2018-12-05](https://github.com/tvheadend/tvheadend/commit/0ffb10398ba6fd80ab1f3431aff13556ced8ea50))
-* Prepend title to autorec comment when created from EPG. ([2018-12-05](https://github.com/tvheadend/tvheadend/commit/a46a8c967382ed27735cb2bc1968a56a1d513509))
-* tvh\_thread: do not use debug code when not activated, issue #5353, issue #5389 ([2018-12-03](https://github.com/tvheadend/tvheadend/commit/80ea669a5cea155ebbd1161635800c11de0175f6))
-* pass muxer: correct SI length for trimmed events ([2018-12-03](https://github.com/tvheadend/tvheadend/commit/3d79abab788753bb4f83aacd16ccec5036deab82))
-* satip client: activity timeout cleanups ([2018-12-03](https://github.com/tvheadend/tvheadend/commit/8635ae50145a91eb8c245b49b0e6662cf1429792))
-* [http: forbidden status / access\_verify2() cleanups, fixes #5391](#user-content-fn-300)[^300] ([2018-12-03](https://github.com/tvheadend/tvheadend/commit/da5dc10440572e4e6e93d000bff9c6ddc7cf0790))
-* pass muxer: fix pass\_muxer\_nit\_cb() - wrong private tag copy ([2018-12-02](https://github.com/tvheadend/tvheadend/commit/e67c795b7b6e5fe1e5ace5fc7b84fdab960fa206))
-* tvhthread: fix the cond wait routines (preserve correctly filename/lineno) ([2018-12-02](https://github.com/tvheadend/tvheadend/commit/b3ecd74f4b8412d4eb56363c63d71f328e9ff543))
-* tvh\_thread: do not print sid for non glibc binaries, fixes #5385 ([2018-12-02](https://github.com/tvheadend/tvheadend/commit/f098a50cc2872abbe42f567a3f77babce83602a0))
-* tvh\_thread: another filename/lineno cleanups ([2018-12-02](https://github.com/tvheadend/tvheadend/commit/2c796e3298257b9b487446f82cb1b0f390757101))
-* tvhlog: add missing lock ([2018-12-02](https://github.com/tvheadend/tvheadend/commit/7cac91a63dd866d81819688077e69ba0b864b7e2))
-* atomic cleanups in tvh\_thread, tvhlog (clang) ([2018-12-02](https://github.com/tvheadend/tvheadend/commit/39b74cbd8624668d03881dbd6e1184c626748788))
-* opentv: add NULL check to the opentv\_find\_entry(), fixes #5381 ([2018-12-01](https://github.com/tvheadend/tvheadend/commit/1daeb9269a029fcde5efd62bd792f1f598ed7a5c))
-* imagecache: try to fix the state handling, fixes #5382 ([2018-12-01](https://github.com/tvheadend/tvheadend/commit/92b96d5efdcf57401bb1d5e204fa0d102afff2c5))
-* imagecache: tiny code reshuffle ([2018-12-01](https://github.com/tvheadend/tvheadend/commit/7ce5d30bb80df59cd35ce4f029d6c26768bbfdbd))
-* linuxdvb: add DMX\_SET\_SOURCE settings at the probe, fixes #5379 ([2018-12-01](https://github.com/tvheadend/tvheadend/commit/5dcbd69827072ed97e8f2f95e62db0738e939f78))
-* dvb support: remove wrong characters bellow 0x20 (except 0x0a - newline), issue #5366 ([2018-12-01](https://github.com/tvheadend/tvheadend/commit/3ae6d947a4d074b3498e59f82d5a860273b0ae7f))
-* http/webui: add special/srvid2 handling ([2018-12-01](https://github.com/tvheadend/tvheadend/commit/07592279436de9473e7ba67f53b84650aa320e47))
-* xmltv: always change the module name after restart, fixes #5383 ([2018-12-01](https://github.com/tvheadend/tvheadend/commit/79ea2a42c477e315ffa2143252273fe2db0c2165))
-* Add ATSC-T With 8VSB Modulation (for Korean User) ([2018-11-30](https://github.com/tvheadend/tvheadend/commit/062d970ecd764bb031cf2f07f2876cfa39675056))
-* satip client: show the proper connection state in 'RTSP cmd error' log message ([2018-11-30](https://github.com/tvheadend/tvheadend/commit/7ae5399c0b04df03bdc4f9468ff66bcc83642cfe))
-* satip client: cosmetic (indent) ([2018-11-30](https://github.com/tvheadend/tvheadend/commit/4c4925b371b78999f3fdf9667dda63d59cf84155))
-* imagecache: fix 'accessed' field loading and the default value, issue #4304 ([2018-11-30](https://github.com/tvheadend/tvheadend/commit/219ba145f82926e972f476debad8be6664782307))
-* imagecache: move saving procedure outside global\_lock, fix imagecache\_id after start, issue #4304 ([2018-11-30](https://github.com/tvheadend/tvheadend/commit/f024531ee4aaab3c1492b141029ffe2b56fec74a))
-* imagecache: fix the build when caching code is deactivated, fixes #5372 ([2018-11-30](https://github.com/tvheadend/tvheadend/commit/fb6c9fa88bd888a9650111f602aaa3de1db7b326))
-* imagecache: another code reshuffle, add save for the accessed update, issue #4304 ([2018-11-30](https://github.com/tvheadend/tvheadend/commit/f048c549c0466ebc44b725457bb2a5a150cc5a6c))
-* opentv: fix the wrong event cleanup in opentv\_add\_entry(), issue #5297 ([2018-11-29](https://github.com/tvheadend/tvheadend/commit/fd22090018507ccf60dfd887baa0f21e893b81d6))
-* watchdog: rename tv\_mutex\_init to tvh\_mutex\_init ([2018-11-29](https://github.com/tvheadend/tvheadend/commit/220e56043d0ef13e015c345869c2d7a7ea1f1083))
-* debian: remove db\_reset lines - fixes #5358 ([2018-11-28](https://github.com/tvheadend/tvheadend/commit/a9d4ec1df0d065d9f5385e4bab8c0694719a50e0))
-* tvhlog: add tvhdbg() and send realtime mutex log lines to the UDP socket (if requested) ([2018-11-28](https://github.com/tvheadend/tvheadend/commit/7f5f4a49f94e8b0cbb5228d464d3b24a5164f70c))
-* tvh thread: print the deadlock text also to stderr ([2018-11-28](https://github.com/tvheadend/tvheadend/commit/19264dc2f913db15f31a50cad8e62e93c9d9ca35))
-* tvhlog: fix NULL dereference crash ([2018-11-28](https://github.com/tvheadend/tvheadend/commit/bf3f0bd16983045a624ebe335eae507aadb4a690))
-* watchdog: fix missing pthread\_mutex\_destroy -> tvh\_mutex\_destroy, issue #5361 ([2018-11-28](https://github.com/tvheadend/tvheadend/commit/c075732a1005d2ace11cb3c8addce262d6858759))
-* tvhlog: fix tvhdbg() prototype when traces are not activated, fixes #5362 ([2018-11-28](https://github.com/tvheadend/tvheadend/commit/70af054ac3bdecf68df1594dd48c7a9e0a9de18d))
-* satip client: fix activity timestamp for TCP data transfer mode, fixes #5348 ([2018-11-27](https://github.com/tvheadend/tvheadend/commit/e72b431564c860d5fc711779856dd7f61ed4f568))
-* imagecache: fix the expire id, issue #4304 ([2018-11-27](https://github.com/tvheadend/tvheadend/commit/750c1e13a504b3c4790fbf6295e86b070d268901))
-* move htsstr.h to tvh\_string.h ([2018-11-27](https://github.com/tvheadend/tvheadend/commit/ef3386ee05201e6fae9c556bfcdf335fc5121ce1))
-* initial pthread mutex/cond wrappers to detect deadlocks ([2018-11-27](https://github.com/tvheadend/tvheadend/commit/7ec273f4ff34f8700ffb3ef03d73bf20e29aca86))
-* thread: add mutex watchdog ([2018-11-27](https://github.com/tvheadend/tvheadend/commit/76dd042e0d3bb93e1102eae65c2d23aa31233274))
-* tvh\_thread: remove restrict keyword ([2018-11-27](https://github.com/tvheadend/tvheadend/commit/6eb97e1c908cffcdc6f95c0a7f44b8b9ad68d37c))
-* access: fix tag exclude ([2018-11-27](https://github.com/tvheadend/tvheadend/commit/4f9fdd0f1517ea07508c54e80d623422959a012b))
-* access: a little code reorganisation for the latest tags exclude change ([2018-11-27](https://github.com/tvheadend/tvheadend/commit/cc4ded03305514b89553abafa6168a3150480970))
-* docs: update and add persistent auth info, refresh some screenshots and tweak a few bits ([2018-11-27](https://github.com/tvheadend/tvheadend/commit/7a9b164937ffa8599b9216fa9888cdbcc1cb66d6))
-* cosmetic: TVHeadend|tvheadend -> Tvheadend, where needed for consistency ([2018-11-27](https://github.com/tvheadend/tvheadend/commit/9ae0d14ededf94f0a4af9037a38b9a4f0aa5eeab))
-* debian packaging: always reset superuser info on removal ([2018-11-27](https://github.com/tvheadend/tvheadend/commit/0fc08d9ad711fa2555fed2914fbf7b181bb5c346))
-* debian packaging: use db\_purge on --purge ([2018-11-27](https://github.com/tvheadend/tvheadend/commit/53d5875f7e54a062ecdcc30b5152bd5cea4e761a))
-* docs: update debugging ([2018-11-27](https://github.com/tvheadend/tvheadend/commit/818c6438571d4dfb859fbd06cbf943d4fd94254c))
-* docs: another screenshot update ([2018-11-27](https://github.com/tvheadend/tvheadend/commit/ab547bd4822bb3ea58932df1332520cd19f84c2a))
-* docs: use a table for the program details dialog toolbar items ([2018-11-27](https://github.com/tvheadend/tvheadend/commit/b425b47f581cf1c31d6330211422089ef95c1810))
-* descrambler: remove unused code ([2018-11-27](https://github.com/tvheadend/tvheadend/commit/fc3e3de319f943d8fb54f321546d77e151606291))
-* webui status: add user-agent (client) column ([2018-11-27](https://github.com/tvheadend/tvheadend/commit/b7b9ef8b8608b2c915d90d860a421221488f620e))
-* webui: streaming - fix the removed scoped lock, fixes #5356 ([2018-11-27](https://github.com/tvheadend/tvheadend/commit/b0c65b0cc58ba095dcca6d985777a6b8e5250358))
-* webui: remove Title0 typo ([2018-11-27](https://github.com/tvheadend/tvheadend/commit/101f6b19ca918b0cfabd9bc36ec5702147e193b9))
-* tvh thread: add mutex debug timing, fix the watchdog code ([2018-11-27](https://github.com/tvheadend/tvheadend/commit/8336f5f7bd074655bfae1c54ffcc0fc29a736804))
-* update valgrind.supp ([2018-11-27](https://github.com/tvheadend/tvheadend/commit/edcf9e37e07d0a52eb593fe39016e581d2932a1e))
-* tvh thread: fix gtimer\_cond timedwait and tvh\_cond\_init() ([2018-11-27](https://github.com/tvheadend/tvheadend/commit/b73311c2a816390a41f5f18ff59a40ba74f042c7))
-* tvh thread: compile the debug thread code only when traces are enabled ([2018-11-27](https://github.com/tvheadend/tvheadend/commit/752fd7cb2b318a86aa0041d736718ed9d6faf67b))
-* tvh-json.py: add proper digest/plain authentication, fixes #5350 ([2018-11-26](https://github.com/tvheadend/tvheadend/commit/d1269210587e3423add62aa0d7aead654eb36ded))
-* imagecache: add 'expire' time for the cached files, fixes #4304 ([2018-11-26](https://github.com/tvheadend/tvheadend/commit/c73e4248a9072be57d5ede3a510773ba06bebc09))
-* opentv: improve the split event merge logic, issue #5297 ([2018-11-26](https://github.com/tvheadend/tvheadend/commit/f62816bdaab067602557262a790b2c8dadce5776))
-* [api: Fix NULL blank argument.](#user-content-fn-301)[^301] ([2018-11-25](https://github.com/tvheadend/tvheadend/commit/0df43b15cc72091301a4293823cb04b19033beae))
-* [ui: Add alternative/similar broadcast buttons, fixes #5335, #5336](#user-content-fn-302)[^302] ([2018-11-25](https://github.com/tvheadend/tvheadend/commit/04cd487bb851abb920483b3135b51e6bd002f070))
-* opentv epg: try to fix the incomplete grabbing (use the whole time window for all subscribed PIDs), issue #5297 ([2018-11-25](https://github.com/tvheadend/tvheadend/commit/5594916309fe2d6afc1ee510225d5e7f76024455))
-* capmt: cosmetic - remove double 'in' from log ([2018-11-25](https://github.com/tvheadend/tvheadend/commit/cb637ca1cd758cb9c5bb98c02236201bfc5e9cf4))
-* satip client: add hard timeout for the incoming data ([2018-11-25](https://github.com/tvheadend/tvheadend/commit/0d101eb9116beea49d99c2d9d4834f77d336a202))
-* pass muxer: add possibility to continue streaming even if the service is changing, issue #5344 ([2018-11-24](https://github.com/tvheadend/tvheadend/commit/e6d3dbaa7d214b6e0c4cccb3b551dbfbd0e34080))
-* pass muxer: do not check for multiple active services (it might not be true), issue #5344 ([2018-11-24](https://github.com/tvheadend/tvheadend/commit/b65a99a4b017c5b24462121c4d3c8a450a952c11))
-* pass muxer: check correct variable for MC\_CAP\_ANOTHER\_SERVICE, issue #5344 ([2018-11-24](https://github.com/tvheadend/tvheadend/commit/764c8d4686bb167d247209abd91b365a99bfe5ab))
-* service: do not stop the raw service streaming when service is not enabled ([2018-11-24](https://github.com/tvheadend/tvheadend/commit/08df6feea5f2a07eeace142484c944377b5f6858))
-* spawn: show permissions problem with kill, issue #4774 ([2018-11-23](https://github.com/tvheadend/tvheadend/commit/e9aefbf2c6034c81153a773eaa7d016fa81a8a2f))
-* webui: Add group renderer capabilities, now when grouping the title don't care about copyright year ([2018-11-23](https://github.com/tvheadend/tvheadend/commit/e9260627c1a46a130113c36746331bfe8599507a))
-* webui: Add 'groupRenderer' in all tabs ([2018-11-23](https://github.com/tvheadend/tvheadend/commit/4d28691d1e8afa02ad0fcb1fb4f3aafe88c90da7))
-* webui: Add 'query CSFD' in dvr broadcast info window ([2018-11-23](https://github.com/tvheadend/tvheadend/commit/e6a818972c20df4896c5409df1a59bb6a725eedc))
-* [webui: epg: fix compatibility issue for FreeBSD](#user-content-fn-303)[^303] ([2018-11-23](https://github.com/tvheadend/tvheadend/commit/d774953f6b1d775ddf31c7ae5bd6cc5e5787d108))
-* http/webui: return not found status when redirection is not possible, fixes #5342 ([2018-11-23](https://github.com/tvheadend/tvheadend/commit/4512836a5149d02768e07a1770c7ba987d12f7b8))
-* webui debugging tab: typo fix ([2018-11-23](https://github.com/tvheadend/tvheadend/commit/bdc2ae9e19520a10cdf0bec0fcc0050b32bc75ff))
-* [main: Fix OpenSSL 1.1 compilation without deprecated APIs](#user-content-fn-304)[^304] ([2018-11-21](https://github.com/tvheadend/tvheadend/commit/3de759873b5e81b9ae0a89d33e0756a6ae10c102))
-* main: Load OpenSSL engines ([2018-11-21](https://github.com/tvheadend/tvheadend/commit/ccd64e698a38adb7f712a841bc3dc4480bb97dfb))
-* http: rewrite again the access verification routines, fixes #5339 ([2018-11-20](https://github.com/tvheadend/tvheadend/commit/fb329606ba8aa21736367296e795d9b53f3b5df1))
-* linuxdvb: fix the exclusive frontend access, fixes #5330 ([2018-11-19](https://github.com/tvheadend/tvheadend/commit/f01679febc6fdccf452d43043b5bc212c4db6fcf))
-* Fix typo ([2018-11-19](https://github.com/tvheadend/tvheadend/commit/718450acd9fe8f9ca35bc2eaef8fedf11ec90878))
-* [dvr: Fix season/episode unique test when recording.](#user-content-fn-305)[^305] ([2018-11-19](https://github.com/tvheadend/tvheadend/commit/aee5f768a44174371f5a7012397bb664addedd31))
-* [dvr: Alter test for season/episode on unique path.](#user-content-fn-306)[^306] ([2018-11-19](https://github.com/tvheadend/tvheadend/commit/8200e8eae6a3d97f578f7f958ad9feafd75d9ab5))
-* [updated nginx example](#user-content-fn-307)[^307] ([2018-11-19](https://github.com/tvheadend/tvheadend/commit/57bd906806c426045cc2a9ed746e9be5e6baee07))
-* [Need to delete files on complex scheduling when replacing timer after crash.](#user-content-fn-308)[^308] ([2018-11-19](https://github.com/tvheadend/tvheadend/commit/6b99571d1dc4ef61acf93a598fc434eba465c0d0))
-* [dvr: Add option to automatically delete recording after playback.](#user-content-fn-309)[^309] ([2018-11-19](https://github.com/tvheadend/tvheadend/commit/d117b0348a4f36ecc8eca91e3c55ee01fcc49e2e))
-* [webui: access theme - colour correction for EPG count info](#user-content-fn-310)[^310] ([2018-11-19](https://github.com/tvheadend/tvheadend/commit/bfa4941a3cab411b786e1d9ebcb85424d67fccf4))
-* linuxdvb: optimise the exclusive check code (previous change) ([2018-11-19](https://github.com/tvheadend/tvheadend/commit/b06567045c70e2d35330688e38c5b702ae084a2c))
-* descrambler: improve EMM handling - add provider id checks ([2018-11-19](https://github.com/tvheadend/tvheadend/commit/6ea7c385a37e49f798ca637d44b985eadd075c3f))
-* dvbpsi: move the cat decoder from descrambler to a common place and use it everywhere ([2018-11-19](https://github.com/tvheadend/tvheadend/commit/39708112cc9d8bed21715f518d89a2f48d1cc271))
-* dvb\_mux\_conf\_init: set default pls\_mode to GOLD, fixes #5328 ([2018-11-14](https://github.com/tvheadend/tvheadend/commit/409a70630801375afd3c95ddf001171c32fcc03d))
-* cclient: fix crash on cc\_remove\_card ([2018-11-12](https://github.com/tvheadend/tvheadend/commit/203c003315d48accf3251c96dbbd11a40c9ee2a9))
-* descrambler: reset 'changed' flag on cc\_remove\_card ([2018-11-12](https://github.com/tvheadend/tvheadend/commit/743da3e1f91eacbc7291b819fffc90139536bb4a))
-* cclient: cc\_remove\_card - move state to ECM\_INIT when active card is removed, issue #5314 ([2018-11-09](https://github.com/tvheadend/tvheadend/commit/42fb10e771e23c58f1536bca28ddb3f85781ed2b))
-* webui: fixes #5320 ([2018-11-09](https://github.com/tvheadend/tvheadend/commit/4c19d2d2ed5ddc3c9d1c650b183b928da4d16ff0))
-* htsmsg: add htsmsg\_remove\_string\_from\_list() function ([2018-11-09](https://github.com/tvheadend/tvheadend/commit/d6b3bc54c6be7bf7a20be049223dc6ac41eac184))
-* satip: rtp - improve udp\_multisend\_send() error / full buffer condition checking, fixes #5319 ([2018-11-09](https://github.com/tvheadend/tvheadend/commit/c8bbae5047286450b5692dc8c5d2aa9825229aee))
-* http: fix http\_access\_verify\_channel(), fixes #5317 ([2018-11-08](https://github.com/tvheadend/tvheadend/commit/29d501042a38b1070756db2e08bda433b182078c))
-* satip server: fix memory leak for the slave service subscription, fixes #5314 ([2018-11-07](https://github.com/tvheadend/tvheadend/commit/905bf283a2fee9348403c95dc9ad3ca4a9c46929))
-* satip server: fix pmt rewrite (wrong CC), use sbuf as the internal data buffer ([2018-11-07](https://github.com/tvheadend/tvheadend/commit/2ad46c44308ab2e6ad9873f22b205cdf196950a8))
-* satip server: fix the weight handling for the scrambled slave subscriptions, fixes #5314 ([2018-11-07](https://github.com/tvheadend/tvheadend/commit/cf4dfcca07bef5a801e3a8d71588180d7a29ede0))
-* mpegts mux: handle better mm\_nicename updates ([2018-11-07](https://github.com/tvheadend/tvheadend/commit/a093b437146189a35ef8be6796a52ee12884c52d))
-* spawn: close pipe on fork() error path ([2018-11-03](https://github.com/tvheadend/tvheadend/commit/4ba55bfb563ea187fa1ad2666ea3ab6570353b3a))
-* iptv: add some more traces for pipe fds... ([2018-11-03](https://github.com/tvheadend/tvheadend/commit/1222de11478788882d3c94a2b01b37e588f5f074))
-* linuxdvb: do not call linuxdvb\_satconf\_power\_save for non DVB-S frontends, fixes #5311 ([2018-11-03](https://github.com/tvheadend/tvheadend/commit/1648c7b7b5cfe4ce457e4fc04b96feb3c9b7d8a2))
-* linuxdvb: set volt - tiny optimisation ([2018-11-01](https://github.com/tvheadend/tvheadend/commit/2b16fcbf657437c227bb48b0d5c3b0b3f7d0d5bb))
-* linuxdvb: try to improve the rotor logic (finish the movement), issue #5307 ([2018-11-01](https://github.com/tvheadend/tvheadend/commit/c4f22d84a09f9b154a236dca1617ec0169499c54))
-* satip client: do faster recovery when the server reboots ([2018-11-01](https://github.com/tvheadend/tvheadend/commit/7fc6cba4d6c9a378aa160751b3f445f500313703))
-* [Update server.c](#user-content-fn-311)[^311] ([2018-10-31](https://github.com/tvheadend/tvheadend/commit/7a922d60d50deba2589f05d7da6f387bbecf87b1))
-* doozer: sort targets, add Fedora 29 ([2018-10-31](https://github.com/tvheadend/tvheadend/commit/7600fa859730b5fd21007104ec1ec716138adb6f))
-* autobuild: remove Ubuntu Precise which is EOL (as of April 28, 2017) ([2018-10-31](https://github.com/tvheadend/tvheadend/commit/17717edaa6322a70f5e6e9367bc0352ab209371d))
-* doozer/autobuild: debian buster target ([2018-10-31](https://github.com/tvheadend/tvheadend/commit/9ceae78f80fd0151577b0cf1b98cafe229c07cf0))
-* epg: play link - use temporary auth tickets again, fixes #5302 ([2018-10-31](https://github.com/tvheadend/tvheadend/commit/981ba4822d388c2331a5af8fa015bb3c2f917c4a))
-* linuxdvb rotor: improve satellite longitude description ([2018-10-31](https://github.com/tvheadend/tvheadend/commit/12fac489b794978d73d5ea919f7fe7cd25bd15a1))
-* scanfile: add support for PLS\_CODE and PLS\_MODE, fixes #5305 ([2018-10-31](https://github.com/tvheadend/tvheadend/commit/cba1d85a574eae0c0bab00274fadc67922fb91cf))
-* htsp server: improve the htsp streaming connection limit check, issue #5290 ([2018-10-30](https://github.com/tvheadend/tvheadend/commit/ed33294f9cdfe41696e9e95cf81a75510d6f1193))
-* intextra: support 12bit unsigned nrs ([2018-10-29](https://github.com/tvheadend/tvheadend/commit/cd52831fdc23d82f051faa2abc6bc8fef5d3022c))
-* msg queue: wake thread on new message ([2018-10-29](https://github.com/tvheadend/tvheadend/commit/77fc1c05f1b6e9db34ea498063eff0f6bd0a2d37))
-* access: do not allocate always 50 bytes for aa\_representative ([2018-10-27](https://github.com/tvheadend/tvheadend/commit/9a27de8caae0f43b3a8dca2f4e750eb93c31bd68))
-* access: set the temporary ticket lifetime between 30 and 3600 seconds ([2018-10-27](https://github.com/tvheadend/tvheadend/commit/a7eacfe7a75da4c64498c2a7be30b734de71236d))
-* access: allow advanced streaming for the permanent tickets, fixes #5294 ([2018-10-27](https://github.com/tvheadend/tvheadend/commit/ac48db1f169e97ec84aff790d21c20f669705593))
-* webui: m3u playlist - add auth tokens for logo, fixes #5291 ([2018-10-27](https://github.com/tvheadend/tvheadend/commit/1fc3b3c4ccefe124845b6fd4a03d42da5706267b))
-* webui: more tooltips for help buttons! ([2018-10-25](https://github.com/tvheadend/tvheadend/commit/689d18238af16fb1516cc1f46ff7cc2bb1aa8e64))
-* webui: Fix #5292 ([2018-10-25](https://github.com/tvheadend/tvheadend/commit/424a108b0fb8d77b2445fa7937fd8d2dfd86feb2))
-* Make authentication ticket lifetime configurable ([2018-10-25](https://github.com/tvheadend/tvheadend/commit/7185713f42eeb82b9fcfcf0b18257c2948e9f95e))
-* tcp: fix wrong used variable initialisation, issue #5290 ([2018-10-24](https://github.com/tvheadend/tvheadend/commit/860fb782d0f2923d0b9d5a8728301475357c5ee2))
-* service mapper: fix locking, issue #5261 ([2018-10-23](https://github.com/tvheadend/tvheadend/commit/7ad64f712e4e62cff8ae7cb878fc90a107c6752b))
-* access: fix access\_copy() for aa\_auth, fixes #5285 ([2018-10-23](https://github.com/tvheadend/tvheadend/commit/275aec3c3cf9b3c368365249c8bf3d37e57cf043))
-* dvr\_rec: fix early access\_destroy ([2018-10-22](https://github.com/tvheadend/tvheadend/commit/8e61fcf5f6cf1ed5f6f57a4b7807f5e56debabee))
-* dvr: cleanup the error path in dvr\_rec\_subscribe() ([2018-10-22](https://github.com/tvheadend/tvheadend/commit/1f74101898cedf5eaaee5cd8195d044250d92100))
-* access: do not use + character for the auth code (HTTP deescaping), issue #5274 ([2018-10-22](https://github.com/tvheadend/tvheadend/commit/3e130baba4318993e8269d781fda999013a4be81))
-* dvr: fix the dvr\_rec\_subscribe cleanup ([2018-10-22](https://github.com/tvheadend/tvheadend/commit/6c3562df520f556efaa3f1fa57e7aa0465a45c13))
-* service mapper: fix mono2sec -> sec2mono thinko ([2018-10-22](https://github.com/tvheadend/tvheadend/commit/476ed21c06a4f381622b3729f4283ec25bb4b55f))
-* webui: fix http\_m3u\_playlist\_add(), fixes #5274 ([2018-10-22](https://github.com/tvheadend/tvheadend/commit/938f65220e2565ddd03b027a6c7ba02210d9f5e3))
-* service mapper: try to determine quickly services without A/V streams, issue #5261 ([2018-10-22](https://github.com/tvheadend/tvheadend/commit/26dc2643eff15312644c4e18ffd07536e7e318d6))
-* http: terminate path correctly in http\_resolve() ([2018-10-21](https://github.com/tvheadend/tvheadend/commit/bc2387248ff425fc4a92a79d21228af7e1702a81))
-* fixes for the permanent tickets, issue #5274 ([2018-10-21](https://github.com/tvheadend/tvheadend/commit/a260ce5f6ae557d7ababbbbfc4dbe7f48b1cb0eb))
-* doc: add authentication type for playlist in url.md ([2018-10-21](https://github.com/tvheadend/tvheadend/commit/7f841a351543ef3cb907a90d1fe090497999aa36))
-* http: auth playlist, return unauthorized when the authcode is not present ([2018-10-21](https://github.com/tvheadend/tvheadend/commit/b7e8102ce0118c7028a7567153d986451c74460a))
-* htsp: Tidy serialisation of category and keyword. ([2018-10-21](https://github.com/tvheadend/tvheadend/commit/64afb2e0c931e00a3fcc538806e1c40391c7cd7f))
-* service mapper: implement time watchdog (cca 30 seconds) ([2018-10-21](https://github.com/tvheadend/tvheadend/commit/ef939ad187f60bf6a009140a529d4945103409af))
-* add permanent tickets for the authentication, fixes #5274 ([2018-10-20](https://github.com/tvheadend/tvheadend/commit/ee714fc11fbebc4c620230df4053f9a833c49eb7))
-* linuxdvb: fix again the PLS code skip when the default value is used ([2018-10-18](https://github.com/tvheadend/tvheadend/commit/6ff543223b2ff4a0b36e9f86769c84f7efad5c93))
-* dvb psi: change PMT monitor when PMT PID changes for SID, issue #4942 ([2018-10-18](https://github.com/tvheadend/tvheadend/commit/f89dc75ba0e9b2aaf86e1746b3ed4434a6f118ed))
-* dvb psi: fix for the previous commit - reinstall pmt monitor only when it's already installed ([2018-10-18](https://github.com/tvheadend/tvheadend/commit/76147c1ddd10c9783a719cfee69931e2da12771b))
-* dvb psi: fix for the previous commits - move pmt monitor change to mpegts\_service\_find() ([2018-10-18](https://github.com/tvheadend/tvheadend/commit/ddfbf14888a4ed13ddd134452e43ad2dab71d67e))
-* campt: fix the ct\_multipid initialisation, fixes #5097 ([2018-10-17](https://github.com/tvheadend/tvheadend/commit/67758d02f2ce9997ba10e22c666f0262ed4efd54))
-* bintray: disable uploads :-( ([2018-10-17](https://github.com/tvheadend/tvheadend/commit/94a7f2df8bd0967328ea7d80f1728c2cd1c226d0))
-* linuxdvb: set PLS code only when it differs from 1, fixes #5266 ([2018-10-17](https://github.com/tvheadend/tvheadend/commit/b37656e74dc4387e2c2e1b4252bf8abe4fb5319f))
-* htsmg: align the access to list/dictionary ([2018-10-16](https://github.com/tvheadend/tvheadend/commit/fdaa48b32b0566fbf56a588e54fec28b4350d35a))
-* [Revert "FreeBSD: Fix recv problem if no data received."](#user-content-fn-312)[^312] ([2018-10-16](https://github.com/tvheadend/tvheadend/commit/f08bbef11c77a6a81d4e2bf974e36e54b0cd14d6))
-* [FreeBSD: kevent is not a bitmask.](#user-content-fn-313)[^313] ([2018-10-16](https://github.com/tvheadend/tvheadend/commit/e3c8cb7dfd8de508a89d304cef5fe9b86bdc08c7))
-* DVR: add username to the subscription, fixes #5215, fixes #5263 ([2018-10-16](https://github.com/tvheadend/tvheadend/commit/72ba707d5232bb4569e616c82c563f457826ec9c))
+* [Nightly build 4.3-2637](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2637*) (2026-04-07)
 
-[**Automatically generated: 2025-06-27 06:12:43 UTC**](#user-content-fn-314)[^314]
+* [Nightly build 4.3-2636](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2636*) (2026-04-07)
 
-[^1]: Update online help text
+* [Merge pull request #10 from tvheadend/copilot/update-changelog-workflow](#user-content-fn-2)[^2] ([2026-04-07 09:55:59](https://github.com/tvheadend/tvheadend/commit/0143afcac18a76da92d5ab09ce60ceb35acb89fb))
+
+* [Harden documentation changelog workflow permissions and metadata](#user-content-fn-3)[^3] ([2026-04-07 09:53:35](https://github.com/tvheadend/tvheadend/commit/7fa1ba922687d723104e627f81efac9779052a8a))
+
+* [Add workflow to update documentation changelog after master PR merges](#user-content-fn-4)[^4] ([2026-04-07 09:51:23](https://github.com/tvheadend/tvheadend/commit/d8c550676cfe58ca9e5500bcb308ae9bead365bb))
+
+* [Plan changelog automation workflow](#user-content-fn-5)[^5] ([2026-04-07 09:49:11](https://github.com/tvheadend/tvheadend/commit/8dd39d0b6360f6fd89eb5429eb2100e12a72155d))
+
+* [Merge pull request #9 from DeltaMikeCharlie/changelog_script](#user-content-fn-6)[^6] ([2026-04-07 05:19:48](https://github.com/tvheadend/tvheadend/commit/45d3881e6e3ad157108db0ccb80cb1484fb67600))
+
+* [NEW] Script to build Release / Change Log ([2026-04-07 05:08:22](https://github.com/tvheadend/tvheadend/commit/133f17ce297cc29bef4bbe9c2c21197442bd2e2d))
+
+* [Nightly build 4.3-2635](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2635*) (2026-03-30)
+
+* [Nightly build 4.3-2634](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2634*) (2026-03-11)
+
+* [Nightly build 4.3-2633](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2633*) (2026-03-08)
+
+* [Nightly build 4.3-2632](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2632*) (2026-03-08)
+
+* [Nightly build 4.3-2631](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2631*) (2026-02-25)
+
+* [Nightly build 4.3-2630](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2630*) (2026-02-25)
+
+* [Nightly build 4.3-2629](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2629*) (2026-02-24)
+
+* [Nightly build 4.3-2628](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2628*) (2026-02-24)
+
+* [Nightly build 4.3-2627](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2627*) (2026-02-24)
+
+* [Nightly build 4.3-2626](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2626*) (2026-02-24)
+
+* [Nightly build 4.3-2607](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2607*) (2026-02-23)
+
+* [Nightly build 4.3-2606](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2606*) (2026-02-23)
+
+* [Nightly build 4.3-2605](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2605*) (2026-02-23)
+
+* [Nightly build 4.3-2604](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2604*) (2026-02-06)
+
+* [Nightly build 4.3-2603](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2603*) (2026-02-06)
+
+* [Nightly build 4.3-2600](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2600*) (2026-01-14)
+
+* [Nightly build 4.3-2598](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2598*) (2026-01-12)
+
+* [Nightly build 4.3-2597](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2597*) (2026-01-10)
+
+* [Nightly build 4.3-2594](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2594*) (2026-01-10)
+
+* [Nightly build 4.3-2593](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2593*) (2026-01-10)
+
+* [Nightly build 4.3-2590](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2590*) (2026-01-05)
+
+* [Nightly build 4.3-2589](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2589*) (2026-01-05)
+
+* [Nightly build 4.3-2580](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2580*) (2026-01-05)
+
+* [Nightly build 4.3-2579](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2579*) (2026-01-02)
+
+* [Nightly build 4.3-2578](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2578*) (2026-01-02)
+
+* [Nightly build 4.3-2577](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2577*) (2026-01-01)
+
+* [Nightly build 4.3-2576](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2576*) (2026-01-01)
+
+* [Nightly build 4.3-2575](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2575*) (2026-01-01)
+
+* [Nightly build 4.3-2574](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2574*) (2025-12-31)
+
+* [Nightly build 4.3-2573](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2573*) (2025-12-31)
+
+* [Nightly build 4.3-2553](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2553*) (2025-12-30)
+
+* [Nightly build 4.3-2552](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2552*) (2025-12-30)
+
+* [Nightly build 4.3-2550](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2550*) (2025-12-22)
+
+* [Nightly build 4.3-2549](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2549*) (2025-12-15)
+
+* [Nightly build 4.3-2548](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2548*) (2025-12-15)
+
+* [Nightly build 4.3-2546](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2546*) (2025-12-15)
+
+* [Nightly build 4.3-2545](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2545*) (2025-12-09)
+
+* [Nightly build 4.3-2544](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2544*) (2025-12-08)
+
+* [Nightly build 4.3-2539](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2539*) (2025-12-08)
+
+* [Nightly build 4.3-2538](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2538*) (2025-11-26)
+
+* [Nightly build 4.3-2529](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2529*) (2025-11-24)
+
+* [Nightly build 4.3-2528](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2528*) (2025-11-15)
+
+* [Nightly build 4.3-2527](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2527*) (2025-11-15)
+
+* [Nightly build 4.3-2526](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2526*) (2025-11-14)
+
+* [Nightly build 4.3-2525](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2525*) (2025-11-14)
+
+* [Nightly build 4.3-2521](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2521*) (2025-11-14)
+
+* [Nightly build 4.3-2520](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2520*) (2025-11-14)
+
+* [Nightly build 4.3-2519](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2519*) (2025-11-14)
+
+* [Nightly build 4.3-2518](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2518*) (2025-11-05)
+
+* [Nightly build 4.3-2514](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2514*) (2025-11-02)
+
+* [Nightly build 4.3-2513](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2513*) (2025-11-01)
+
+* [Nightly build 4.3-2512](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2512*) (2025-10-31)
+
+* [Nightly build 4.3-2511](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2511*) (2025-10-26)
+
+* [Nightly build 4.3-2510](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2510*) (2025-10-25)
+
+* [Nightly build 4.3-2504](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2504*) (2025-10-25)
+
+* [Nightly build 4.3-2503](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2503*) (2025-10-25)
+
+* [Nightly build 4.3-2502](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2502*) (2025-10-25)
+
+* [Nightly build 4.3-2501](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2501*) (2025-10-25)
+
+* [Nightly build 4.3-2500](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2500*) (2025-10-18)
+
+* [Nightly build 4.3-2499](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2499*) (2025-10-18)
+
+* [Nightly build 4.3-2498](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2498*) (2025-10-12)
+
+* [Nightly build 4.3-2477](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2477*) (2025-10-08)
+
+* [Nightly build 4.3-2476](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2476*) (2025-10-07)
+
+* [Nightly build 4.3-2475](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2475*) (2025-10-05)
+
+* [Nightly build 4.3-2474](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2474*) (2025-10-04)
+
+* [Nightly build 4.3-2473](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2473*) (2025-10-04)
+
+* [Nightly build 4.3-2472](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2472*) (2025-10-04)
+
+* [Merge pull request #6 from tvheadend/copilot/fix-0639d7ea-5bb6-440e-9bfc-6c14a266e420](#user-content-fn-7)[^7] ([2025-09-25 21:58:01](https://github.com/tvheadend/tvheadend/commit/f69f59a60ad487f047dca045578f1804dde3e2b4))
+
+* [Fix compilation errors in Configuration component](#user-content-fn-8)[^8] ([2025-09-25 21:49:29](https://github.com/tvheadend/tvheadend/commit/0305f224d23921c0e6076d91e4e5b97967869ada))
+
+* [Fix API requests and configuration issues](#user-content-fn-9)[^9] ([2025-09-25 21:39:08](https://github.com/tvheadend/tvheadend/commit/740110a892e1f94f9734e82df0051e548bd72c4d))
+
+* [Complete comprehensive configuration framework implementation](#user-content-fn-10)[^10] ([2025-09-25 21:15:01](https://github.com/tvheadend/tvheadend/commit/34a55f216da39b14c586edd954588f0be4aa045e))
+
+* [Changes before error encountered](#user-content-fn-11)[^11] ([2025-09-25 20:25:04](https://github.com/tvheadend/tvheadend/commit/52700c8b04fb4dee34e809d8edbf8f4312ea1d40))
+
+* [Expand configuration sections with multiple grid and form components](#user-content-fn-12)[^12] ([2025-09-25 20:12:02](https://github.com/tvheadend/tvheadend/commit/2604196fd82e3d6409058de823863adda42ecb72))
+
+* [Implement configuration sections infrastructure and Access Entries](#user-content-fn-13)[^13] ([2025-09-25 20:05:30](https://github.com/tvheadend/tvheadend/commit/0114c76a791622b6c2cd5d869fd531c4b043c60c))
+
+* [Implement comprehensive Watch TV dialog with video player](#user-content-fn-14)[^14] ([2025-09-25 19:47:06](https://github.com/tvheadend/tvheadend/commit/a59082503b3e365ba8c5189723896db3cc026c3a))
+
+* [Make modern UI use dynamic data instead of static lists](#user-content-fn-15)[^15] ([2025-09-25 19:16:25](https://github.com/tvheadend/tvheadend/commit/4c4bc68651764fa47e08a5819e165c399529d1d4))
+
+* [Initial analysis and plan for making modern UI dynamic](#user-content-fn-16)[^16] ([2025-09-25 18:52:34](https://github.com/tvheadend/tvheadend/commit/e433ddadc9d07dab6e7727d890f81737c3026690))
+
+* Initial plan ([2025-09-25 18:45:43](https://github.com/tvheadend/tvheadend/commit/7edd31f8f17943a4df7def1083271bccfdabea00))
+
+* [Start of a new, modern UI](#user-content-fn-17)[^17] ([2025-09-25 18:45:02](https://github.com/tvheadend/tvheadend/commit/a6731ef6b66c73a6c84620b707b351bf6f147bee))
+
+* [Fix routing: redirect to /modern/index.html and add homepage configuration](#user-content-fn-18)[^18] ([2025-09-25 16:58:41](https://github.com/tvheadend/tvheadend/commit/175da570cb172d27790390ac8628e0821b201808))
+
+* [Implement automatic cache invalidation for modern web interface](#user-content-fn-19)[^19] ([2025-09-25 16:24:05](https://github.com/tvheadend/tvheadend/commit/401caae4f24c0a4e12525cc5081be34092818c82))
+
+* [Fix all critical issues: Build integration, no mock data, proper routing, functional buttons](#user-content-fn-20)[^20] ([2025-09-25 15:55:36](https://github.com/tvheadend/tvheadend/commit/67952163857072c1defa3445c6447def861a92ab))
+
+* [Final comprehensive fix: All buttons functional, real API calls, proper routing, build integration](#user-content-fn-21)[^21] ([2025-09-25 15:07:01](https://github.com/tvheadend/tvheadend/commit/da1a9c11c1e7621ed911e4218f849c6b2587e6d4))
+
+* [Complete modern web interface - production ready with all features functional](#user-content-fn-22)[^22] ([2025-09-25 13:23:20](https://github.com/tvheadend/tvheadend/commit/2890165509abd56bc95a5adc13817b562decadda))
+
+* [Implement complete modern React web interface with all ExtJS functionality - fixed routing, real API calls, all dialogs working](#user-content-fn-23)[^23] ([2025-09-25 13:10:39](https://github.com/tvheadend/tvheadend/commit/32507f7d808611f1cfec0bc1c3e41073a25286f4))
+
+* [Complete modern web interface implementation - all features working](#user-content-fn-24)[^24] ([2025-09-25 12:15:44](https://github.com/tvheadend/tvheadend/commit/e4728dabe07ee2206d7f5aa319d22db9075ceafc))
+
+* [Complete modern React web interface - fully functional with real API integration](#user-content-fn-25)[^25] ([2025-09-25 09:33:13](https://github.com/tvheadend/tvheadend/commit/7706f250f99df6aeac7d4c5ad34e77ec5471e0d5))
+
+* [Implement complete modern React web interface to replace ExtJS 3](#user-content-fn-26)[^26] ([2025-09-25 09:07:47](https://github.com/tvheadend/tvheadend/commit/e7f71bc2defab2835c74c93e46dbaccde18b882d))
+
+* Initial plan ([2025-09-24 22:57:04](https://github.com/tvheadend/tvheadend/commit/75a7d42d6466ce7a9603c82afc09c2b262aa3ee5))
+
+* [Merge pull request #1 from tvheadend/copilot/fix-1934](#user-content-fn-27)[^27] ([2025-09-24 19:37:13](https://github.com/tvheadend/tvheadend/commit/d525b6f18b11322407c38d9f36e6eff726222f5f))
+
+* [Fix workflow to avoid committing .pot files and prevent multiple PRs](#user-content-fn-28)[^28] ([2025-09-24 10:18:19](https://github.com/tvheadend/tvheadend/commit/30b18a9ad27d2a86dc9d7cc6aec7f506a15770cf))
+
+* [Add automated internationalization template updates](#user-content-fn-29)[^29] ([2025-09-24 09:59:57](https://github.com/tvheadend/tvheadend/commit/e1cc8efa0864375bf2aa40256ca10fd6c0f81400))
+
+* [Add automated internationalization template updates](#user-content-fn-30)[^30] ([2025-09-24 09:59:24](https://github.com/tvheadend/tvheadend/commit/123747cfb6ec12a52fd4775b1ce8781a41a93123))
+
+* [Initial exploration and understanding of intl process](#user-content-fn-31)[^31] ([2025-09-24 09:56:44](https://github.com/tvheadend/tvheadend/commit/0905b2761f280e21a84da3bdd5200abb896c6a09))
+
+* Initial plan ([2025-09-24 09:52:28](https://github.com/tvheadend/tvheadend/commit/22cf6f684f467556d74b822fb9261e3040780489))
+
+* [Nightly build 4.3-2471](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2471*) (2025-09-22)
+
+* [Standardize language descriptions](#user-content-fn-32)[^32] ([2025-09-22 19:34:11](https://github.com/tvheadend/tvheadend/commit/5fd594910abbff1091e11b606124905a1cc92bb6))
+
+* [Nightly build 4.3-2470](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2470*) (2025-09-22)
+
+* [Fix Docker containers missing bzip2 for backup functionality](#user-content-fn-33)[^33] ([2025-09-22 17:38:54](https://github.com/tvheadend/tvheadend/commit/f7077df46b3850fb764663aba02dfd54362c7930))
+
+* [Nightly build 4.3-2469](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2469*) (2025-09-19)
+
+* [Translation for 'fr' updated.](#user-content-fn-34)[^34] ([2025-09-19 00:27:06](https://github.com/tvheadend/tvheadend/commit/edf1b937f8b47bc58f7ffba6931f5b78c33fad5f))
+
+* [Translation for 'fr' updated.](#user-content-fn-35)[^35] ([2025-09-19 00:27:06](https://github.com/tvheadend/tvheadend/commit/ec8a44a893178b1475508d6acd7871ae6e0f0a70))
+
+* [Translation for 'fr' updated.](#user-content-fn-36)[^36] ([2025-09-19 00:27:06](https://github.com/tvheadend/tvheadend/commit/bed53d312be08472d567d027c07872cdc603a91f))
+
+* [Nightly build 4.3-2466](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2466*) (2025-09-15)
+
+* [Reinstate references to 'url'](#user-content-fn-37)[^37] ([2025-09-15 19:46:49](https://github.com/tvheadend/tvheadend/commit/7cbe50c6e646e0d2443ef5bd73ba3c49c3c632c3))
+
+* [Nightly build 4.3-2465](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2465*) (2025-09-15)
+
+* Remove useless git PPA from builds ([2025-09-15 16:44:09](https://github.com/tvheadend/tvheadend/commit/a1bfc676c1d72528a4ce540b0fa7bee589d1b92a))
+
+* [Nightly build 4.3-2464](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2464*) (2025-09-15)
+
+* [remove deprecated ticks_per_frame](#user-content-fn-38)[^38] ([2025-09-15 12:16:05](https://github.com/tvheadend/tvheadend/commit/56d0ef76efbde144b17f3a94c9a9dd6eae0afcdb))
+
+* [Nightly build 4.3-2463](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2463*) (2025-09-12)
+
+* [update ch_layout implementation](#user-content-fn-39)[^39] ([2025-09-12 12:57:53](https://github.com/tvheadend/tvheadend/commit/537969d663d83d856ffe6f7a456809a7c761fd7b))
+
+* [Nightly build 4.3-2462](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2462*) (2025-09-09)
+
+* [Nightly build 4.3-2461](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2461*) (2025-09-09)
+
+* [Nightly build 4.3-2455](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2455*) (2025-09-09)
+
+* [transcode: avoid multi-line encoder configuration log](#user-content-fn-40)[^40] ([2025-09-09 19:01:15](https://github.com/tvheadend/tvheadend/commit/664cc1b621695b7933f6be1387c2031b401b33fa))
+
+* Avoid image container if there is no image ([2025-09-09 18:31:51](https://github.com/tvheadend/tvheadend/commit/b977b10cb9c110508af21009f6f017abb3769e0a))
+
+* [Do not use number hardcoding in recording details dialog](#user-content-fn-41)[^41] ([2025-09-09 18:31:51](https://github.com/tvheadend/tvheadend/commit/b944feb3ce3cb459213f4d0135ad4d9307b29767))
+
+* Parameter name is uri instead of url for the crid ([2025-09-09 18:31:51](https://github.com/tvheadend/tvheadend/commit/9d28f564eea81b3b7899844965a3c0a655830593))
+
+* Show details dialog for encrypted services even if we have no cards ([2025-09-09 18:31:51](https://github.com/tvheadend/tvheadend/commit/73982782d46497296730326bab3a8bbd0498b0c9))
+
+* [Request event details for EPG dialog display](#user-content-fn-42)[^42] ([2025-09-09 18:31:51](https://github.com/tvheadend/tvheadend/commit/6f720653a7c20201947f5ec77a8740522afa2e0d))
+
+* [WebUI: Allow categories to be represented by multiple icons](#user-content-fn-43)[^43] ([2025-09-09 18:31:51](https://github.com/tvheadend/tvheadend/commit/1edfaba452b4cdfca8994a1b881e2fb5e0f9c467))
+
+* Avoid implicit conversion from ‘float’ to ‘double’ [-Wdouble-promotion] ([2025-09-09 18:31:27](https://github.com/tvheadend/tvheadend/commit/d26b3f173bbd64d98ea821639cc3c4f0c77aaf17))
+
+* [Fix suspicious usage of pointer to aggregate [bugprone-sizeof-expression]](#user-content-fn-44)[^44] ([2025-09-09 18:31:27](https://github.com/tvheadend/tvheadend/commit/7603f65bf205518028ddc3270dd69c69313c3e87))
+
+* [Set #pragma once for build.h](#user-content-fn-45)[^45] ([2025-09-09 18:31:27](https://github.com/tvheadend/tvheadend/commit/629ed8e091a2c49a1357a9601b469a37a8ff62cd))
+
+* Use correct feature test macro for qsort_r detection ([2025-09-09 18:31:27](https://github.com/tvheadend/tvheadend/commit/04e155a84b4695607d3a6fceb8c876005f0414b8))
+
+* [Nightly build 4.3-2451](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2451*) (2025-08-26)
+
+* [issues: misc. template updates](#user-content-fn-46)[^46] ([2025-08-25 18:24:39](https://github.com/tvheadend/tvheadend/commit/74720af6296f11d2be3122ce7e55adef8052934e))
+
+* [Nightly build 4.3-2450](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2450*) (2025-08-23)
+
+* Add EL9 and EL10 support for both x86_64 and aarch64 ([2025-08-23 18:28:21](https://github.com/tvheadend/tvheadend/commit/4bf4f7d87ccf343c3bbe9cb65eb5a6133d168044))
+
+* [Nightly build 4.3-2449](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2449*) (2025-08-22)
+
+* [Create comprehensive copilot instructions for tvheadend development](#user-content-fn-47)[^47] ([2025-08-22 20:32:39](https://github.com/tvheadend/tvheadend/commit/c4cd8649fb9b6f16337191844aba84596cc21045))
+
+* [Update copilot instructions for whitelisted internet access](#user-content-fn-48)[^48] ([2025-08-22 20:32:39](https://github.com/tvheadend/tvheadend/commit/3622fe228a36497aa34788e145d589793e3d667a))
+
+* [Nightly build 4.3-2447](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2447*) (2025-08-22)
+
+* [Nightly build 4.3-2446](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2446*) (2025-08-22)
+
+* [Add single-threaded build fallback for both Debian and RPM builds](#user-content-fn-49)[^49] ([2025-08-22 13:43:29](https://github.com/tvheadend/tvheadend/commit/af7d204d3a32a864ef70238a890c99afeb354f40))
+
+* [Fix WiFi startup issue: Add network-online.target to systemd service files](#user-content-fn-50)[^50] ([2025-08-22 13:43:03](https://github.com/tvheadend/tvheadend/commit/11c534f1a0f6612b994291ffe6764f626c11882c))
+
+* [Nightly build 4.3-2445](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2445*) (2025-08-21)
+
+* [vaapi improvements](#user-content-fn-51)[^51] ([2025-08-21 15:26:12](https://github.com/tvheadend/tvheadend/commit/d69021326922bc2029f25858460ff4f5e245f89c))
+
+* [Nightly build 4.3-2444](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2444*) (2025-08-20)
+
+* dvb_psi_pmt: Don't recognize extension descriptor as AC-4 audio ([2025-08-20 19:50:47](https://github.com/tvheadend/tvheadend/commit/ec0469c199783f261e852a66d289906ea5097d86))
+
+* [Nightly build 4.3-2443](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2443*) (2025-08-15)
+
+* [Nightly build 4.3-2442](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2442*) (2025-08-15)
+
+* Fix memory leak in iptv_mux.c ([2025-08-15 21:20:11](https://github.com/tvheadend/tvheadend/commit/24efc44e6a2236ecf023d82fa96f36e41f865fa3))
+
+* [transcode: fix VAAPI deinterlace mode handling for software decode/encode profiles](#user-content-fn-52)[^52] ([2025-08-15 21:01:47](https://github.com/tvheadend/tvheadend/commit/33066c476068792eacbbd9748eaaaf73fe8bf829))
+
+* [Nightly build 4.3-2441](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2441*) (2025-08-15)
+
+* Add Fedora 44 to cloudsmith script (ignored for now) ([2025-08-15 16:15:25](https://github.com/tvheadend/tvheadend/commit/905f6d8f7b856d9a2d186ff39397a2fc9be1386d))
+
+* Update debian docker dependencies ([2025-08-15 16:15:25](https://github.com/tvheadend/tvheadend/commit/4d46e5d12319d992e3866ab28094a5c018f6272f))
+
+* Add fedora 43 to builds ([2025-08-15 16:15:25](https://github.com/tvheadend/tvheadend/commit/13ec46ae99564a7c9e98d2f1ce4b35900a22687d))
+
+* Add debian forky files ([2025-08-15 16:15:25](https://github.com/tvheadend/tvheadend/commit/0294b864340db75543fec03bfdd6bd71a10808a0))
+
+* [Nightly build 4.3-2437](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2437*) (2025-08-10)
+
+* [Nightly build 4.3-2436](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2436*) (2025-08-10)
+
+* Fix memory leak in iptv.c ([2025-08-10 11:31:20](https://github.com/tvheadend/tvheadend/commit/ccc7ce914e248ae8a73cbb5be7b86e37d70fe4d2))
+
+* [Nightly build 4.3-2435](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2435*) (2025-08-10)
+
+* Fix memory leak in HTSP-Server ([2025-08-10 10:53:43](https://github.com/tvheadend/tvheadend/commit/f2731e37d6fd1b13bbdde47825f1f7046185cdef))
+
+* Fix memory leak in idnode.c ([2025-08-10 10:53:22](https://github.com/tvheadend/tvheadend/commit/4b3910d5938b2172b1f17e79a2efbb1a1355d85a))
+
+* [Nightly build 4.3-2434](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2434*) (2025-08-07)
+
+* [transcode: clean up unused parameters and fix SonarQube issues](#user-content-fn-53)[^53] ([2025-08-07 11:30:27](https://github.com/tvheadend/tvheadend/commit/b3974f7d6f62acb82ebe5f310bf7d579ef7cba79))
+
+* [Nightly build 4.3-2433](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2433*) (2025-07-27)
+
+* linuxdvb_adapter: increase MAX_DEV_OPEN_ATTEMPTS to 50 ([2025-07-27 17:09:01](https://github.com/tvheadend/tvheadend/commit/f1c460feba34491d473c60216bd35eccc73c178e))
+
+* [Nightly build 4.3-2432](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2432*) (2025-07-21)
+
+* [transcode: add advanced options for deinterlacing](#user-content-fn-54)[^54] ([2025-07-21 15:07:29](https://github.com/tvheadend/tvheadend/commit/0af87f13f786046df7bb610f8a6b291c26af1b14))
+
+* [Nightly build 4.3-2431](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2431*) (2025-07-20)
+
+* [move filter_hw_denoise and filter_hw_sharpness to tvh_codec_profile_video](#user-content-fn-55)[^55] ([2025-07-20 03:11:35](https://github.com/tvheadend/tvheadend/commit/b9d34f9135a0b40405581e7dd6534d97327f86eb))
+
+* [Nightly build 4.3-2430](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2430*) (2025-07-18)
+
+* Add Season number and Episode number to file name formatting strings. ([2025-07-18 00:38:26](https://github.com/tvheadend/tvheadend/commit/da9fa60323a972f66ac3adf5800ef78f571fba82))
+
+* [Nightly build 4.3-2429](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2429*) (2025-07-17)
+
+* Add Scene Markers to recordings at scheduled EPG event start/stop times. ([2025-07-17 09:37:09](https://github.com/tvheadend/tvheadend/commit/5ff6128c7468f3606bb1f0622422878ad39a7c45))
+
+* [Nightly build 4.3-2428](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2428*) (2025-07-17)
+
+* [Implement age ratings on XMLTV](#user-content-fn-56)[^56] ([2025-07-16 23:21:28](https://github.com/tvheadend/tvheadend/commit/e065d661aa837aef0fa93b5350afef4a2b77ed79))
+
+* [Nightly build 4.3-2427](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2427*) (2025-07-16)
+
+* Fix builds on debian buster ([2025-07-16 14:37:46](https://github.com/tvheadend/tvheadend/commit/aaf31d96422bad6474744e2bddc65451b2c6b96a))
+
+* [Nightly build 4.3-2426](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2426*) (2025-07-12)
+
+* Fix broken squash-autocomment ([2025-07-11 23:19:00](https://github.com/tvheadend/tvheadend/commit/d1fb6da0a3a4583d9bb125276bb680ab7b2b87fe))
+
+* [Nightly build 4.3-2425](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2425*) (2025-07-05)
+
+* Add 'sudo make install' to the Linux build notes. ([2025-07-05 13:45:19](https://github.com/tvheadend/tvheadend/commit/d431956cc62f80115fa17103374f7c921081d72c))
+
+* [Nightly build 4.3-2424](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2424*) (2025-07-03)
+
+* Cloudsmith supports fedora 42 now ([2025-07-03 12:34:11](https://github.com/tvheadend/tvheadend/commit/bfcc001423c1ae423ce67e8e35ca702c65f994b2))
+
+* [Nightly build 4.3-2423](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2423*) (2025-06-27)
+
+* Update coverity secret check to new ENV file ([2025-06-27 02:04:34](https://github.com/tvheadend/tvheadend/commit/ea3d32791b94c9a9285920d8cc1396eb3db2b52c))
+
+* [Nightly build 4.3-2422](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2422*) (2025-06-21)
+
+* [Update online help text](#user-content-fn-57)[^57] ([2025-06-21 11:20:08](https://github.com/tvheadend/tvheadend/commit/61d728e1a4bd3e35653a902bf82e3b57c5564013))
+
+* [Nightly build 4.3-2421](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2421*) (2025-06-12)
+
+* [fix memory leak 3 - transcoding](#user-content-fn-58)[^58] ([2025-06-12 19:43:09](https://github.com/tvheadend/tvheadend/commit/730718c2888a121a00b96f3460b2e8f5ca8396d1))
+
+* [Nightly build 4.3-2420](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2420*) (2025-06-10)
+
+* [remove coded_width and coded_height from encoding](#user-content-fn-59)[^59] ([2025-06-10 13:00:01](https://github.com/tvheadend/tvheadend/commit/19026f3202fbacb8ddd89b13d358ee64ce7f4929))
+
+* [Nightly build 4.3-2419](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2419*) (2025-06-10)
+
+* [Nightly build 4.3-2418](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2418*) (2025-06-10)
+
+* User's DVR Configuration profile not used when scheduling recordings via HTSP ([2025-06-10 04:50:37](https://github.com/tvheadend/tvheadend/commit/7bbbe57e9ebb204e1070b219fda611be91bb0ae0))
+
+* Recognize checkbox for feature proposals properly ([2025-06-10 00:16:12](https://github.com/tvheadend/tvheadend/commit/f7edaf48cbe2e068e2126a6b355ae64b2d1b1f6e))
+
+* [Nightly build 4.3-2417](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2417*) (2025-06-09)
+
+* [Nightly build 4.3-2416](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2416*) (2025-06-09)
+
+* Add missing coverity env ([2025-06-09 16:18:43](https://github.com/tvheadend/tvheadend/commit/42ed6affc42ef06e427fb8b1465532a4489e182c))
+
+* Fix coverity builds ([2025-06-09 15:20:24](https://github.com/tvheadend/tvheadend/commit/09a06f11acf0d3957b6dfa08f13b48f7bd1262fd))
+
+* [Nightly build 4.3-2415](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2415*) (2025-06-06)
+
+* [ci: disable coverity on forks](#user-content-fn-60)[^60] ([2025-06-06 15:48:17](https://github.com/tvheadend/tvheadend/commit/56d23c8725b0563587eda0ccaed93153fa77505c))
+
+* [Nightly build 4.3-2414](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2414*) (2025-06-06)
+
+* [repo: cleanup CONTRIBUTING.md](#user-content-fn-61)[^61] ([2025-06-06 11:53:55](https://github.com/tvheadend/tvheadend/commit/c4ce95ab9603e0ceaccf868690aad7414af5cd95))
+
+* repo: cleanup README.md ([2025-06-06 11:53:55](https://github.com/tvheadend/tvheadend/commit/91d107523767bbf311682275c1c604ec420a0166))
+
+* [Nightly build 4.3-2412](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2412*) (2025-06-06)
+
+* [intl: js: change freenode to Libera.Chat](#user-content-fn-62)[^62] ([2025-06-06 08:59:15](https://github.com/tvheadend/tvheadend/commit/aadcc3a8d946ad28e33cf721880abe4709bd44bc))
+
+* [intl: docs: change freenode to Libera.Chat](#user-content-fn-63)[^63] ([2025-06-06 08:59:15](https://github.com/tvheadend/tvheadend/commit/6eb00af2fe19cfec2308027251563a16dd4e6004))
+
+* [Nightly build 4.3-2410](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2410*) (2025-06-04)
+
+* [HTSP: Expose is_new flag in EPG event data](#user-content-fn-64)[^64] ([2025-06-04 17:55:07](https://github.com/tvheadend/tvheadend/commit/808a87a6aa6eeabd4be3a024e4eea023aaf00cf6))
+
+* [Nightly build 4.3-2409](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2409*) (2025-06-04)
+
+* Coverity CID 552897 ([2025-06-04 00:08:55](https://github.com/tvheadend/tvheadend/commit/0f74b0ab0a3b96d87da04d9c778142ecfb370a1d))
+
+* [Nightly build 4.3-2408](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2408*) (2025-06-02)
+
+* [transcode: gracefully handle common hardware decoder errors](#user-content-fn-65)[^65] ([2025-06-02 19:54:56](https://github.com/tvheadend/tvheadend/commit/85360924d0e215c2ba0b1b224e3111be712eae0f))
+
+* [transcode: improve logging of packet transcode errors](#user-content-fn-66)[^66] ([2025-06-02 19:54:56](https://github.com/tvheadend/tvheadend/commit/3f78c11a44a4277048b52d34a3a6ae1a1fb5aced))
+
+* [Nightly build 4.3-2406](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2406*) (2025-06-02)
+
+* [fix for video stream detection](#user-content-fn-67)[^67] ([2025-06-02 05:00:20](https://github.com/tvheadend/tvheadend/commit/1288546386ae775200083ff0788dcdb8d783ce46))
+
+* [Nightly build 4.3-2405](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2405*) (2025-06-02)
+
+* Add API call 'status/activity'. ([2025-06-02 00:47:08](https://github.com/tvheadend/tvheadend/commit/8d469350fa67cb1ce923ecaf303d5ba3bf5c1518))
+
+* [Nightly build 4.3-2404](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2404*) (2025-05-27)
+
+* [fix memory leak 2 - transcoding](#user-content-fn-68)[^68] ([2025-05-27 16:51:03](https://github.com/tvheadend/tvheadend/commit/c0c55c7838ae505c04e90be16da9919b6d49a146))
+
+* [Nightly build 4.3-2403](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2403*) (2025-05-27)
+
+* [fix dead error condition](#user-content-fn-69)[^69] ([2025-05-27 12:01:20](https://github.com/tvheadend/tvheadend/commit/532c2a71f2f7ad938e6763db2f0f3013863fffc0))
+
+* [Nightly build 4.3-2402](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2402*) (2025-05-26)
+
+* [add mpegts parameters from input stream](#user-content-fn-70)[^70] ([2025-05-25 16:35:19](https://github.com/tvheadend/tvheadend/commit/ede23be0d25fc7d42f144fec551e4742f082a37c))
+
+* [Nightly build 4.3-2401](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2401*) (2025-05-25)
+
+* [fix memory leak - transcoding](#user-content-fn-71)[^71] ([2025-05-25 11:07:12](https://github.com/tvheadend/tvheadend/commit/27b12a92d04d5120b9e61f16e620d496d18d6f6d))
+
+* [Nightly build 4.3-2400](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2400*) (2025-05-25)
+
+* Fix recording thread freeze when unable to create unique file name. ([2025-05-25 01:46:08](https://github.com/tvheadend/tvheadend/commit/1a3ca885a4706b57cb9326663955176f72804376))
+
+* [Nightly build 4.3-2399](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2399*) (2025-05-23)
+
+* MKV Tags - Change rating label.  Add Sub-title and Comment. ([2025-05-23 13:22:23](https://github.com/tvheadend/tvheadend/commit/26a14aa318a631a9f96008215e63efd6d6132727))
+
+* [Nightly build 4.3-2398](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2398*) (2025-05-22)
+
+* [fix memory leak](#user-content-fn-72)[^72] ([2025-05-22 18:04:45](https://github.com/tvheadend/tvheadend/commit/7e1f9caa95bf8d3d3e5c3a5eb687e7acf5b9a916))
+
+* [Nightly build 4.3-2397](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2397*) (2025-05-20)
+
+* [video hw accel should only be applied for video streams](#user-content-fn-73)[^73] ([2025-05-20 17:02:13](https://github.com/tvheadend/tvheadend/commit/ebac08749e1272e41ac94aadce8a4d716da3a779))
+
+* [Nightly build 4.3-2396](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2396*) (2025-05-19)
+
+* Add Sub-Title Processing Options for DVB OTA EPG ([2025-05-19 22:26:01](https://github.com/tvheadend/tvheadend/commit/36ba82848bc1837a9b9ee790219ae38e1228b576))
+
+* [Nightly build 4.3-2395](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2395*) (2025-05-19)
+
+* [Update VAAPI transcoding as recommended by ffmpeg 6.1.1/doc/examples/… (#1792)](#user-content-fn-74)[^74] ([2025-05-19 13:21:52](https://github.com/tvheadend/tvheadend/commit/75119b6e9640992cefe67cc3b45025367df7071e))
+
+* [Nightly build 4.3-2394](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2394*) (2025-05-18)
+
+* [update audio abuffersink from deprecated channel_layouts to ch_layouts and deprecated FF_PROFILE_* --> AV_PROFILE_*](#user-content-fn-75)[^75] ([2025-05-18 20:43:21](https://github.com/tvheadend/tvheadend/commit/7da199b61cb2589d65100d55bb736c378ad7c125))
+
+* [Nightly build 4.3-2393](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2393*) (2025-05-17)
+
+* iptv: handle relative key URL ([2025-05-17 04:50:32](https://github.com/tvheadend/tvheadend/commit/221400c9f2d41e974cc8f96269e65c1b2e20dce1))
+
+* [Nightly build 4.3-2392](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2392*) (2025-05-15)
+
+* [Docker]: Tag alpine master as latest ([2025-05-15 19:00:01](https://github.com/tvheadend/tvheadend/commit/03272650dd6cc071163baeb03182bb77c249f024))
+
+* [Nightly build 4.3-2391](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2391*) (2025-05-14)
+
+* [fix read/write of PT_DYN_INT](#user-content-fn-76)[^76] ([2025-05-14 22:11:13](https://github.com/tvheadend/tvheadend/commit/bdec3c501fe4ef6d5d8c1d94c3ba733ddb7e391c))
+
+* [Nightly build 4.3-2390](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2390*) (2025-05-14)
+
+* [allow NVENC, VAAPI and MMAL to coexist in the same build](#user-content-fn-77)[^77] ([2025-05-14 11:36:09](https://github.com/tvheadend/tvheadend/commit/cf29292592756f778024b3f5d8df166dad899285))
+
+* [Nightly build 4.3-2389](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2389*) (2025-05-14)
+
+* Show recording file name ([2025-05-14 10:12:29](https://github.com/tvheadend/tvheadend/commit/13804ab50ce41d81b987d97f050942efe49c4792))
+
+* [Nightly build 4.3-2388](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2388*) (2025-05-14)
+
+* [wizard: increase buffer size to silence -Wformat-truncation on GCC 15](#user-content-fn-78)[^78] ([2025-05-13 22:55:24](https://github.com/tvheadend/tvheadend/commit/cebe6159042c0782cbe22d26446b141fa07d43b8))
+
+* [Nightly build 4.3-2387](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2387*) (2025-05-13)
+
+* [Nightly build 4.3-2386](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2386*) (2025-05-13)
+
+* Fix crash when updating 'disp_summary' ([2025-05-13 20:56:26](https://github.com/tvheadend/tvheadend/commit/df4eaf8e1913028c5cccd6320e462069382b6720))
+
+* [Nightly build 4.3-2382](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2382*) (2025-05-13)
+
+* [Translation for 'pl' updated.](#user-content-fn-79)[^79] ([2025-05-13 16:08:53](https://github.com/tvheadend/tvheadend/commit/e838e06bb2bb8eaa99eec2dfff0669092632d2e3))
+
+* [Translation for 'en_GB' updated.](#user-content-fn-80)[^80] ([2025-05-13 16:08:53](https://github.com/tvheadend/tvheadend/commit/cf317a9223629fe5bdb49aa5bd5116bc77a361a7))
+
+* [Translation for 'en_US' updated.](#user-content-fn-81)[^81] ([2025-05-13 16:08:53](https://github.com/tvheadend/tvheadend/commit/ba243eaf3eb8b70f765ae6d4ad3f33bd18e50a9a))
+
+* [Translation for 'pl' updated.](#user-content-fn-82)[^82] ([2025-05-13 16:08:53](https://github.com/tvheadend/tvheadend/commit/4e3b56c1c6dc4725e5dcb1a6cbee652f159ce8fd))
+
+* Global setting for 'Items per page' ([2025-05-13 16:08:27](https://github.com/tvheadend/tvheadend/commit/da1ac73b92f1b9426bcf08dc7f8d2746cf139bb9))
+
+* [Nightly build 4.3-2381](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2381*) (2025-05-13)
+
+* [Nightly build 4.3-2380](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2380*) (2025-05-13)
+
+* [Nightly build 4.3-2379](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2379*) (2025-05-13)
+
+* [Remove links to old Wiki (#1793)](#user-content-fn-83)[^83] ([2025-05-13 06:38:55](https://github.com/tvheadend/tvheadend/commit/0eea8a59f0834e2a3babdd8028c02509428a097c))
+
+* [httpc.c: Fix HTTPS with OpenSSL 3.5 (#1813)](#user-content-fn-84)[^84] ([2025-05-13 05:43:04](https://github.com/tvheadend/tvheadend/commit/728885fbe3019c6896efc474c8cf336bfadaeea5))
+
+* [lovcombo-all.js: Fix autorec create/edit TypeError with Firefox 134 (#1786)](#user-content-fn-85)[^85] ([2025-05-13 05:41:47](https://github.com/tvheadend/tvheadend/commit/cc07e3471e314469dca3086f134bf3384e06fc83))
+
+* [Nightly build 4.3-2378](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2378*) (2025-05-13)
+
+* Fix Cloudsmith uploads ([2025-05-12 23:16:26](https://github.com/tvheadend/tvheadend/commit/ab81dce3ebfef30626a8ddf3f9a68b6bdd4f47ba))
+
+* [Fix CI Builds 2/2](#user-content-fn-86)[^86] ([2025-05-12 16:35:33](https://github.com/tvheadend/tvheadend/commit/7ec167ae89bdc85ec8b7a918fbd014c12cfd9783))
+
+* [Fix CI Builds 1/2](#user-content-fn-87)[^87] ([2025-05-12 16:35:33](https://github.com/tvheadend/tvheadend/commit/0805edc4b87d60757c9964fd19292e3ad0c33db3))
+
+* [Nightly build 4.3-2375](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2375*) (2024-11-13)
+
+* Check for hidden fields before reading them. Fixes #1782. ([2024-11-12 23:49:11](https://github.com/tvheadend/tvheadend/commit/653bd0400b4413db96b80c807f0f7524f9248adb))
+
+* [Nightly build 4.3-2374](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2374*) (2024-10-08)
+
+* [Nightly build 4.3-2372](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2372*) (2024-10-08)
+
+* [Translation for 'en_US' updated.](#user-content-fn-88)[^88] ([2024-10-08 13:01:02](https://github.com/tvheadend/tvheadend/commit/26ec161fb3c903f8b0d0be8b54d1b67c596fb829))
+
+* [Translation for 'en_GB' updated.](#user-content-fn-89)[^89] ([2024-10-08 13:01:02](https://github.com/tvheadend/tvheadend/commit/06fea47a6fa29f7eaf1ff015f0b095c7be622c1b))
+
+* iptv: allow to limit UDP ports for unicast inputs ([2024-10-08 12:58:23](https://github.com/tvheadend/tvheadend/commit/b69dac9299fde5fd43200a9a56c43bba1ce145cf))
+
+* [Nightly build 4.3-2371](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2371*) (2024-10-05)
+
+* [update libvpx v.1.14.1](#user-content-fn-90)[^90] ([2024-10-05 23:03:47](https://github.com/tvheadend/tvheadend/commit/eee5cdadf244b80efddedb944a55c9cdbb0ff6c9))
+
+* [Nightly build 4.3-2370](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2370*) (2024-09-28)
+
+* [Nightly build 4.3-2369](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2369*) (2024-09-28)
+
+* [Fix - Audio transcoding not working #1663](#user-content-fn-91)[^91] ([2024-09-28 13:39:27](https://github.com/tvheadend/tvheadend/commit/28de5c092c657ffbbffa422c2ca3c07ba513c567))
+
+* [Add start timeout to streaming profile](#user-content-fn-92)[^92] ([2024-09-28 11:58:31](https://github.com/tvheadend/tvheadend/commit/05c3170aef2d28136e34ba6b95afbbb57916e4d7))
+
+* [Nightly build 4.3-2368](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2368*) (2024-09-23)
+
+* [Nightly build 4.3-2367](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2367*) (2024-09-23)
+
+* Remove HTSP client version test for rating labels and string UUIDs ([2024-09-23 15:44:50](https://github.com/tvheadend/tvheadend/commit/55404da6cfd3b0dbbfd5982f87d31dc41f93f509))
+
+* fixes #1733 ([2024-09-23 15:43:17](https://github.com/tvheadend/tvheadend/commit/9dec5b585d8c1b4bb8ae8890985cc5a0148de24f))
+
+* [Nightly build 4.3-2366](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2366*) (2024-09-06)
+
+* bouquet: fix overzealous channel removals in merged multi-network setup ([2024-09-06 21:30:23](https://github.com/tvheadend/tvheadend/commit/9ac57a0c1a4551012260008cfca6bfc2386f6dcf))
+
+* [Nightly build 4.3-2365](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2365*) (2024-09-06)
+
+* Fixup updating comment in _dvr_entry_update. Only overwrite existing title if comment is not NULL. Follows the same logic now as other updates done in this function. ([2024-09-06 17:14:49](https://github.com/tvheadend/tvheadend/commit/2e92208c3c97672efad3b5d65889a048bbebdea1))
+
+* [Nightly build 4.3-2364](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2364*) (2024-09-06)
+
+* HTSP: deliver 'comment' with autorecEntry(Add|Update), timerecEntry(Add|Update). Allow setting 'comment' with 'updateDvrEntry'. ([2024-09-06 12:51:47](https://github.com/tvheadend/tvheadend/commit/4aff543283b88017a59c90ccd7d22aee24b5ee4f))
+
+* [Nightly build 4.3-2363](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2363*) (2024-09-06)
+
+* Add full UUID to channel, chTag and dvrEntry. ([2024-09-06 09:04:39](https://github.com/tvheadend/tvheadend/commit/f9d5e885b307b07be012a9acff276f9e7dd2dbc5))
+
+* Add country and authority to HTPS messages containing rating labels. ([2024-09-06 09:04:39](https://github.com/tvheadend/tvheadend/commit/18ff23f909d8b5c27e9e209c7e50bc5bddce9da2))
+
+* [Nightly build 4.3-2361](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2361*) (2024-08-28)
+
+* HTSP: Expose DVR configuration id in 'dvrEntryAdd', 'dvrEntryUpdate', 'autorecEntryAdd', 'autorecEntryUpdate', 'timerecEntryAdd', 'timerecEntryUpdate'. ([2024-08-28 15:11:45](https://github.com/tvheadend/tvheadend/commit/dd82541c4c4c372a5b6af15e3dc0477f75c1b1bd))
+
+* [Nightly build 4.3-2360](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2360*) (2024-08-25)
+
+* Fix mapping HTSP field 'broadcastType' to internal field. Must be 'btype'. ([2024-08-25 20:12:54](https://github.com/tvheadend/tvheadend/commit/266d03527936ea0d65e6edb06010cd91847493ab))
+
+* [Nightly build 4.3-2359](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2359*) (2024-08-25)
+
+* HTSP: Expose broadcast type in 'autorecEntryAdd' and 'autorecEntryUpdate'. Handle broadcast type in 'addAutorecEntry' and 'updateAutorecEntry'. ([2024-08-25 16:27:41](https://github.com/tvheadend/tvheadend/commit/fc5a1672e083155193f3daf697748780f0d02aa9))
+
+* [Nightly build 4.3-2358](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2358*) (2024-08-24)
+
+* [Fix FTBFS introduced by 76d8fc8bc5455322558c764c84755ebbba254ad5](#user-content-fn-93)[^93] ([2024-08-24 00:38:39](https://github.com/tvheadend/tvheadend/commit/facbd4e4b79f6175daa45bfe5d724b8304648c12))
+
+* [Nightly build 4.3-2357](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2357*) (2024-08-23)
+
+* [fix bug in AAC channel layout configuration tab](#user-content-fn-94)[^94] ([2024-08-23 12:02:26](https://github.com/tvheadend/tvheadend/commit/3bb78afa456f6f430827450612b67f53f9cd211e))
+
+* [Nightly build 4.3-2356](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2356*) (2024-08-23)
+
+* HTSP: Expose service provider name with channel information. ([2024-08-22 20:34:55](https://github.com/tvheadend/tvheadend/commit/267aef151ec30fa9c5469500100ab7f59092d39a))
+
+* [Nightly build 4.3-2355](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2355*) (2024-08-22)
+
+* Update Fedora versions for cloudsmith uploads ([2024-08-22 16:55:40](https://github.com/tvheadend/tvheadend/commit/f20e38daeb6a9727b24923eb77da2a35a96d8a3f))
+
+* [Nightly build 4.3-2354](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2354*) (2024-08-12)
+
+* [Nightly build 4.3-2353](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2353*) (2024-08-12)
+
+* [Update linuxdvb_satconf.c - lnb poweroff requires power save](#user-content-fn-95)[^95] ([2024-08-12 20:54:50](https://github.com/tvheadend/tvheadend/commit/adef81b8d2a6edb3a665679f394bac05b7dc91c8))
+
+* [update vaapi - vainfo](#user-content-fn-96)[^96] ([2024-08-12 20:17:48](https://github.com/tvheadend/tvheadend/commit/76d8fc8bc5455322558c764c84755ebbba254ad5))
+
+* [Nightly build 4.3-2352](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2352*) (2024-08-10)
+
+* Enforce issue templates on GitHub ([2024-08-10 16:19:02](https://github.com/tvheadend/tvheadend/commit/49ac9387186d32b55a399a04155e835eac22c6c1))
+
+* [Nightly build 4.3-2351](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2351*) (2024-08-04)
+
+* Fix function passed to avio_alloc_context() (ffmpeg 7) ([2024-08-04 12:43:25](https://github.com/tvheadend/tvheadend/commit/3c3a8af8f5f31303e7be91eca29b70b1b8dfad59))
+
+* Replace deprecated channels/channel_layout ([2024-08-04 12:43:25](https://github.com/tvheadend/tvheadend/commit/078a822cf548b37bc474475fa57e48e9604090ee))
+
+* [Nightly build 4.3-2349](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2349*) (2024-07-21)
+
+* [Translation for 'en_GB' updated.](#user-content-fn-97)[^97] ([2024-07-21 22:47:21](https://github.com/tvheadend/tvheadend/commit/f5c08ce327d07926aa7876bea48dd2c79dbdf09c))
+
+* [Translation for 'en_US' updated.](#user-content-fn-98)[^98] ([2024-07-21 22:47:21](https://github.com/tvheadend/tvheadend/commit/b774bdd25351e51eba0282ccf7c65904dc1b5655))
+
+* [Nightly build 4.3-2347](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2347*) (2024-07-14)
+
+* Rework fullscreen request method detection ([2024-07-13 23:10:10](https://github.com/tvheadend/tvheadend/commit/1dc8ffe781b688f6ba7bacddd518399ea289efa6))
+
+* [Nightly build 4.3-2346](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2346*) (2024-07-13)
+
+* Allow node16 for GitHub Actions ([2024-07-13 12:33:38](https://github.com/tvheadend/tvheadend/commit/652b291a65c059af43c788d19eeb473761402eab))
+
+* Add dependency for recent Fedora versions ([2024-07-13 12:33:38](https://github.com/tvheadend/tvheadend/commit/457c02d305d92a5036c6d3406f64e03de9ac235a))
+
+* [Nightly build 4.3-2344](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2344*) (2024-06-27)
+
+* [Nightly build 4.3-2343](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2343*) (2024-06-27)
+
+* [Remove tvheadend user on purge](#user-content-fn-99)[^99] ([2024-06-27 21:10:03](https://github.com/tvheadend/tvheadend/commit/d2e41b553e7cc6eb06fd21b42bbed4b3a1f28bc0))
+
+* Refactor null value handling. ([2024-06-27 21:09:43](https://github.com/tvheadend/tvheadend/commit/1644b6e15738490c337a50d2b46fa4e9eb0a18e5))
+
+* [Nightly build 4.3-2342](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2342*) (2024-06-25)
+
+* Replace deprecated av_init_packet() ([2024-06-25 00:02:05](https://github.com/tvheadend/tvheadend/commit/33dc3f38192ccf47a73606c71319abf5604f7ad4))
+
+* Replace deprecated interlaced_frame, top_field_first and key_frame ([2024-06-25 00:02:05](https://github.com/tvheadend/tvheadend/commit/128d6861fac67ea6638c2956d092a46e23eb8988))
+
+* [Nightly build 4.3-2340](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2340*) (2024-06-23)
+
+* [Nightly build 4.3-2339](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2339*) (2024-06-23)
+
+* [Remove useless NULL-check in ratinglabels.c](#user-content-fn-100)[^100] ([2024-06-23 02:22:19](https://github.com/tvheadend/tvheadend/commit/c8435a0985ca66a9bd12f33703c8f76c95ddea43))
+
+* Fix potential null-pointer dereference in muxer_mkv.c ([2024-06-23 01:12:27](https://github.com/tvheadend/tvheadend/commit/cd6bfbb0bb45e7a22690f3d82183125f2b105cfd))
+
+* [Nightly build 4.3-2338](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2338*) (2024-06-23)
+
+* [Remove useless NULL-assignment in http.c](#user-content-fn-101)[^101] ([2024-06-23 00:25:43](https://github.com/tvheadend/tvheadend/commit/fd61453da3118c174cadca9cec1ee1d49f0a1548))
+
+* [Nightly build 4.3-2337](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2337*) (2024-06-18)
+
+* [Use safer htsmsg_add_str2 when copying de->de_directory](#user-content-fn-102)[^102] ([2024-06-18 16:50:09](https://github.com/tvheadend/tvheadend/commit/e855f62e6697cf756ad2eed2ed03b8d06ba2019b))
+
+* [Nightly build 4.3-2336](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2336*) (2024-06-15)
+
+* XMLTV: Rating Labels: Use 'NONE' when 'system' attribute is missing ([2024-06-15 07:32:43](https://github.com/tvheadend/tvheadend/commit/366e5629057e39de68932a0a0613a8af14076e31))
+
+* [Nightly build 4.3-2335](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2335*) (2024-06-07)
+
+* [Allow setting a custom grace period for LinuxDVB adapters](#user-content-fn-103)[^103] ([2024-06-06 23:30:05](https://github.com/tvheadend/tvheadend/commit/f15f05761fb713fb9d754e94fc92253922fc4357))
+
+* [Nightly build 4.3-2334](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2334*) (2024-06-06)
+
+* [Nightly build 4.3-2327](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2327*) (2024-06-06)
+
+* Update x265 to 3.6 ([2024-06-06 14:19:17](https://github.com/tvheadend/tvheadend/commit/f9910c065b9f080dbfd03728501effa6197dfbbe))
+
+* Make builds parallel and add bookworm and ubuntu 24.04 builds ([2024-06-06 14:19:17](https://github.com/tvheadend/tvheadend/commit/f159f6aec04526c20837fe43c1c7ba9117555955))
+
+* Add current pcloud cert ([2024-06-06 14:19:17](https://github.com/tvheadend/tvheadend/commit/ccc0a8e5ff904bf5f06d430378d0be9f3235b39f))
+
+* Always compile x265 as PIC ([2024-06-06 14:19:17](https://github.com/tvheadend/tvheadend/commit/552f9414e26f1d1d80440881da44c24db6968b5d))
+
+* Update libx264 ([2024-06-06 14:19:17](https://github.com/tvheadend/tvheadend/commit/504d0328743312e4a15f0f31be1fc4f64239e06a))
+
+* Update libogg and libfdkaac ([2024-06-06 14:19:17](https://github.com/tvheadend/tvheadend/commit/45033919aeeb10acd9f21a52ed53b89065eaec27))
+
+* Update nasm ([2024-06-06 14:19:17](https://github.com/tvheadend/tvheadend/commit/2eba40c99c974347271b813af488917c17a077d8))
+
+* [Extend CORS origin help/hover message ](#user-content-fn-104)[^104] ([2024-06-06 13:11:26](https://github.com/tvheadend/tvheadend/commit/e6b1d5ffbaa59956aeea7a9ace2410638cbcc211))
+
+* [Nightly build 4.3-2326](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2326*) (2024-06-06)
+
+* [dvr: Added missing directory to rerecord-entry](#user-content-fn-105)[^105] ([2024-06-06 06:16:39](https://github.com/tvheadend/tvheadend/commit/6c5c8eae494943b7749b3fc9ee58a30ab1983bf4))
+
+* [Nightly build 4.3-2325](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2325*) (2024-06-06)
+
+* [Nightly build 4.3-2324](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2324*) (2024-06-05)
+
+* [tvhdhomerun: Add ISDB to type check in tvhdhomerun_device_create](#user-content-fn-106)[^106] ([2024-06-05 21:50:23](https://github.com/tvheadend/tvheadend/commit/3ac184725c3d4b58aa6cd15691e6fab6a0d22e07))
+
+* [Docker/Alpine: Remove USB group](#user-content-fn-107)[^107] ([2024-06-05 21:47:14](https://github.com/tvheadend/tvheadend/commit/5432361184cc4afa585bf31914e58c0a0eee66ee))
+
+* [Nightly build 4.3-2323](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2323*) (2024-04-26)
+
+* [Fix echo target for superuser file in Debian postinst](#user-content-fn-108)[^108] ([2024-04-26 17:57:22](https://github.com/tvheadend/tvheadend/commit/73a6bd00d29421da04be5e1c41b2097fdc9c148b))
+
+* [Nightly build 4.3-2322](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2322*) (2024-04-26)
+
+* Correct M3U playlist logo tag ([2024-04-26 08:43:40](https://github.com/tvheadend/tvheadend/commit/c42043188e73057cf9f5db0aefaed38f8384bbe8))
+
+* [Nightly build 4.3-2321](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2321*) (2024-04-25)
+
+* Properly escape json in setup ([2024-04-25 20:57:37](https://github.com/tvheadend/tvheadend/commit/aba5e60792177d6a2a867445559f4806973b3258))
+
+* [Nightly build 4.3-2320](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2320*) (2024-04-24)
+
+* [satip: Ignore additional parameters](#user-content-fn-109)[^109] ([2024-04-24 23:14:50](https://github.com/tvheadend/tvheadend/commit/aaccc147ea0aac385241d038fd7f1bd3f6d32d10))
+
+* [configure: fix parsing args if values contain "="](#user-content-fn-110)[^110] ([2024-04-20 23:47:11](https://github.com/tvheadend/tvheadend/commit/a68d340a89a3786c441185698ae999b86d77c777))
+
+* Update WebUI to allow debug/trace subsystem selection from a list. ([2024-04-20 06:44:47](https://github.com/tvheadend/tvheadend/commit/b100585070ef794225397d7b99375a5bef246d46))
+
+* Add subsystems to JSON API. ([2024-04-13 10:31:23](https://github.com/tvheadend/tvheadend/commit/223f83b6ec616e5c254b97dd52bd49106b09e33a))
+
+* [Nightly build 4.3-2316](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2316*) (2024-04-08)
+
+* [Fix detection of unknown version numbers in support/version](#user-content-fn-111)[^111] ([2024-04-08 22:49:35](https://github.com/tvheadend/tvheadend/commit/4874aaa3161fbdd8b9d3abe50fd3fa20b18f8b0b))
+
+* [Nightly build 4.3-2314](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2314*) (2024-03-24)
+
+* [Update manpage](#user-content-fn-112)[^112] ([2024-03-24 13:38:57](https://github.com/tvheadend/tvheadend/commit/ab6ea89b11b1f1a8dcbfd7cfc29d65b3013f2702))
+
+* [webui: Fix year being replaced incorrectly when using custom date format](#user-content-fn-113)[^113] ([2024-03-24 11:52:06](https://github.com/tvheadend/tvheadend/commit/cbaf2b1de79206c311a3967cae5928e65c988daf))
+
+* [Translation for 'pl' updated.](#user-content-fn-114)[^114] ([2024-03-22 10:13:46](https://github.com/tvheadend/tvheadend/commit/c63115464d8f6556fb4cac93ce8740afea1b00d5))
+
+* [Nightly build 4.3-2312](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2312*) (2024-03-18)
+
+* [Translation for 'pl' updated.](#user-content-fn-115)[^115] ([2024-03-18 12:04:22](https://github.com/tvheadend/tvheadend/commit/fd0c8bf5d3053b602d96f3c60121302eadc8c157))
+
+* [Translation for 'pl' updated.](#user-content-fn-116)[^116] ([2024-03-18 12:04:22](https://github.com/tvheadend/tvheadend/commit/fb16d716e88cb8cb35fb03056c8c0ca8cddeaaec))
+
+* [Translation for 'pl' updated.](#user-content-fn-117)[^117] ([2024-03-18 12:04:22](https://github.com/tvheadend/tvheadend/commit/ed4e48bed955b516acd3d4bc8d9395d3dd4ce5e7))
+
+* [Translation for 'pl' updated.](#user-content-fn-118)[^118] ([2024-03-18 12:04:22](https://github.com/tvheadend/tvheadend/commit/ccaa407a13cf86ba5bef391963a547219ab74324))
+
+* [Translation for 'pl' updated.](#user-content-fn-119)[^119] ([2024-03-18 12:04:22](https://github.com/tvheadend/tvheadend/commit/a2127cc121a4b29ff1fd866cf1ae360208e5f391))
+
+* [Translation for 'pl' updated.](#user-content-fn-120)[^120] ([2024-03-18 12:04:22](https://github.com/tvheadend/tvheadend/commit/9a74f3f939612e61382ebfd21fcbd8cebab70dca))
+
+* [Translation for 'pl' updated.](#user-content-fn-121)[^121] ([2024-03-18 12:04:22](https://github.com/tvheadend/tvheadend/commit/50ef73a39566f941efefe71ef4c85c377c9156ae))
+
+* [Translation for 'pl' updated.](#user-content-fn-122)[^122] ([2024-03-18 12:04:22](https://github.com/tvheadend/tvheadend/commit/433b1e975df93e953fdd933fad7b3a346c60db80))
+
+* [Translation for 'pl' updated.](#user-content-fn-123)[^123] ([2024-03-18 12:04:22](https://github.com/tvheadend/tvheadend/commit/2b591b093db66cd130159b1f492d2e112d5eb212))
+
+* [Translation for 'pl' updated.](#user-content-fn-124)[^124] ([2024-03-18 12:04:22](https://github.com/tvheadend/tvheadend/commit/1f6b8b0e738c4b4aba676d3e1258bc3c4a7901b0))
+
+* [Translation for 'pl' updated.](#user-content-fn-125)[^125] ([2024-03-18 12:04:22](https://github.com/tvheadend/tvheadend/commit/19c502b15a91360470ca8212261acbe3f8f79058))
+
+* [Translation for 'pl' updated.](#user-content-fn-126)[^126] ([2024-03-18 12:04:22](https://github.com/tvheadend/tvheadend/commit/1014bb87f7691e6088544156f1fbf207d11ffa54))
+
+* [Nightly build 4.3-2300](https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/?q=version%3A4.3-2300*) (2024-03-14)
+
+* [Update README.md](#user-content-fn-127)[^127] ([2024-03-14 08:20:02](https://github.com/tvheadend/tvheadend/commit/1212b940b584e336da175361d02a5c193a3b65c0))
+
+* CI: remove NODIRTY option as those builds may be dirty ([2024-03-09 21:53:29](https://github.com/tvheadend/tvheadend/commit/79aaa14346d9d40f3728c4b0fdc7b4240da76364))
+
+* Revert accidental package renaming ([2024-03-08 19:42:08](https://github.com/tvheadend/tvheadend/commit/e287b2fc600c9874e72211a97f2200d4e10ca574))
+
+* Improve armv6l-packages and remove various outdated references/commands ([2024-03-08 19:22:58](https://github.com/tvheadend/tvheadend/commit/145efcd4c72d46102d51e06cf9f9c96b6bb40c61))
+
+* [Create special tvheadend-armv6l and tvheadend-dbg-armv6l packages](#user-content-fn-128)[^128] ([2024-03-08 01:43:12](https://github.com/tvheadend/tvheadend/commit/ba3b5e56f2f25efb8298a12b5118843de053813d))
+
+* [Translation for 'pl' updated.](#user-content-fn-129)[^129] ([2024-03-07 04:20:34](https://github.com/tvheadend/tvheadend/commit/5e9feb1a9c65f13bacb7378b623ddda00992964f))
+
+* [Translation for 'pl' updated.](#user-content-fn-130)[^130] ([2024-03-07 04:20:34](https://github.com/tvheadend/tvheadend/commit/4d5166ca4b98299cff7a3d90e2fe44dc5720ad00))
+
+* [Translation for 'pl' updated.](#user-content-fn-131)[^131] ([2024-03-07 04:20:34](https://github.com/tvheadend/tvheadend/commit/0a682e82e1a658c960a9c453fec3fcc2d3d77fd9))
+
+* [update to libvpx 1.14.0-patch](#user-content-fn-132)[^132] ([2024-03-03 20:50:16](https://github.com/tvheadend/tvheadend/commit/9ac61d7677feaf1078e2f3752cd8e580e2e61267))
+
+* Improve autorec duplicate handling ([2024-03-01 03:31:57](https://github.com/tvheadend/tvheadend/commit/a9c6db8acbd85297238771b8b4430435b7994928))
+
+* ci: added more info logging to cloudsmith.sh ([2024-03-01 03:31:33](https://github.com/tvheadend/tvheadend/commit/ae97d5bc57ae551febf342cca9b0c7c927a29d4d))
+
+* [Translation for 'pl' updated.](#user-content-fn-133)[^133] ([2024-03-01 03:31:18](https://github.com/tvheadend/tvheadend/commit/eba8414941efd95435418c6f0fa9b5eaabe1d1b3))
+
+* [Translation for 'pl' updated.](#user-content-fn-134)[^134] ([2024-03-01 03:31:18](https://github.com/tvheadend/tvheadend/commit/a5bafb26e0d92c3f76e0be791ac62ffcd341ae78))
+
+* [Translation for 'pl' updated.](#user-content-fn-135)[^135] ([2024-03-01 03:31:18](https://github.com/tvheadend/tvheadend/commit/7e694e3c0b45423769f914d1212e1f32336579ea))
+
+* Replace broken links, update copyright year ([2024-02-23 23:23:45](https://github.com/tvheadend/tvheadend/commit/ae51d24fe1c50a591d4e25ec76076560a6e2e962))
+
+* [Translation for 'es' updated.](#user-content-fn-136)[^136] ([2024-02-23 19:12:11](https://github.com/tvheadend/tvheadend/commit/dc4150158bb6f3af2a95f91266c1c138b278cfc2))
+
+* [Translation for 'de' updated.](#user-content-fn-137)[^137] ([2024-02-23 19:12:11](https://github.com/tvheadend/tvheadend/commit/af8a49376e103699d56b013ccb0781c6510386d0))
+
+* [Translation for 'pl' updated.](#user-content-fn-138)[^138] ([2024-02-23 19:12:11](https://github.com/tvheadend/tvheadend/commit/8cce99fedbd08c5737d57d8813832d61ac056fa3))
+
+* [Translation for 'pl' updated.](#user-content-fn-139)[^139] ([2024-02-23 19:12:11](https://github.com/tvheadend/tvheadend/commit/8b429efb72f6da7b62878bbb9ceafd14b8d00732))
+
+* [Translation for 'hu' updated.](#user-content-fn-140)[^140] ([2024-02-23 19:12:11](https://github.com/tvheadend/tvheadend/commit/8b04bfec9537d481e279b9617feb13f451076551))
+
+* [Translation for 'cs' updated.](#user-content-fn-141)[^141] ([2024-02-23 19:12:11](https://github.com/tvheadend/tvheadend/commit/80fa520753f2216b4f12fee877511d8fdbbf130d))
+
+* [Translation for 'et' updated.](#user-content-fn-142)[^142] ([2024-02-23 19:12:11](https://github.com/tvheadend/tvheadend/commit/764b582eb96db2f3d06784c0ed95d58a8afbeb08))
+
+* [Translation for 'fr' updated.](#user-content-fn-143)[^143] ([2024-02-23 19:12:11](https://github.com/tvheadend/tvheadend/commit/657c41b42a3d60f025f44a8a74c4c2fc80aebcf7))
+
+* [Translation for 'en_GB' updated.](#user-content-fn-144)[^144] ([2024-02-23 19:12:11](https://github.com/tvheadend/tvheadend/commit/64e6a376532e07823ddb42afd935e6b361e89b93))
+
+* [Translation for 'it' updated.](#user-content-fn-145)[^145] ([2024-02-23 19:12:11](https://github.com/tvheadend/tvheadend/commit/5e59bc8f3cb1ea339fb1dd6475252c06630ab1a7))
+
+* [Translation for 'pt' updated.](#user-content-fn-146)[^146] ([2024-02-23 19:12:11](https://github.com/tvheadend/tvheadend/commit/5d9ef4efed72aaa4e7033d28783cc6bf4809b397))
+
+* [Translation for 'nl' updated.](#user-content-fn-147)[^147] ([2024-02-23 19:12:11](https://github.com/tvheadend/tvheadend/commit/38c3c281a5c0102aab0a50f2eae16fb1171a02dc))
+
+* [Translation for 'ko' updated.](#user-content-fn-148)[^148] ([2024-02-23 19:12:11](https://github.com/tvheadend/tvheadend/commit/2be93efe3cb7899bd697547239127911e663a562))
+
+* [Translation for 'en_US' updated.](#user-content-fn-149)[^149] ([2024-02-23 19:12:11](https://github.com/tvheadend/tvheadend/commit/13b1c04093284675bae7a1d669ad1e113359b4af))
+
+* Give comment-on-labels.yml permissions to write to PRs ([2024-02-22 13:40:36](https://github.com/tvheadend/tvheadend/commit/7acca01c4153adc1dd409c82f27338fdeb353045))
+
+* Add OpenCollective donate link to Wizard ([2024-02-22 07:09:32](https://github.com/tvheadend/tvheadend/commit/60bd9dce6a10f80c09cc30b1be82825e0f1f805b))
+
+* [Translation for '(#1655)' updated.](#user-content-fn-150)[^150] ([2024-02-22 05:01:40](https://github.com/tvheadend/tvheadend/commit/9b88c25022f84c886232d60bc62bc6e6bfd47fb8))
+
+* Run enforce-pr-rebase whenever a PR is updated ([2024-02-21 20:25:51](https://github.com/tvheadend/tvheadend/commit/a8f525f36ca777345218726269ea2bb8ef1cbd43))
+
+* Fix Auto-PR comment on squash-label ([2024-02-21 20:24:36](https://github.com/tvheadend/tvheadend/commit/0d26809e39c41bead3aef33fd4a815512aa312ab))
+
+* [Make sure we spawn the best matching executable and not the first match](#user-content-fn-151)[^151] ([2024-02-21 13:41:02](https://github.com/tvheadend/tvheadend/commit/e02e812ee550e93cd0aacaa9677036d977c1d94b))
+
+* ci: change CLOUDSMITH_OWNER from a var to a secret ([2024-02-21 12:30:50](https://github.com/tvheadend/tvheadend/commit/41a326bcecd80a2d4c6ca50b0e62af4acea894ba))
+
+* [Translation for 'pl' updated.](#user-content-fn-152)[^152] ([2024-02-20 22:36:39](https://github.com/tvheadend/tvheadend/commit/c723dfa4b927cac9552e544a4e9557767ac17b8f))
+
+* [Translation for 'pl' updated.](#user-content-fn-153)[^153] ([2024-02-20 22:36:39](https://github.com/tvheadend/tvheadend/commit/b8bd1672686f71ad5027a81e48e41eff8bfb11d8))
+
+* [Translation for 'pl' updated.](#user-content-fn-154)[^154] ([2024-02-20 22:36:39](https://github.com/tvheadend/tvheadend/commit/a2c5a039fb4aa8d4c38aa4d1752ed9ebbcd04815))
+
+* [Translation for 'pl' updated.](#user-content-fn-155)[^155] ([2024-02-20 22:36:39](https://github.com/tvheadend/tvheadend/commit/76f4d6809ed52e926a78218e817c6422c4a1beac))
+
+* [Translation for 'pl' updated.](#user-content-fn-156)[^156] ([2024-02-20 22:36:39](https://github.com/tvheadend/tvheadend/commit/3cb8f2bf1e21dce5f88ce7a57a8903d99bd36cec))
+
+* [Translation for 'pl' updated.](#user-content-fn-157)[^157] ([2024-02-20 22:36:39](https://github.com/tvheadend/tvheadend/commit/06451ae9f32aad87f55c38b09dfa2ff9b20886bb))
+
+* Replace poison memset by memset_s to avoid compiler optimizing it out ([2024-02-20 21:17:05](https://github.com/tvheadend/tvheadend/commit/c7a63e7e3b7c15d6f2c1048efafbaaa5a854ea7d))
+
+* Show SeriesLink for AutoRecs ([2024-02-20 10:28:58](https://github.com/tvheadend/tvheadend/commit/771504eb3ea8540cc3c558e8fa91aa67acd6f350))
+
+* Add some ERRNOs for DVR & Config ([2024-02-20 10:27:41](https://github.com/tvheadend/tvheadend/commit/df46dea3524b313bfeffa60dbeb42b4c93d44099))
+
+* Shorten time for stale issues before a warning is applied ([2024-02-19 23:00:37](https://github.com/tvheadend/tvheadend/commit/595bbaad56dba7c19eed54ced143d1c58c362c81))
+
+* [Add missing tvheadend-prefix in JS file](#user-content-fn-158)[^158] ([2024-02-19 22:32:44](https://github.com/tvheadend/tvheadend/commit/c3a7ce11cec531f8eebaa9f9391e60379533cbe2))
+
+* Add support for 12-hour custom date formats ([2024-02-19 18:07:01](https://github.com/tvheadend/tvheadend/commit/2ca8a19e4c8761af1a6653fed09af658e9cd5b67))
+
+* Add missing htmsg_destroy() call in hdhomerun_server_discover ([2024-02-19 11:10:42](https://github.com/tvheadend/tvheadend/commit/4430ee70f2a2888853d944fe7de619e51880f515))
+
+* [Replace single-bit signed integers with unsigned integers](#user-content-fn-159)[^159] ([2024-02-19 09:44:57](https://github.com/tvheadend/tvheadend/commit/2b0b6a4c4c82adeaed9793f574e39247473c43e1))
+
+* [ci: Enforce rebasing PRs before merging](#user-content-fn-160)[^160] ([2024-02-19 02:16:54](https://github.com/tvheadend/tvheadend/commit/15e1e3f08026e98047bc7d1ff50aeb306f797234))
+
+* [Translation for 'pl' updated.](#user-content-fn-161)[^161] ([2024-02-18 16:00:27](https://github.com/tvheadend/tvheadend/commit/e4a495486a43e9a4623574e15b6cbb818ae84514))
+
+* [Translation for 'pl' updated.](#user-content-fn-162)[^162] ([2024-02-18 16:00:27](https://github.com/tvheadend/tvheadend/commit/d98312dac6507746c55216f5a8f23e6bd3ec2d47))
+
+* [Translation for 'pl' updated.](#user-content-fn-163)[^163] ([2024-02-18 16:00:27](https://github.com/tvheadend/tvheadend/commit/bdaf0f32397072b0b8c5fdbed21ee9dba5c50005))
+
+* [Translation for 'pl' updated.](#user-content-fn-164)[^164] ([2024-02-18 16:00:27](https://github.com/tvheadend/tvheadend/commit/828d43861a991208b4ddbd46c2e0335ddb0dd90c))
+
+* [Translation for 'pl' updated.](#user-content-fn-165)[^165] ([2024-02-18 16:00:27](https://github.com/tvheadend/tvheadend/commit/6372bd0d753865ae90bcdfa5abd723be3827497a))
+
+* [Translation for 'pl' updated.](#user-content-fn-166)[^166] ([2024-02-18 16:00:27](https://github.com/tvheadend/tvheadend/commit/2962b4318c29b2aafc5da1fb9ebbddfb1e34aaea))
+
+* [bouquet: Allow merging of services across network bouquet, fixes #5617](#user-content-fn-167)[^167] ([2024-02-18 15:27:51](https://github.com/tvheadend/tvheadend/commit/b0be01cb034f16a59ee449ac365c953165b0c61b))
+
+* ci: Use correct version of merge commit block action ([2024-02-18 08:37:56](https://github.com/tvheadend/tvheadend/commit/075e6cdf7fe9169a8a862b5d9795c5917a3993a9))
+
+* ci: Block merge or autosquash commits in PRs ([2024-02-17 23:59:55](https://github.com/tvheadend/tvheadend/commit/757eaa92a5ed6d538a08807b1170cb1e5407c354))
+
+* docs: Fix broken Readme.md badge for builds ([2024-02-17 23:31:03](https://github.com/tvheadend/tvheadend/commit/c53b0f5bb013e1d186988d2b1067c0fb58277034))
+
+* Add automatic labels to PRs ([2024-02-17 13:54:58](https://github.com/tvheadend/tvheadend/commit/d85be496a68a8e946c8c21754657f407fa52c04e))
+
+* Remove broken codeball ([2024-02-17 13:48:14](https://github.com/tvheadend/tvheadend/commit/3ca673c8a363d5103d15c72f0573ff47c4c4d222))
+
+* [Translation for 'pl' updated.](#user-content-fn-168)[^168] ([2024-02-17 12:20:03](https://github.com/tvheadend/tvheadend/commit/d37022cf78aae6ab863cca91ba299d582d846a52))
+
+* [Translation for 'pl' updated.](#user-content-fn-169)[^169] ([2024-02-17 12:20:03](https://github.com/tvheadend/tvheadend/commit/abe4081e4264ea49bc7f3571264fb9f8c6fa3458))
+
+* [Translation for 'pl' updated.](#user-content-fn-170)[^170] ([2024-02-17 12:20:03](https://github.com/tvheadend/tvheadend/commit/92ae05a5e1ea7f4724ad77c5c296e0e7e865441e))
+
+* [Translation for 'pl' updated.](#user-content-fn-171)[^171] ([2024-02-17 12:20:03](https://github.com/tvheadend/tvheadend/commit/7435051aa5ae7ba16a43269dc3788b7d7630b62c))
+
+* [Translation for 'pl' updated.](#user-content-fn-172)[^172] ([2024-02-17 12:20:03](https://github.com/tvheadend/tvheadend/commit/6a40d60d8f925f3e14470a5c0cc5a549914d09a1))
+
+* [Translation for 'pl' updated.](#user-content-fn-173)[^173] ([2024-02-17 12:20:03](https://github.com/tvheadend/tvheadend/commit/00394f8068fa29a385b991c02570a3b8305a4204))
+
+* [intl: update translation templates from code](#user-content-fn-174)[^174] ([2024-02-16 21:56:26](https://github.com/tvheadend/tvheadend/commit/ccb8b5e2d0260ad40f7e7fde4dbe655f7704b96e))
+
+* ci: use CURL for cloudsmith.sh and enable RPM upload ([2024-02-15 16:54:56](https://github.com/tvheadend/tvheadend/commit/4c1a1d26e786175352c891836a25e16e893d12cc))
+
+* [CI: Ensure we clone the whole repo](#user-content-fn-175)[^175] ([2024-02-11 22:56:21](https://github.com/tvheadend/tvheadend/commit/6b5defc76d71c184a5a7a5e82f2a9c0eaf3a65f3))
+
+* [container: Add container support](#user-content-fn-176)[^176] ([2024-02-10 17:52:05](https://github.com/tvheadend/tvheadend/commit/ce429efe9bc48acd31cfb9f2e971fa3094a7f147))
+
+* [transcoding: access the codec name only when codec pointer is valid](#user-content-fn-177)[^177] ([2024-02-09 22:20:24](https://github.com/tvheadend/tvheadend/commit/a2ddd30661058955dd1ac3ff9e59b49dc4188bb6))
+
+* [dvr: Fix incorrect usage of `strerror`](#user-content-fn-178)[^178] ([2024-02-08 01:10:31](https://github.com/tvheadend/tvheadend/commit/b91587037c6099e77d233877162e36138c62e5b2))
+
+* [Add "recordings" to the backup exclude list](#user-content-fn-179)[^179] ([2024-02-07 04:57:04](https://github.com/tvheadend/tvheadend/commit/8bd13ca278f3826826a0eeedf9ab1bce951b4244))
+
+* [Correct description of Change Parameters flag](#user-content-fn-180)[^180] ([2024-02-06 20:58:41](https://github.com/tvheadend/tvheadend/commit/63c41acc6ec404e202cf0e4f79cbbefd0daae895))
+
+* descrambler: Fix Sky-UK descrambling ([2024-02-05 23:22:09](https://github.com/tvheadend/tvheadend/commit/6409a6382f1ded18cd6f21649519879c410eb8ab))
+
+* [Translation for 'pt' updated.](#user-content-fn-181)[^181] ([2024-02-05 11:44:13](https://github.com/tvheadend/tvheadend/commit/d944d87a0c2f599619b6f1e227da767ff267e9e3))
+
+* [Translation for 'pt' updated.](#user-content-fn-182)[^182] ([2024-02-05 11:44:13](https://github.com/tvheadend/tvheadend/commit/d784d52ef7f0f9bc0881086b0e8c963bda7df2da))
+
+* [Translation for 'pt' updated.](#user-content-fn-183)[^183] ([2024-02-05 11:44:13](https://github.com/tvheadend/tvheadend/commit/a793cc95323d1b22ff722c71c248897cee4a2af4))
+
+* [Translation for 'pt' updated.](#user-content-fn-184)[^184] ([2024-02-05 11:44:13](https://github.com/tvheadend/tvheadend/commit/5f2e23e2eae9584cdaff2a199c5d0625dccd14ee))
+
+* [Translation for 'pt' updated.](#user-content-fn-185)[^185] ([2024-02-05 11:44:13](https://github.com/tvheadend/tvheadend/commit/4b70198205232a5e80786b33339cc44f2250f6b4))
+
+* [Translation for 'en_US' updated.](#user-content-fn-186)[^186] ([2024-02-05 11:44:13](https://github.com/tvheadend/tvheadend/commit/154cf25ada0da959e4ca3ab2353fcbf87bcec4cb))
+
+* [Translation for 'pt' updated.](#user-content-fn-187)[^187] ([2024-02-05 11:44:13](https://github.com/tvheadend/tvheadend/commit/14bffd8f854fbc3d4664ab704f5cc2c3c6746fb2))
+
+* [satipcli: Rename flag to include client reference](#user-content-fn-188)[^188] ([2024-02-04 00:29:25](https://github.com/tvheadend/tvheadend/commit/9b00888e319c412a2a91008b1f78f4482975b879))
+
+* Remove sweep-ai again as it is not useful at all ([2024-02-03 20:56:39](https://github.com/tvheadend/tvheadend/commit/5acf42462141e26d2c5114c59b672c5f6cec634b))
+
+* Mark PRs needing squashing as stale after a while ([2024-02-03 20:55:17](https://github.com/tvheadend/tvheadend/commit/f12919042c60566e3dd90d58940e3add60550e7a))
+
+* Automatically comment on PRs needing squash ([2024-02-03 20:39:35](https://github.com/tvheadend/tvheadend/commit/ac4a041e00529ba5325755061cd6caef0e3e8210))
+
+* Fix audio-only timeshift memory usage ([2024-02-03 20:29:48](https://github.com/tvheadend/tvheadend/commit/990b5a8f41dd9c0c039d4ce551e35809a4acbb22))
+
+* Sanitize filename in content-disposition header ([2024-02-03 19:56:50](https://github.com/tvheadend/tvheadend/commit/154b202288701013be926d5c13b205504483db93))
+
+* [Clean up Debian postinst and postrm scripts](#user-content-fn-189)[^189] ([2024-02-02 21:54:00](https://github.com/tvheadend/tvheadend/commit/b225e4d6ccb966824f453aeabbd311799d24b471))
+
+* [Fix handling of legacy configuration directories in debian/postinst](#user-content-fn-190)[^190] ([2024-02-02 21:54:00](https://github.com/tvheadend/tvheadend/commit/360ece9f140f2498138c3a169363dc9c6cb4add6))
+
+* [Configure Sweep (#1612)](#user-content-fn-191)[^191] ([2024-02-02 00:49:47](https://github.com/tvheadend/tvheadend/commit/c7f46ec5650ce7dda0b4f60bdb02b6996efff368))
+
+* Add stale-bot for issues/PRs needing more info ([2024-02-02 00:18:44](https://github.com/tvheadend/tvheadend/commit/8ceb72f9307371da3318ac2efea768a683548b2b))
+
+* [main: Warn about unexpected configuration location](#user-content-fn-192)[^192] ([2024-02-02 00:00:05](https://github.com/tvheadend/tvheadend/commit/0485cf470b64d3cfcc5a4e62c711789ff316cea8))
+
+* [Use sigaction() instead of signal()](#user-content-fn-193)[^193] ([2024-02-01 00:39:39](https://github.com/tvheadend/tvheadend/commit/717056be02e1d1754bc86948c8523964c5ea0f1c))
+
+* Add timeshift support for audio-only channels ([2024-01-31 12:41:51](https://github.com/tvheadend/tvheadend/commit/bcfbe7dbeebb79c08fad22a214ecbfbbd426a3bd))
+
+* [templates: add log section to bug_report.yml](#user-content-fn-194)[^194] ([2024-01-31 06:53:43](https://github.com/tvheadend/tvheadend/commit/af5e2c962a3ac7a170f343ef3beb9bdf18f34a93))
+
+* Add missing Lithuanian string template (#1608) ([2024-01-30 13:01:20](https://github.com/tvheadend/tvheadend/commit/6229a74aa08cc41fae2f64864543f961809531f1))
+
+* ci: fix cloudsmith.sh & add to CI workflow ([2024-01-28 16:04:24](https://github.com/tvheadend/tvheadend/commit/212e85c91e6138af58e9757fdb8893e1685d0cb5))
+
+* [src: filesystem permission fixes](#user-content-fn-195)[^195] ([2024-01-24 16:44:41](https://github.com/tvheadend/tvheadend/commit/7b762336e1a4f7cfdc154d394fb17b1a26659cf1))
+
+* [templates: add bug_report.yml](#user-content-fn-196)[^196] ([2024-01-23 13:02:20](https://github.com/tvheadend/tvheadend/commit/e1dc30088df8e313f1ba102be79d1658332628bd))
+
+* [templates: add config.yml](#user-content-fn-197)[^197] ([2024-01-23 13:02:20](https://github.com/tvheadend/tvheadend/commit/88e83bb81769c3ad87ed94c15a39a7a94a5160fe))
+
+* [templates: add feature_proposal.yml](#user-content-fn-198)[^198] ([2024-01-23 13:02:20](https://github.com/tvheadend/tvheadend/commit/5cdc6cb1c3dfbb9f6edc051431e62fa2cf91eef8))
+
+* ci: fix broken cloudsmith python ([2024-01-23 00:48:55](https://github.com/tvheadend/tvheadend/commit/bebc91b7f349d56536ea94e8a12c0445f9657f41))
+
+* ci: fix cloudsmith for python3.5 ([2024-01-22 13:33:53](https://github.com/tvheadend/tvheadend/commit/e954d1661da3b32d4ac52e8a365444453a9b83ed))
+
+* [update to ffmpeg 6.1.1](#user-content-fn-199)[^199] ([2024-01-21 13:23:33](https://github.com/tvheadend/tvheadend/commit/b7d5a1632f3088368ade07bce7412f46968e9ae9))
+
+* descrambler: apply ICAM update from Chris230291 ([2024-01-11 13:04:55](https://github.com/tvheadend/tvheadend/commit/c9b38a81aa3d3a379d8b41cc0ffab1307304da48))
+
+* descrambler: avoid dlopen() ([2024-01-11 13:04:08](https://github.com/tvheadend/tvheadend/commit/b4b1cbd479f3ec3856ed35e5931eab2aff3892fd))
+
+* linuxdvb: add DVB-S2X parameters ([2024-01-05 04:58:31](https://github.com/tvheadend/tvheadend/commit/2151348f7198061a22de3cfc4f4407634554003b))
+
+* descrambler: support ICAM if detected in libdvbcsa ([2024-01-04 23:41:39](https://github.com/tvheadend/tvheadend/commit/899b38ae5b960688b600be3e77526d92cecea536))
+
+* [ci: fix raspios detection in cloudsmith.sh](#user-content-fn-200)[^200] ([2024-01-01 00:24:01](https://github.com/tvheadend/tvheadend/commit/b40a62b31e809523d2fe2f7f3f331cc55dfdbd0f))
+
+* [ci: rename build.yml to reduce confusion](#user-content-fn-201)[^201] ([2023-12-26 08:27:57](https://github.com/tvheadend/tvheadend/commit/fd8b9e8ba21600d0bf6cdb20a7cc153482a2efa5))
+
+* [Makefile.ffmpeg nvenc update](#user-content-fn-202)[^202] ([2023-12-18 08:42:37](https://github.com/tvheadend/tvheadend/commit/4825b8414fc276ee74e9d0c3ebf5eaf09825d6b6))
+
+* [Transifex updates for project Tvheadend (#1587)](#user-content-fn-203)[^203] ([2023-12-13 18:42:47](https://github.com/tvheadend/tvheadend/commit/0da7fc0b7cf8f0159924d37a8c00b84ca3efdfc2))
+
+* Remove references to Tvheadend Foundation. ([2023-12-13 18:42:08](https://github.com/tvheadend/tvheadend/commit/3cf5acdc714dc025b2246d2395478fcfd058afeb))
+
+* [tfx: fix URLs in tvheadend/c files](#user-content-fn-204)[^204] ([2023-12-11 05:36:50](https://github.com/tvheadend/tvheadend/commit/e80d86fa0621fd9998192e1f6fdecb23ff095cae))
+
+* [tfx: fix URLs in tvheadend/docs files](#user-content-fn-205)[^205] ([2023-12-11 05:36:50](https://github.com/tvheadend/tvheadend/commit/e0d1bbca55c1f3db60c89e79c5c100326816a699))
+
+* [tfx: fix URLs in tvheadend/js files](#user-content-fn-206)[^206] ([2023-12-11 05:36:50](https://github.com/tvheadend/tvheadend/commit/a0bd2b3590a2b059da37439d2445a35cfc796814))
+
+* [hdhomerun: Add HDHomeRun server support for LiveTV only (#4461)](#user-content-fn-207)[^207] ([2023-12-09 20:16:23](https://github.com/tvheadend/tvheadend/commit/3dcb7ecf36666dcb43211a84141b1b645c9ca757))
+
+* Update copyright year and correct current surname ([2023-12-09 20:14:42](https://github.com/tvheadend/tvheadend/commit/f75cb334612885fdd7e8ff74b183e7d30c628e4d))
+
+* github: add FUNDING.yml with OpenCollective link ([2023-12-09 20:14:24](https://github.com/tvheadend/tvheadend/commit/b2fac61fa343e78ce08b885dc63d81d5d30670d4))
+
+* [webui: remove old doc references to paypal](#user-content-fn-208)[^208] ([2023-12-09 20:14:24](https://github.com/tvheadend/tvheadend/commit/7a5f062e9ace148c02715245ef7ef7cf3e56b705))
+
+* [webui: change donation button to opencollective](#user-content-fn-209)[^209] ([2023-12-09 20:14:24](https://github.com/tvheadend/tvheadend/commit/2a23e7f32403aab145efbf701f31e8e2450c1ba1))
+
+* WebUI: Update donation string as a test to Transifex feed ([2023-12-06 21:57:31](https://github.com/tvheadend/tvheadend/commit/d85c957aa2b54c83301361f3d6dc7453def3302d))
+
+* [ci: remove the test-compile workflow](#user-content-fn-210)[^210] ([2023-12-06 07:26:44](https://github.com/tvheadend/tvheadend/commit/49b095e1850435d63c9c2f01f28770fdf46d55dd))
+
+* [ci: schedule weekly coverity scans](#user-content-fn-211)[^211] ([2023-12-06 06:46:46](https://github.com/tvheadend/tvheadend/commit/b3ac61a01badb40320973cfcec978a97c56e6114))
+
+* [ci: add concurrency to the main CI workflows](#user-content-fn-212)[^212] ([2023-12-06 06:46:27](https://github.com/tvheadend/tvheadend/commit/8b34c31f25078c985ac473c4843427c361372a2d))
+
+* [ci: remove references to doozer](#user-content-fn-213)[^213] ([2023-12-06 06:45:16](https://github.com/tvheadend/tvheadend/commit/f96ea64930f4d2191f5df79e1331f28213805463))
+
+* [ci: remove references to travis](#user-content-fn-214)[^214] ([2023-12-06 06:45:16](https://github.com/tvheadend/tvheadend/commit/2b77517d8e127fda422644c498a28aa361e20662))
+
+* [ci: don't trigger cloudsmith on .github changes](#user-content-fn-215)[^215] ([2023-12-06 06:42:32](https://github.com/tvheadend/tvheadend/commit/433cf8bbf55b28b67c25defe2e81c186f11e4ea8))
+
+* Add Parental Rating Labels ([2023-12-05 23:35:06](https://github.com/tvheadend/tvheadend/commit/b061e641bc4f863d4c91340b691672bedd46b035))
+
+* gitignore: add debian/.debhelper folder ([2023-12-01 12:19:35](https://github.com/tvheadend/tvheadend/commit/583de2330416e5122446920ef441c7e11129f92b))
+
+* ci update build config ([2023-12-01 12:15:53](https://github.com/tvheadend/tvheadend/commit/ae1ffbe576742842c55ca3c685d829dd6df975f3))
+
+* update libvpx to 1.13.1 ([2023-11-29 17:12:27](https://github.com/tvheadend/tvheadend/commit/dd884b84054ba663a64734aaa7d98c38658a89bc))
+
+* update x264 to c196240 ([2023-11-29 17:12:27](https://github.com/tvheadend/tvheadend/commit/752af5f2ab169b280d8fe1e7af372e0266151a15))
+
+* update ffmpeg to 6.0.1 ([2023-11-29 17:12:27](https://github.com/tvheadend/tvheadend/commit/1ac062fbfe6d37cc79f649fe31b46e445b6f695e))
+
+* Fix builds on stretch ([2023-11-28 22:27:31](https://github.com/tvheadend/tvheadend/commit/bdadcb8b2bc07a65818a098b5db550bdbbf3caae))
+
+* Add rpi-bookworm to targets ([2023-11-21 13:48:27](https://github.com/tvheadend/tvheadend/commit/bc30a74de8ab5efc3605afd68eb6d01d08170316))
+
+* Update ffmpeg to 5.1.4 ([2023-11-20 22:19:31](https://github.com/tvheadend/tvheadend/commit/2d963dab6289028dd9f252dd41e13d881d6a9f92))
+
+* [Correct handling of Remove and Ignore settings](#user-content-fn-216)[^216] ([2023-10-26 17:53:51](https://github.com/tvheadend/tvheadend/commit/62adbebfd062d7b97829268274aad92df2033784))
+
+* 6310 Set 'okay' default to True ([2023-10-14 20:49:55](https://github.com/tvheadend/tvheadend/commit/2d92f58fadf6b63c0a5a79a52d67f51e85b02be3))
+
+* [Removed nested function 'appendPidRange' from within function 'tvhdhomerun_frontend_update_pids'](#user-content-fn-217)[^217] ([2023-10-14 20:49:23](https://github.com/tvheadend/tvheadend/commit/3d16edb0f59dd974b3924b463efc58be1cb1fac1))
+
+* [Fix non-admin users not receiving any updates in web UI](#user-content-fn-218)[^218] ([2023-10-01 00:12:22](https://github.com/tvheadend/tvheadend/commit/51adc040429c001820a44c6b26825c1bdc19c779))
+
+* [Fix htsstr_argsplit (treat quotes inside an argument correctly)](#user-content-fn-219)[^219] ([2023-09-06 12:07:28](https://github.com/tvheadend/tvheadend/commit/fe4df311d1209ba86d514a34abc0b9c694d53b5f))
+
+* [support/mkbundle: switch from distutils to setuptools](#user-content-fn-220)[^220] ([2023-08-11 23:34:48](https://github.com/tvheadend/tvheadend/commit/ec56067f4f6cb3fae5a03f0fb492c45413d095bb))
+
+* [webui/dvr: Remove unused & duplicated functions](#user-content-fn-221)[^221] ([2023-08-11 23:33:57](https://github.com/tvheadend/tvheadend/commit/db62c0bd467e800fc6aa1702a94672b6bf7697ce))
+
+* [webui/dvr: Add age_rating in recording details dialogs](#user-content-fn-222)[^222] ([2023-08-11 23:33:57](https://github.com/tvheadend/tvheadend/commit/21911b5e37a20b6f2a10ef48a93ccf7bf2dd179c))
+
+* Fix bug #6293 – Missing EIT EPG Content Type ([2023-08-09 15:01:01](https://github.com/tvheadend/tvheadend/commit/76ca76761693eb7c1f347e79d271618f08ec3824))
+
+* Fix some build and add more targets ([2023-08-08 08:15:47](https://github.com/tvheadend/tvheadend/commit/6e352c6c7871d434f9b022f7f203c31e9609121b))
+
+* [otamux: Make sure we use PRItime_t](#user-content-fn-223)[^223] ([2023-08-06 07:39:22](https://github.com/tvheadend/tvheadend/commit/17eebbef5b017352afcded36c27cb0be11ebd4a1))
+
+* [Use explicitly on format warnings for Time test](#user-content-fn-224)[^224] ([2023-08-06 07:39:05](https://github.com/tvheadend/tvheadend/commit/2375a63a118797bb0dbac9d71740a5351dd49f3d))
+
+* [CI: Run the full build with cloudsmith only on master](#user-content-fn-225)[^225] ([2023-08-05 18:16:54](https://github.com/tvheadend/tvheadend/commit/ac6caf3b1117a80fb30d528767c0d55635ba2cb4))
+
+* [CI: Build (without cloudsmith) all targets on every merge request](#user-content-fn-226)[^226] ([2023-08-05 18:16:54](https://github.com/tvheadend/tvheadend/commit/1179ce28a530ac48358266e8c46cb9b06e5f71c6))
+
+* [Fix time for old 32bit systems](#user-content-fn-227)[^227] ([2023-08-04 15:23:03](https://github.com/tvheadend/tvheadend/commit/1c22d866f336d4d38dc0679a0cb03b11237c48fc))
+
+* Add 'age rating' field to recording metadata ([2023-08-02 17:15:36](https://github.com/tvheadend/tvheadend/commit/d50105999522cc7c35909f7c0f2a504fc40c2e1b))
+
+* [Fix time for 32bit systems again](#user-content-fn-228)[^228] ([2023-07-30 15:18:22](https://github.com/tvheadend/tvheadend/commit/fe47ecb5504a521fed9c1ca9705fb0dd2bb8443a))
+
+* OTA Genre translation squashed v2 ([2023-07-30 15:17:18](https://github.com/tvheadend/tvheadend/commit/23263a54d9bbda2779489c06d3aa909ec618ad63))
+
+* Bug Fix: OTA EIT Parental Rating ([2023-07-19 19:53:15](https://github.com/tvheadend/tvheadend/commit/c531383ca6654639dc112db67fd8dc893c1f5272))
+
+* Revert non-portable function to previous code ([2023-06-25 09:30:11](https://github.com/tvheadend/tvheadend/commit/14298acb6a8e3a83ed1091fab1f3a924077ddfea))
+
+* [Update Debian packaging to use the new configuration directories](#user-content-fn-229)[^229] ([2023-06-23 11:27:51](https://github.com/tvheadend/tvheadend/commit/9958c34210f21b6a7487e3df899230df3a545489))
+
+* Fix spelling errors encountered during previous work ([2023-06-23 11:27:51](https://github.com/tvheadend/tvheadend/commit/7b5c526977eddfa4535df91ea4e23c8910c69b11))
+
+* [Fix configuration-loading logic to account for forking operation](#user-content-fn-230)[^230] ([2023-06-23 11:27:51](https://github.com/tvheadend/tvheadend/commit/612b615ffd8adfd33f905cf15b67ff817cc59c20))
+
+* [config: Fix whitespace errors](#user-content-fn-231)[^231] ([2023-06-21 09:17:24](https://github.com/tvheadend/tvheadend/commit/f28e69a5f1f24da7a973a6ef1dec9f7beece2acc))
+
+* [Fix portability: Do not use linux/limits.h](#user-content-fn-232)[^232] ([2023-06-21 09:17:24](https://github.com/tvheadend/tvheadend/commit/a9b83afb2d6badaa01ab2b964f0285b7206bf52c))
+
+* [dvr_storage: Also support server configurations for recordings](#user-content-fn-233)[^233] ([2023-06-21 09:17:24](https://github.com/tvheadend/tvheadend/commit/335b1255d644d06740758d8a264e4864b6539e55))
+
+* [spawn: Do not close every possible file descriptor](#user-content-fn-234)[^234] ([2023-06-21 09:16:07](https://github.com/tvheadend/tvheadend/commit/85360356660a11e5c7a65274d58e5f4945f83f5f))
+
+* [config: Support server configurations](#user-content-fn-235)[^235] ([2023-06-16 11:11:41](https://github.com/tvheadend/tvheadend/commit/e15c1abe97370b461ed1457b3ac2dc4dff58dbd7))
+
+* [dvr_storage: Use XDG spec directories](#user-content-fn-236)[^236] ([2023-06-16 11:11:41](https://github.com/tvheadend/tvheadend/commit/dbf973307ae34d8a7918b781b9f315ad51ef15a8))
+
+* [config: Store config directory variable internally](#user-content-fn-237)[^237] ([2023-06-16 11:11:41](https://github.com/tvheadend/tvheadend/commit/cf87a5ddba7b439631d2c105879671422d118638))
+
+* [settings: Add XDG support helper functions](#user-content-fn-238)[^238] ([2023-06-16 11:11:41](https://github.com/tvheadend/tvheadend/commit/c00c4eb71d604112da7cbc58f4aee4a8c5a1f0d9))
+
+* [config: Add support for XDG config](#user-content-fn-239)[^239] ([2023-06-16 11:11:41](https://github.com/tvheadend/tvheadend/commit/af49e4bd9066bcba873718cf7dab42235de49982))
+
+* [config: Deal with configuration before anything else](#user-content-fn-240)[^240] ([2023-06-16 11:11:41](https://github.com/tvheadend/tvheadend/commit/04283a9a4ab81ed435f8ee0d36e271e6f51f8418))
+
+* Fix Fedora CI build ([2023-06-15 09:48:53](https://github.com/tvheadend/tvheadend/commit/4c1b4dbcee7fd5eeeec8bf27e5ff2d178ee8bfee))
+
+* Disable broken codeball ([2023-06-12 11:15:07](https://github.com/tvheadend/tvheadend/commit/5f6be407a8e72c45ed4c9178c8b38826bb9a8684))
+
+* [Add simple 'ping' endpoint for healthchecks](#user-content-fn-241)[^241] ([2023-06-11 18:19:44](https://github.com/tvheadend/tvheadend/commit/1705297c27d76848a87cff34dd6bfe7d9d74c87a))
+
+* Update config for Fedora 37/38 ([2023-06-07 11:55:12](https://github.com/tvheadend/tvheadend/commit/cd30663793f7155f93a1dd4977ae096718cf9cd6))
+
+* Add Fedora RPM build to Github Actions ([2023-06-07 11:55:12](https://github.com/tvheadend/tvheadend/commit/9df7d2d6bc37b8aa25ac63be7b0a5d69be10c892))
+
+* [dvr_rec: Fix a buffer overflow in filename generation](#user-content-fn-242)[^242] ([2023-06-05 15:39:14](https://github.com/tvheadend/tvheadend/commit/003fd92707531bdf7ad1753ab028db8748ac5ab8))
+
+* [- fixed bug with _lang3_to_lang2()](#user-content-fn-243)[^243] ([2023-04-19 00:33:05](https://github.com/tvheadend/tvheadend/commit/18effa8ad93e901f3cdaa534123d910f14453d1f))
+
+* [update pict_type from AVPacket to AVFrame](#user-content-fn-244)[^244] ([2023-04-17 23:41:45](https://github.com/tvheadend/tvheadend/commit/e10f98601b8bfee4c6b0093012ce45654666f501))
+
+* [update to ffmpeg 5.1.3](#user-content-fn-245)[^245] ([2023-04-17 23:38:56](https://github.com/tvheadend/tvheadend/commit/8efac01dccdf11b4b3b196080c085aaa801a62f7))
+
+* [update to ffmpeg 5.1.2](#user-content-fn-246)[^246] ([2023-04-08 19:56:27](https://github.com/tvheadend/tvheadend/commit/f32c7c59a19a276648d7b068041738e4e8337638))
+
+* [tv_meta_tvdb.py: Fix 'languague' typo.](#user-content-fn-247)[^247] ([2023-04-08 12:05:40](https://github.com/tvheadend/tvheadend/commit/e0f2d3234a67c6c0c88ac84166ce2626d668e0cf))
+
+* [tvhmeta: Fix tvhmeta authentication to the tvheadend API.](#user-content-fn-248)[^248] ([2023-04-02 00:18:48](https://github.com/tvheadend/tvheadend/commit/a10f7ea4408e5ba2b0f04cc9db970873eafa883c))
+
+* Remove references to CLA which is no longer available ([2023-04-02 00:17:47](https://github.com/tvheadend/tvheadend/commit/543fbee6344514b57366ce7c4fe2e103d2570e55))
+
+* [updated 'AVCodec' to 'const AVCodec'](#user-content-fn-249)[^249] ([2023-04-01 13:31:53](https://github.com/tvheadend/tvheadend/commit/8acd83df2335469216c3f8d07424a3e06486da0b))
+
+* [remove deprecate struct vaapi_context and the vaapi.h](#user-content-fn-250)[^250] ([2023-03-30 15:07:39](https://github.com/tvheadend/tvheadend/commit/247d3d032ce3f609254b3782aa95143eb5dd99f5))
+
+* Remove deprecated get_best_effort_timestamp() call ([2023-03-25 02:32:42](https://github.com/tvheadend/tvheadend/commit/a1cb8cffb1d5af17c9bce2b3ef65319ab984854f))
+
+* [remove ffmpeg component avresample](#user-content-fn-251)[^251] ([2023-03-24 00:09:34](https://github.com/tvheadend/tvheadend/commit/ef13a600afb35905ddfa84447073c016d320c185))
+
+* [iconv: Allow using GNU libiconv](#user-content-fn-252)[^252] ([2023-03-23 02:24:42](https://github.com/tvheadend/tvheadend/commit/21a5c6399aaba600886f1bc1ad0ce79d454b8ba8))
+
+* [remove unused function and migrate from AVBitStreamFilterContext to AVBSFContext](#user-content-fn-253)[^253] ([2023-03-23 02:24:20](https://github.com/tvheadend/tvheadend/commit/0acb338a762afbd46658fadc55ae3e6827c5b73a))
+
+* [update to ffmpeg codecpar](#user-content-fn-254)[^254] ([2023-03-23 02:23:04](https://github.com/tvheadend/tvheadend/commit/933ae5f767ea4ddd08656f59b8cc973756b59342))
+
+* [Revert "fix for 64bit time_t on 32bit systems"](#user-content-fn-255)[^255] ([2023-03-14 00:11:52](https://github.com/tvheadend/tvheadend/commit/9e1eb89be731ffb4687327c09b2de3bf58f548cf))
+
+* fix for 64bit time_t on 32bit systems ([2023-03-08 02:13:09](https://github.com/tvheadend/tvheadend/commit/76a6263f1be4e3ccff968b47155b050fcc15f042))
+
+* [update NASM to 2.16.01](#user-content-fn-256)[^256] ([2023-03-06 12:27:05](https://github.com/tvheadend/tvheadend/commit/5aa50b12fc4bab29855edba8557f0ad8fe26e2d1))
+
+* [update vaapi](#user-content-fn-257)[^257] ([2023-03-06 01:35:55](https://github.com/tvheadend/tvheadend/commit/cfb20ca688995e690f58528379619827263bbce2))
+
+* Don't attempt to approve PRs automatically ([2023-03-06 01:09:08](https://github.com/tvheadend/tvheadend/commit/508de087216e8918cdc45fbcf30a9efeb5fe5654))
+
+* Codeball should also label PRs that need review ([2023-03-05 02:57:06](https://github.com/tvheadend/tvheadend/commit/39df64bb8e8888db0817e133b50b7f4823a69489))
+
+* Fix for DVB Grabber and IPTV Stream ([2023-02-24 11:22:55](https://github.com/tvheadend/tvheadend/commit/d1366a0669c785141a128678a671c008abd1fb5a))
+
+* RTSP redirect support fix and moved to http client ([2023-02-24 11:22:35](https://github.com/tvheadend/tvheadend/commit/061cf95b148680cc01689f1f49d10d3977bda15d))
+
+* Use codeball for PRs ([2023-02-21 04:13:18](https://github.com/tvheadend/tvheadend/commit/44bf691ac3c4abe3b11dc284ace84d863db376e3))
+
+* [update to ffmpeg codecpar](#user-content-fn-258)[^258] ([2023-02-20 23:53:37](https://github.com/tvheadend/tvheadend/commit/2f3e53380bff7fb7a571de438d3fc541139259cc))
+
+* [update ffmpeg from 4.4.1 to 4.4.3](#user-content-fn-259)[^259] ([2023-02-12 22:19:10](https://github.com/tvheadend/tvheadend/commit/02987438db97e54a39491853099db7ead4d50eb3))
+
+* [update vaapi](#user-content-fn-260)[^260] ([2023-02-10 00:32:57](https://github.com/tvheadend/tvheadend/commit/470f02fb3f00d3f88e61303cd5db7ec303d0145d))
+
+* [update vaapi](#user-content-fn-261)[^261] ([2023-02-05 16:32:00](https://github.com/tvheadend/tvheadend/commit/becc74b2874a43007709952950e03fd137e0d8bb))
+
+* [Fix Coverity-Build  (#1499)](#user-content-fn-262)[^262] ([2023-01-28 23:40:03](https://github.com/tvheadend/tvheadend/commit/060df517c16537da69fd0717f52254ff7477398f))
+
+* [Revert "Update debian/compat to version 10"](#user-content-fn-263)[^263] ([2023-01-28 19:16:03](https://github.com/tvheadend/tvheadend/commit/bed37ea208b8acaf914b4fb14498d143a1fbbd93))
+
+* [Ignore title mismatch if dup checking by CRID](#user-content-fn-264)[^264] ([2023-01-27 00:24:01](https://github.com/tvheadend/tvheadend/commit/905b4f0d0387818cbbf7012bf4dffb25e9893748))
+
+* [Update debian/compat to version 10](#user-content-fn-265)[^265] ([2023-01-24 16:36:07](https://github.com/tvheadend/tvheadend/commit/2a370dd17fcac7e587d45fd9971e346536379ea3))
+
+* Unify names and order of Unicable-specific configuration fields ([2023-01-24 02:43:52](https://github.com/tvheadend/tvheadend/commit/dde8856982c4293a1f9c8686b08f752e6e504dcc))
+
+* [Add configurable delays after Unicable operations](#user-content-fn-266)[^266] ([2023-01-24 02:43:52](https://github.com/tvheadend/tvheadend/commit/b70f3b3f12b4398cfdf18fb311e9e57abcf86260))
+
+* [Unify command time range to 10-300 ms](#user-content-fn-267)[^267] ([2023-01-24 02:43:52](https://github.com/tvheadend/tvheadend/commit/5948200c7e04ebeab28efb3285d3f13e11df20ca))
+
+* Add descriptions to the existing Unicable configuration fields ([2023-01-24 02:43:52](https://github.com/tvheadend/tvheadend/commit/377c108194292abdaf71ff26b7527412c4f7a0aa))
+
+* [Unify power up time range to 10-500 ms](#user-content-fn-268)[^268] ([2023-01-24 02:43:52](https://github.com/tvheadend/tvheadend/commit/1620218ed01600bbc1784528a10f0723a998a741))
+
+* [update vaapi](#user-content-fn-269)[^269] ([2023-01-23 11:37:33](https://github.com/tvheadend/tvheadend/commit/0adacbdf18f018c9167bbceacc2d5ebb756688e2))
+
+* [descrambler: cccam: move send keepalive message to traces](#user-content-fn-270)[^270] ([2023-01-23 11:08:00](https://github.com/tvheadend/tvheadend/commit/8082b104aecd7f2bbac3b16b853be50c902cefb3))
+
+* [descrambler: cccam - simplify cccam_handle_keys()](#user-content-fn-271)[^271] ([2023-01-23 09:56:28](https://github.com/tvheadend/tvheadend/commit/b8b6d5eba112a9ace28db4ebee12c4b6154327c7))
+
+* [descrambler: cclient: optimization for multiple key clients](#user-content-fn-272)[^272] ([2023-01-23 08:40:01](https://github.com/tvheadend/tvheadend/commit/d3cd3d66795df59ca41294a8008b751782f2b948))
+
+* [descrambler: cosmetic cleanups, more CAID logs](#user-content-fn-273)[^273] ([2023-01-23 08:38:09](https://github.com/tvheadend/tvheadend/commit/c32ace5a81e86856b3ecb29fa5e0abc170d13182))
+
+* [descrambler: cwc: do not register bad provider numbers for betacrypt and irdeto](#user-content-fn-274)[^274] ([2023-01-22 16:12:29](https://github.com/tvheadend/tvheadend/commit/3a12b3f99bc31a3217e3e2de96f3a62dac137735))
+
+* [descrambler: cwc: Fix the additional card registration (mgclient option in o*s*c*a*m)](#user-content-fn-275)[^275] ([2023-01-22 15:52:07](https://github.com/tvheadend/tvheadend/commit/36c1d65d9d3d6319cde25c76cb3340ed065e8e94))
+
+* grammar: Replace "then" with "than" ([2023-01-17 02:32:34](https://github.com/tvheadend/tvheadend/commit/760f32bf531e15346a40cef864f87edd5bae9681))
+
+* [Preserve existing Unicable idnode during the set operation](#user-content-fn-276)[^276] ([2023-01-17 02:32:34](https://github.com/tvheadend/tvheadend/commit/11358ba2537c988c940a46500434417b7cf98f0f))
+
+* [updated function _video_filters_get_filters()](#user-content-fn-277)[^277] ([2023-01-14 13:09:50](https://github.com/tvheadend/tvheadend/commit/576ae16a1c4db90db262c671df5f703ff5d23d0b))
+
+* [profile video resize improvements](#user-content-fn-278)[^278] ([2023-01-14 02:04:22](https://github.com/tvheadend/tvheadend/commit/1eeb608033804c3b5b35c842389f276cde299600))
+
+* [Add autorec duplicate handling default to dvr config.](#user-content-fn-279)[^279] ([2023-01-10 19:19:09](https://github.com/tvheadend/tvheadend/commit/cc602833684953fc3e6f1c89d4f08f6dfef179e3))
+
+* [update vaapi](#user-content-fn-280)[^280] ([2023-01-10 19:18:39](https://github.com/tvheadend/tvheadend/commit/6a6c9b7240ae4d19a8d57dd7e4a9428c326a68de))
+
+* remove libavresample from build scripts ([2023-01-10 01:56:02](https://github.com/tvheadend/tvheadend/commit/17a357fee8bccacd931476411200b05f2b06f47c))
+
+* Add amd64 jammy to builds ([2023-01-04 14:48:38](https://github.com/tvheadend/tvheadend/commit/2beb6c9c889d840f232379db52cd3363e23a5b1f))
+
+* Fix a few more builds, add kinetic support ([2022-12-21 18:37:10](https://github.com/tvheadend/tvheadend/commit/c9a156a25a07f1f84c2f48a1b03b481430c8257d))
+
+* Allow old builds to pass ([2022-12-21 00:57:32](https://github.com/tvheadend/tvheadend/commit/cdd2af4bd30d8f873fb3f66c2543bd6d3f758719))
+
+* Build for kinetic instead of impish ([2022-12-21 00:34:08](https://github.com/tvheadend/tvheadend/commit/44a202b9232f141bd36e617c138d6efb653d7fd3))
+
+* Remove variable declaration from for-loop ([2022-12-17 18:54:07](https://github.com/tvheadend/tvheadend/commit/81c986d553277e0275b8ce47749a7fb0388b455d))
+
+* Don't fail on strict aliasing violations ([2022-12-17 18:46:41](https://github.com/tvheadend/tvheadend/commit/b45571d42e9a08f45d18e368a754d4d82d047d29))
+
+* [Don't confuse GCC with zero-length array](#user-content-fn-281)[^281] ([2022-12-10 23:17:42](https://github.com/tvheadend/tvheadend/commit/abcb0ea676e7b7e822be990aae7df1aa8ff5b990))
+
+* [config: Enable HbbTV parser by default](#user-content-fn-282)[^282] ([2022-11-28 21:32:36](https://github.com/tvheadend/tvheadend/commit/d8854960361b0fb6846f0912f509dfad61f3ccbf))
+
+* [dvb_psi_pmt: Recognize AC-4 audio descriptor](#user-content-fn-283)[^283] ([2022-11-28 21:32:20](https://github.com/tvheadend/tvheadend/commit/765d3ed4fd0cc87f8b8594b296833f490ae86ebd))
+
+* [Add South Africa to Countries list.](#user-content-fn-284)[^284] ([2022-11-28 20:25:31](https://github.com/tvheadend/tvheadend/commit/eb844deb40cf9a4331c7071e56964f58910c3509))
+
+* [Build various targets and prepare new repository  (#1476)](#user-content-fn-285)[^285] ([2022-11-27 21:03:38](https://github.com/tvheadend/tvheadend/commit/cd8491a5ba3c75c349997357d7751cf0fd83fb53))
+
+* [Avoid breaking strict aliasing in IP_AS_V{4,6}](#user-content-fn-286)[^286] ([2022-11-24 11:55:34](https://github.com/tvheadend/tvheadend/commit/7b95ba4cf9113ae8808b3e4a9425010b607dbaca))
+
+* Remove always-true checks ([2022-11-21 19:47:29](https://github.com/tvheadend/tvheadend/commit/5543ce518faaeeb0677fd7c2fca26f8ae0d265d3))
+
+* Reduce ADTS header size for better compatibility ([2022-11-21 13:03:00](https://github.com/tvheadend/tvheadend/commit/19c3b87c23fe92a5dc8f4b2bf3ccd69111de0d09))
+
+* Don't call epg_broadcast_set_description twice ([2022-11-21 01:33:44](https://github.com/tvheadend/tvheadend/commit/fed1eeb4d120ac2b0f3728bd63280c27ad94834d))
+
+* Serve static html files with mimetype text/html ([2022-11-21 01:33:44](https://github.com/tvheadend/tvheadend/commit/f3376c764c3015279ec1b687bb017292a12d2d82))
+
+* [Simplify IPv6 compare functions to unconfuse gcc compiler](#user-content-fn-287)[^287] ([2022-11-21 01:33:44](https://github.com/tvheadend/tvheadend/commit/c0f616e56bc4df70978a060b72f8c6a7ca487d3f))
+
+* [Use application/json instead of text/x-json as mimetype](#user-content-fn-288)[^288] ([2022-11-21 01:33:44](https://github.com/tvheadend/tvheadend/commit/b881ca6e1d15db012f3470b5412241273a0ebdfe))
+
+* [Don't crash the wizard if tvh has no inputs](#user-content-fn-289)[^289] ([2022-11-21 01:33:44](https://github.com/tvheadend/tvheadend/commit/0b8df3e2d55240d4b21ec5bdf20cc89b4a5e73b2))
+
+* [epgdb: Resolve symlinks before using file location](#user-content-fn-290)[^290] ([2022-11-20 01:09:49](https://github.com/tvheadend/tvheadend/commit/0ff96106aa2e0f9a384c3a2662ca005797a6b399))
+
+* Increase maximum ADTS packet size to match FFMPEG ([2022-11-10 17:31:18](https://github.com/tvheadend/tvheadend/commit/52c3ed3ef17eeccddc6a4cf7c0d7151c2823438f))
+
+* [iptv_auto: Add support for m3u "channel-number" tag](#user-content-fn-291)[^291] ([2022-10-31 21:43:29](https://github.com/tvheadend/tvheadend/commit/1a437c88ea35d28e235b76bf890b227d60e84db4))
+
+* Fix race condition/data corruption in imagecache ([2022-10-27 20:01:31](https://github.com/tvheadend/tvheadend/commit/185013382c1d9a2aee8425746b65b7415802fc29))
+
+* Fix bad mono2sec usage ([2022-10-27 03:30:10](https://github.com/tvheadend/tvheadend/commit/c616fcc0136f79e8b1d502707c451645560520f9))
+
+* [Attempt to fix profile sharer memory leak](#user-content-fn-292)[^292] ([2022-10-27 00:37:00](https://github.com/tvheadend/tvheadend/commit/fc3759a58dd9dc914166262c8b59c2d4f0ed3f53))
+
+* Attempt to fix HBBTV memory leak ([2022-10-26 23:56:57](https://github.com/tvheadend/tvheadend/commit/a2a702b1001828f49e884bcdd81817e21d79eaf8))
+
+* Fix typo ([2022-10-26 22:59:59](https://github.com/tvheadend/tvheadend/commit/e1d4ab791db3845873eb1e906d2a61660b573f55))
+
+* [Revert 4355488b8e1e868cb434bf95676c0944b44e88b3](#user-content-fn-293)[^293] ([2022-10-26 22:58:18](https://github.com/tvheadend/tvheadend/commit/7eb08ba14ca00df3588adffecdaa11b6f6e1e588))
+
+* Close FDs even if no UDP connection is used ([2022-10-26 22:56:01](https://github.com/tvheadend/tvheadend/commit/a2b6a1db5740c174a92fe77292ff5431d2c7782b))
+
+* Fixed typo ([2022-10-26 22:07:46](https://github.com/tvheadend/tvheadend/commit/7a3a88cf7a2e15f1bbe3c68b5b6e3fd12a461831))
+
+* Update regexps for the finnish EIT scraping ([2022-10-16 11:38:20](https://github.com/tvheadend/tvheadend/commit/604d81a29f88b37189b49cf6a2dfe73b1ca546da))
+
+* mpegts dvb: Add support for LCN for provider DigiTV ([2022-10-14 11:18:15](https://github.com/tvheadend/tvheadend/commit/3edbd57246129c99b079cfd6269688430591e0d1))
+
+* output: UDP streaming ([2022-10-07 19:24:18](https://github.com/tvheadend/tvheadend/commit/5f9404117f59ad1f5aa7ca542ce39d9e064e8209))
+
+* Fix potential memory leak ([2022-10-07 19:22:43](https://github.com/tvheadend/tvheadend/commit/d9b76b57e1826240c98dd4b63c3b294bca143486))
+
+* [Ignore PCRE2 illegal accesses](#user-content-fn-294)[^294] ([2022-10-07 18:20:10](https://github.com/tvheadend/tvheadend/commit/81838dbb6cbfcb42cb63dc38aef824c2cabf6817))
+
+* Avoid leaking iptv fd's ([2022-10-07 16:52:14](https://github.com/tvheadend/tvheadend/commit/4355488b8e1e868cb434bf95676c0944b44e88b3))
+
+* [Added support for ATSC text mode == 0x3F](#user-content-fn-295)[^295] ([2022-10-03 22:12:03](https://github.com/tvheadend/tvheadend/commit/8f8877430cfcc9e2bca6d5066241600a8742c1ac))
+
+* Fix FTBFS introduced by 86f3617c8972c5362e51cee7d34cc2d69d799126 ([2022-09-15 11:30:12](https://github.com/tvheadend/tvheadend/commit/4741b3c1901d4c998b1c5ef7c777728b4827e828))
+
+* Fix crash when mpegts_service_refresh tries to open the CAT again ([2022-09-15 00:31:24](https://github.com/tvheadend/tvheadend/commit/86f3617c8972c5362e51cee7d34cc2d69d799126))
+
+* [Added more 'text modes' to the ATSC Multiple String Structure decoder and convert text to UTF-8. (Fixes #5162)](#user-content-fn-296)[^296] ([2022-09-15 00:22:46](https://github.com/tvheadend/tvheadend/commit/d25c19d673136fbf8572e901ed3c3e871e8b6dd4))
+
+* [Allow network scan to modify muxes](#user-content-fn-297)[^297] ([2022-09-03 10:13:02](https://github.com/tvheadend/tvheadend/commit/ca756e3f7aa8a778fe7a4e69be66b428d3f5afb5))
+
+* [Fixed and cleanup the "PSIP: ATSC Grabber" module (Fixes #5610)](#user-content-fn-298)[^298] ([2022-08-28 08:20:01](https://github.com/tvheadend/tvheadend/commit/1fa49afbca482999a3d32d8da73b01963efe3ff1))
+
+* [Regexps for the finnish EIT scraping](#user-content-fn-299)[^299] ([2022-07-17 21:21:14](https://github.com/tvheadend/tvheadend/commit/1c65e8b0f03384a5ca5b5fc7635ecad4fd85b415))
+
+* extending the regexps for the italian EIT scraping ([2022-07-08 00:52:12](https://github.com/tvheadend/tvheadend/commit/e3f4f222ec86cb5e46576ac97fcb404ffbafc317))
+
+* [Fix use-after-free](#user-content-fn-300)[^300] ([2022-07-04 00:22:44](https://github.com/tvheadend/tvheadend/commit/351b5b4158e4201b3567371f80775aca182cbb0e))
+
+* No longer use git-protocol ([2022-06-17 23:07:13](https://github.com/tvheadend/tvheadend/commit/fbc94aee8bfdd25baba87ab62a39234da20e8dd2))
+
+* add Access-Control-Allow-Headers content-length ([2022-04-22 16:49:22](https://github.com/tvheadend/tvheadend/commit/420786927eea22b7a009f03b0b867058d0818e99))
+
+* Update Copyright year ([2022-04-14 13:39:34](https://github.com/tvheadend/tvheadend/commit/26713c1e451a74dbcc7aaec8427c0356cc2c546f))
+
+* Travis CI is dead, use GitHub actions for badge ([2022-04-11 04:22:19](https://github.com/tvheadend/tvheadend/commit/9a51cea492e4a5579ca3ddf9233fecfa419de078))
+
+* GitHub actions improvements ([2022-04-11 04:01:18](https://github.com/tvheadend/tvheadend/commit/9208984d7917a1f2f8999a620fec0ec9755e1b79))
+
+* Use GitHubs CI for Building ([2022-04-11 03:09:53](https://github.com/tvheadend/tvheadend/commit/70bcfbe376804ad44a06d12fd9c03d1bef58853c))
+
+* Add HMF_UUID to htsmsg_binary_write ([2022-04-11 03:00:07](https://github.com/tvheadend/tvheadend/commit/efe613d2ee28d050db3e9c8ecd75e92a9b222a79))
+
+* Prevent deadlock-detector leaking memory ([2022-04-08 04:23:26](https://github.com/tvheadend/tvheadend/commit/58df4bf5142a7628b3994ec6c0c4b8e1d8d27694))
+
+* Remove useless null-check on an array ([2022-04-08 04:18:55](https://github.com/tvheadend/tvheadend/commit/04998bd54be27e76062b424eb4bab7419f9ff4d2))
+
+* Fix potential null-pointer-dereference ([2022-04-08 03:58:34](https://github.com/tvheadend/tvheadend/commit/6be740c79340510abb8309d151bb455aacc0b31f))
+
+* [Fix FTBFS in utils.c](#user-content-fn-301)[^301] ([2022-04-07 01:52:38](https://github.com/tvheadend/tvheadend/commit/fd01737270d98c28465c86a688bd7d1c640486c5))
+
+* [fix build with libressl](#user-content-fn-302)[^302] ([2022-04-06 21:28:11](https://github.com/tvheadend/tvheadend/commit/ea65f8025a9124cd7353b21f167968bdb897306f))
+
+* [Always parse 'src' in RTSP-requests](#user-content-fn-303)[^303] ([2022-04-05 05:02:14](https://github.com/tvheadend/tvheadend/commit/90ba8b1c1ec01021da032813eae14007d753fc91))
+
+* [dvr_disk_space_cleanup() - do not return error if called again too soon (#1)](#user-content-fn-304)[^304] ([2022-04-05 05:01:55](https://github.com/tvheadend/tvheadend/commit/a1f0b41b7e4eaf36e91f410141a473a2a9738bed))
+
+* [Update for VAAPI transcoding](#user-content-fn-305)[^305] ([2022-03-30 00:55:50](https://github.com/tvheadend/tvheadend/commit/2bf1629280bcd7d33e93df165985f3f6253c4b70))
+
+* [SAT>IP client: UPnP header field names are case insensitive](#user-content-fn-306)[^306] ([2022-03-15 10:27:41](https://github.com/tvheadend/tvheadend/commit/3b1d7a928a8632d8c59e1fc6bb1a0a25dde9d5af))
+
+* More doozer build fixes ([2022-02-14 14:45:48](https://github.com/tvheadend/tvheadend/commit/1295dd2be863f5beb764290fce9317b24193dfc0))
+
+* Fix doozer CentOS build ([2022-02-14 03:51:04](https://github.com/tvheadend/tvheadend/commit/e2ae8f4ebe0ac2c85d0acccc6f31d1a22bb9e802))
+
+* Fix sid doozer build ([2022-02-14 01:08:18](https://github.com/tvheadend/tvheadend/commit/0893a31010c15b46de06233a372d832fe48e6706))
+
+* Update Python shebangs to python3 ([2022-02-14 01:07:07](https://github.com/tvheadend/tvheadend/commit/72bfa4d32c7a556facd8e580f0892e090ea3a01d))
+
+* Update RPM to python3 ([2022-02-13 02:11:21](https://github.com/tvheadend/tvheadend/commit/a0bbcc055e7d1743aa311d488a25bcfdbd7b4e82))
+
+* Doozer fixes ([2022-02-13 02:09:48](https://github.com/tvheadend/tvheadend/commit/718b5b3e879580b73b8423e42bb1dfb8895d4a0d))
+
+* Fix doozer builds ([2022-02-13 01:16:58](https://github.com/tvheadend/tvheadend/commit/025eac1a5e07907e455dd0feb3857de54f9c79a4))
+
+* Fix some failing builds ([2022-02-13 00:07:22](https://github.com/tvheadend/tvheadend/commit/a09fe2acf33949860e83a97bc56a668850f676f2))
+
+* Add --nowerror to build for RPM packages ([2022-02-13 00:04:04](https://github.com/tvheadend/tvheadend/commit/e8f8ddfc05af14fc3fdc89e2db97c6b063f86790))
+
+* Fix failing builds again ([2022-02-12 18:55:29](https://github.com/tvheadend/tvheadend/commit/462c76ec16ccd75042375542496171bfb2773923))
+
+* doozer: Migrate to Fedora 34 and 35 ([2022-02-12 18:32:53](https://github.com/tvheadend/tvheadend/commit/f9a55af89df3eb96e342b24540fca2194a2313ca))
+
+* [Update buffer size for h264 and hevc](#user-content-fn-307)[^307] ([2022-02-12 18:30:59](https://github.com/tvheadend/tvheadend/commit/f90831c015889b5430602b34ba224358243540b5))
+
+* [Changed debian package version to 7](#user-content-fn-308)[^308] ([2022-02-12 18:30:59](https://github.com/tvheadend/tvheadend/commit/39b93710b5b88b1681516f4cf56d22804d5a6766))
+
+* epg: ignore past events when matching on eid ([2022-02-12 18:30:40](https://github.com/tvheadend/tvheadend/commit/a402f07f7c68c9d5498ac7dbc1591320a9d4c81b))
+
+* [httpc: Fix multi-value "Connection" header checks](#user-content-fn-309)[^309] ([2022-02-12 18:29:41](https://github.com/tvheadend/tvheadend/commit/d9989cc761c977fa0689c3f0cfccf9913499e0e5))
+
+* [Episode number regexp](#user-content-fn-310)[^310] ([2022-01-12 23:18:54](https://github.com/tvheadend/tvheadend/commit/c7b713edb0ae4fee6acbd65c27017cb01c12348a))
+
+* Fix some issues introduced in #0165f365cd58bbcc3734e4ec9ce696b42870ff8e ([2022-01-10 02:59:37](https://github.com/tvheadend/tvheadend/commit/1b19167c3f627d53109f8d642bd755c97b9d4bc2))
+
+* Fix "as: invalid option" during libvpx compilation ([2022-01-09 16:33:38](https://github.com/tvheadend/tvheadend/commit/07b3d405f85731abe5b6310b787074e1f8233d5f))
+
+* [nvenc: Fix Werror=int-conversion FTBFS (and likely bug)](#user-content-fn-311)[^311] ([2022-01-02 19:25:10](https://github.com/tvheadend/tvheadend/commit/3ed76138a768d8ce0b9028806273610a92a5617f))
+
+* [nvenc: Fix Werror=misleading-indentation FTBFS](#user-content-fn-312)[^312] ([2022-01-02 18:50:57](https://github.com/tvheadend/tvheadend/commit/067b662ef7479af2b830b95fbd7b2e6c1cb9e7a1))
+
+* [some changes to nvenc](#user-content-fn-313)[^313] ([2022-01-02 14:08:50](https://github.com/tvheadend/tvheadend/commit/0165f365cd58bbcc3734e4ec9ce696b42870ff8e))
+
+* Update Makefile.ffmpeg ([2022-01-02 14:08:39](https://github.com/tvheadend/tvheadend/commit/4deae00a11e92e6c19da4fd1bae48ef7f124c67b))
+
+* [configure: add execinfo option](#user-content-fn-314)[^314] ([2022-01-02 14:07:39](https://github.com/tvheadend/tvheadend/commit/fb7b24114685a7e38d842168dce4c613360cd330))
+
+* [iptv: Fix stream limit starting a new input on a running mux](#user-content-fn-315)[^315] ([2021-12-12 22:10:21](https://github.com/tvheadend/tvheadend/commit/09a2c71abb01db8735437f233b8a54a0bb4939fc))
+
+* [Check the return code of snprintf in utils.c:rmtree](#user-content-fn-316)[^316] ([2021-12-12 22:08:16](https://github.com/tvheadend/tvheadend/commit/6f3b31043d89324c6b406286c1561ca0a213ba48))
+
+* [Use clock_gettime() instead of time() in epggrab.c](#user-content-fn-317)[^317] ([2021-12-12 22:06:16](https://github.com/tvheadend/tvheadend/commit/9ed7d10ac2e895080d08587048ac5a24a2f9fae3))
+
+* [Improve the performance of updating the pid filter table in hdhomerun digital tuners.](#user-content-fn-318)[^318] ([2021-11-21 13:00:54](https://github.com/tvheadend/tvheadend/commit/b8710206eb073c72b142bce95846b77a0ffa34a6))
+
+* Fixed parsing w_scan format ([2021-11-15 23:53:57](https://github.com/tvheadend/tvheadend/commit/2efe90cdcf74fdc4179692d283cf46c85e1cf681))
+
+* [opentv: fix missing summary data on rescrape, #5995](#user-content-fn-319)[^319] ([2021-10-21 00:14:56](https://github.com/tvheadend/tvheadend/commit/c6bb43d8554643a772aa40c5e56904717b55a95f))
+
+* [opentv: fix incorrect summaries for skyuk epg, fixes #5995](#user-content-fn-320)[^320] ([2021-10-17 00:12:53](https://github.com/tvheadend/tvheadend/commit/1ee9c5b9cc516d37cb55a9d924a4ca854a64f720))
+
+* [Revert "Remove unnecessary conversion"](#user-content-fn-321)[^321] ([2021-09-07 17:14:59](https://github.com/tvheadend/tvheadend/commit/8fc2dfa7e1b1b3b1e8ba6f78cd4a81f77fa6a736))
+
+* [Remove unnecessary conversion](#user-content-fn-322)[^322] ([2021-09-06 19:32:09](https://github.com/tvheadend/tvheadend/commit/7757f066582bdb244c56e658c4a99f8e1d5832cd))
+
+* Add support for SCT_RDS ([2021-09-06 19:30:59](https://github.com/tvheadend/tvheadend/commit/dd7b010afd6e25893712bf8bdfc1c235b9077d7b))
+
+* Expose RDS flag via HTSP. ([2021-09-06 19:30:59](https://github.com/tvheadend/tvheadend/commit/814036346418386144756400ada2bb9200540893))
+
+* [Upgrade to libhdhomerun_20210624](#user-content-fn-323)[^323] ([2021-07-29 22:45:22](https://github.com/tvheadend/tvheadend/commit/23754f9a63dad8540214d549b4baec2464e5d33a))
+
+* Fix ffmpeg jessie build error ([2021-07-24 21:40:03](https://github.com/tvheadend/tvheadend/commit/6efa411648cee0b9ca0ce5ab39ee847035c88566))
+
+* Attempt to fix jessie build ([2021-07-23 18:15:38](https://github.com/tvheadend/tvheadend/commit/0778a348e0d2614eb7d586f50ad92bf6631ef8f3))
+
+* Attempt to fix jessie build ([2021-07-23 17:16:48](https://github.com/tvheadend/tvheadend/commit/1979ea7e4e517fd21f7091547bd1bcb9163d069e))
+
+* Attempt to fix trusty and centos builds ([2021-07-23 16:36:19](https://github.com/tvheadend/tvheadend/commit/40c48203511cca2d0f1723b8764ca53035db28e5))
+
+* Doozer.io: Add build targets for Debian, Bullseye & Sid ([2021-07-23 13:27:22](https://github.com/tvheadend/tvheadend/commit/c685f3eab6d1fcc2df5a64de38bf0e6e84b06676))
+
+* [Autobuild: Add arm64, armhf and armel for bullseye and buster.](#user-content-fn-324)[^324] ([2021-07-23 13:27:22](https://github.com/tvheadend/tvheadend/commit/711592186757f8f0dc64f30b38cd9671dd3b6349))
+
+* Fix slow loading bandwidth monitor graph in status tab ([2021-07-21 14:13:09](https://github.com/tvheadend/tvheadend/commit/129df4ff3591ce144e7467e93c3f1a3a194bb583))
+
+* As we no longer have access to #hts on freenode swap to using libera - see https://tvheadend.org/issues/6054 ([2021-06-12 13:56:23](https://github.com/tvheadend/tvheadend/commit/eb59284b8527e3c51eadfeca94ec1e9174cdbdb0))
+
+* Add NVIDIA Hardware accelerated decoding for transcoding ([2021-06-09 02:24:11](https://github.com/tvheadend/tvheadend/commit/04853f0dad2282226ec40bf7a95714b722edf66b))
+
+* Fix EN50211 size for large messages ([2021-05-31 21:07:45](https://github.com/tvheadend/tvheadend/commit/9476680f88d3c2363f86bdb1d4ea93dd3c7d2c95))
+
+* Update ffmpeg to 4.4 ([2021-05-05 14:38:29](https://github.com/tvheadend/tvheadend/commit/637844055c186e981495da711e4887806f656c98))
+
+* Fix missing } from previous commit ([2021-05-05 14:12:21](https://github.com/tvheadend/tvheadend/commit/97d33e8f2a9021d49928529434ab4bcadd16807c))
+
+* [Allow PMT Parsing when PMT shares a PID with another table](#user-content-fn-325)[^325] ([2021-05-05 14:07:56](https://github.com/tvheadend/tvheadend/commit/3038059db8b16f85ca23387c5ccdb6d8f40414ae))
+
+* SAT>IP-Client: Add option for 16, 24 and 32-channel DVB-C tuners ([2021-05-04 17:37:47](https://github.com/tvheadend/tvheadend/commit/2c0d0a52d516efc9100d1ef110f11b737892c1c3))
+
+* [seen is a unsigned type](#user-content-fn-326)[^326] ([2021-05-04 12:40:14](https://github.com/tvheadend/tvheadend/commit/3d19cd20e87350db7e0d1dd6bd382ec9ee2853b3))
+
+* [else is missing](#user-content-fn-327)[^327] ([2021-05-04 02:37:26](https://github.com/tvheadend/tvheadend/commit/e66581e730d83e134320529087472d73956f19f3))
+
+* Update .gitignore ([2021-05-01 03:45:44](https://github.com/tvheadend/tvheadend/commit/fdc3f945f2b759a743a595b134786b881538f52e))
+
+* Delete .DS_Store ([2021-05-01 03:45:44](https://github.com/tvheadend/tvheadend/commit/fd3316469933fc51e2921ceee65561fcb7606d36))
+
+* Delete .DS_Store ([2021-05-01 03:45:44](https://github.com/tvheadend/tvheadend/commit/d843dd2710b5179c373f34a8b273c0eba3391a6c))
+
+* specified the value on each line ([2021-05-01 03:45:44](https://github.com/tvheadend/tvheadend/commit/d2299aba0f1746b5c5b71d0356f3c1e1108426f5))
+
+* Delete .DS_Store ([2021-05-01 03:45:44](https://github.com/tvheadend/tvheadend/commit/9d9dffd6248369ad31c2fa18701817a355389387))
+
+* [Update profile.c](#user-content-fn-328)[^328] ([2021-05-01 03:45:44](https://github.com/tvheadend/tvheadend/commit/123ae50a58835fbeb57f3d9667f62c3994c820b6))
+
+* Improve Readme.md file with a more visual approach ([2021-04-21 17:35:23](https://github.com/tvheadend/tvheadend/commit/b824e237e9450ab73273f5bfc41630cc8339bde7))
+
+* Move travis builds from trusty to bionic ([2021-04-20 18:39:59](https://github.com/tvheadend/tvheadend/commit/10d117e6ed912759db59633ea426bed5ceb6819a))
+
+* [Add pid file hint for systemd-sysv-generator](#user-content-fn-329)[^329] ([2021-04-02 19:21:56](https://github.com/tvheadend/tvheadend/commit/98a7c6cfd9fc72a37e59b358ae326815b0913ab5))
+
+* Update libssl-dependency information ([2021-04-02 12:06:35](https://github.com/tvheadend/tvheadend/commit/69bfa71a8eb5db7bfaf2291e03ef010d5c42ab87))
+
+* Fix possible deadlock ([2021-04-02 01:40:39](https://github.com/tvheadend/tvheadend/commit/967c038dc0db18e84ca536583a8b22dc00e926f5))
+
+* remote timeshift: fix compilation with IPTV disabled ([2021-03-19 18:25:03](https://github.com/tvheadend/tvheadend/commit/dbaa0f850394af8ab845df802f5f781ac0218ec4))
+
+* [Upgrade to libhdhomerun_20210224](#user-content-fn-330)[^330] ([2021-03-17 00:06:32](https://github.com/tvheadend/tvheadend/commit/d003145d7b8c2f28ea238fbfbbac7833ea542857))
+
+* Try to fix error during compilation ([2021-03-16 16:04:04](https://github.com/tvheadend/tvheadend/commit/b3a98ae7e948e76d25c1610105a86f2790994062))
+
+* Reset error counters for IPTV on start, issue #5760 ([2021-03-16 03:16:44](https://github.com/tvheadend/tvheadend/commit/6c537b1fddc40ce84eb032a06e2a846a366aa30b))
+
+* remote timeshift: fix crash on multiple subscriptions and cleanup ([2021-03-16 03:16:18](https://github.com/tvheadend/tvheadend/commit/2ea441d668a3c010f32519201dd02901076d2e19))
+
+* [iptv: new features for multicast, rtsp & rtcp](#user-content-fn-331)[^331] ([2021-03-12 03:26:15](https://github.com/tvheadend/tvheadend/commit/d67fff914417955e4ab8e9fbc091576855425ae2))
+
+* Fix possible NULL-Pointer-reference ([2021-03-12 03:16:21](https://github.com/tvheadend/tvheadend/commit/817a8d4e48414cca0c21c58bfdccf6fc01e56109))
+
+* Fix issues identified by coverity ([2021-02-24 18:32:16](https://github.com/tvheadend/tvheadend/commit/fe0e5f1f9c8fa175183cede9b3182fb25de2d367))
+
+* [EMM patch](#user-content-fn-332)[^332] ([2021-02-24 10:56:39](https://github.com/tvheadend/tvheadend/commit/052c629c530574f96018dd15efaa3384e9fe8a4d))
+
+* Attempt to fix nvenc encoding ([2021-02-21 01:52:07](https://github.com/tvheadend/tvheadend/commit/00b35ec7803388eb08e4835a1df821283ddef4a9))
+
+* [Several coverity fixes, year updated, map muxes between DVB Types](#user-content-fn-333)[^333] ([2021-02-21 01:22:52](https://github.com/tvheadend/tvheadend/commit/2f0c4f298b1e176cf995b8bcd10fd05c425d3a4f))
+
+* Rewrite scanfile.c for dynamic memory allocation  (#1387) ([2021-02-20 20:19:36](https://github.com/tvheadend/tvheadend/commit/0046c96d8d17f455caa8251c569355b77fe9f104))
+
+* [Several enhancements](#user-content-fn-334)[^334] ([2021-02-20 14:36:56](https://github.com/tvheadend/tvheadend/commit/b863e339033b5fffe4ab956663b814fa5896b725))
+
+* Fix more issues identified by coverity ([2021-02-18 21:24:01](https://github.com/tvheadend/tvheadend/commit/1619f9e44678dba5467e4ac94b3e47ea92b72f3e))
+
+* Fix crash when using matroska profile ([2021-02-18 21:11:59](https://github.com/tvheadend/tvheadend/commit/a477a3b39d42cf9af1394fbdf5b3ee7cb2699da6))
+
+* More coverity fixes ([2021-02-18 15:49:30](https://github.com/tvheadend/tvheadend/commit/d3faccf5568ff4de789b65cc2b23dd9b8a9c4067))
+
+* Fix several issues discovered by coverity ([2021-02-18 14:03:37](https://github.com/tvheadend/tvheadend/commit/c5d4d7dea487770dd8b7e4722f0c7fcc7d5315eb))
+
+* Remove link to bintray as they will shutdown in 2 weeks ([2021-02-18 01:52:48](https://github.com/tvheadend/tvheadend/commit/bbf76ca96b274d0e007ee32b371d94d750217653))
+
+* Move from travis-ci.org to travis-ci.com and update date ([2021-02-18 01:39:13](https://github.com/tvheadend/tvheadend/commit/d6eff494c5f1329959d435513071dcd2f80cf0fb))
+
+* Silcense more x265 warnings ([2021-02-18 01:35:08](https://github.com/tvheadend/tvheadend/commit/d002eedb9a57b43c4e4b20a0d2583a7c03027802))
+
+* Enable LIBX265_DIFFS again ([2021-02-18 01:34:26](https://github.com/tvheadend/tvheadend/commit/4105972735abda7ca955305dd7fac098edd0aaa1))
+
+* Add accidentally deleted line again ([2021-02-18 00:15:59](https://github.com/tvheadend/tvheadend/commit/9660b9c5ff8f7f3976975939f79b9ef8cd463d6e))
+
+* [Fix uninitialized memory access for several ioctl commands (#1382)](#user-content-fn-335)[^335] ([2021-02-18 00:13:00](https://github.com/tvheadend/tvheadend/commit/71a597df3e8a2f1c075c21e5786a2f88e334e20d))
+
+* Fix too small memory allocation ([2021-02-17 23:17:08](https://github.com/tvheadend/tvheadend/commit/8e2ac3ac8dd804f2d6c892644948b8178b5f285b))
+
+* Add ISDB-T in hdhomerun ([2020-12-29 19:55:11](https://github.com/tvheadend/tvheadend/commit/aaca05cc1087e0786eb2b41f050ee8fd3e66c728))
+
+* [fix vaapi-profiles (#1366)](#user-content-fn-336)[^336] ([2020-12-29 18:04:14](https://github.com/tvheadend/tvheadend/commit/4d91bca9af0ee05b3dd6182549f83cba252ac867))
+
+* Added ISDB-T SATIP Support ([2020-12-29 18:02:52](https://github.com/tvheadend/tvheadend/commit/f0dfae1bcfa7e26a07422a42b05c6e261a098579))
+
+* [Upgrade to libhdhomerun_20200907](#user-content-fn-337)[^337] ([2020-12-29 17:56:06](https://github.com/tvheadend/tvheadend/commit/38c0445a4bb1870532d5feb65e2151aa8bae611d))
+
+* [Fix possible deadlock when using tvh_mutex_trylock()](#user-content-fn-338)[^338] ([2020-12-16 12:40:08](https://github.com/tvheadend/tvheadend/commit/52b255940f9eb71904b9ac01c733cad090cd061a))
+
+* Sat>IP clear old signal info when opening new stream ([2020-12-14 22:03:21](https://github.com/tvheadend/tvheadend/commit/bd88f3db6a7ed43dc0dca5ed832da13bf627feaf))
+
+* Remove libva-x11 dependency ([2020-12-06 14:01:26](https://github.com/tvheadend/tvheadend/commit/ecd05a21de3075466476df97cf37ffd42c787e58))
+
+* [docs: fix simple typo, seperately -> separately](#user-content-fn-339)[^339] ([2020-11-27 22:33:51](https://github.com/tvheadend/tvheadend/commit/1884300f016027cc3427e3f84c1acfbace5561da))
+
+* [in python 3, dict.has_key() has been removed](#user-content-fn-340)[^340] ([2020-11-14 15:44:53](https://github.com/tvheadend/tvheadend/commit/febcf9818d7c37fec8a98d424934edcb3243d5e4))
+
+* [Changed shebang of tvhmeta to python](#user-content-fn-341)[^341] ([2020-10-28 13:25:43](https://github.com/tvheadend/tvheadend/commit/214a14f2968857331dc746609e15c9ad46b5f13e))
+
+* Correct Environment variable name. ([2020-10-28 13:25:15](https://github.com/tvheadend/tvheadend/commit/9a51036e86375103039d38b9c70030c681d06425))
+
+* [Silcence x265 warnings (#1368)](#user-content-fn-342)[^342] ([2020-10-27 01:20:50](https://github.com/tvheadend/tvheadend/commit/04dd1143ff23ddad5b67d95515a906fa070a5410))
+
+* Add removed checksum ([2020-10-27 00:58:38](https://github.com/tvheadend/tvheadend/commit/11cda04ab15d269d4bf3597d0f1398f49f5fac08))
+
+* Use https for downloading ffmpeg and update nv-codec-headers ([2020-10-27 00:52:21](https://github.com/tvheadend/tvheadend/commit/cd0f33b148028330c5d6b2c4021934e2cdef271f))
+
+* Change no_sanitize("thread") attributes ([2020-10-22 21:18:52](https://github.com/tvheadend/tvheadend/commit/c66e3bc7db52c1e1bcae9de86d8c6fe8ccb46aa4))
+
+* Adding polish scraper for DVBC ([2020-10-21 15:46:56](https://github.com/tvheadend/tvheadend/commit/ba94ccf283594e6195ab6c598a4bd972a3c2d4f6))
+
+* Fix #5962 ([2020-10-19 22:39:36](https://github.com/tvheadend/tvheadend/commit/c1552692e030ea245d4bf091537ba94b8864a07f))
+
+* Make focal use python3 for upload ([2020-10-14 17:17:59](https://github.com/tvheadend/tvheadend/commit/7e1dac82261dba52900e8d6def943d6149102875))
+
+* Attempt to fix focal build in doozer ([2020-10-14 13:38:36](https://github.com/tvheadend/tvheadend/commit/d0fb31c67cbd6285e1310ff06064fa96aa524a73))
+
+* Fix vaapi patch ([2020-10-12 10:32:27](https://github.com/tvheadend/tvheadend/commit/9ed76c0a176b055a57b6e8bd2e0b6e29409269a9))
+
+* [Remove wrong test in nvenc.c](#user-content-fn-343)[^343] ([2020-10-08 20:45:58](https://github.com/tvheadend/tvheadend/commit/c4d086cc098e5d44a5ab9f2c7c1e0afedb0a4106))
+
+* [Fix NVENC](#user-content-fn-344)[^344] ([2020-10-08 20:33:14](https://github.com/tvheadend/tvheadend/commit/627c17ae86119f87038ef76d0c02377adbfd5a84))
+
+* [update Makefile.ffmpeg (#1359)](#user-content-fn-345)[^345] ([2020-10-08 20:32:37](https://github.com/tvheadend/tvheadend/commit/ce92e8c8f2842416018b29b2fc8571e5ddaa09b6))
+
+* Fix cut & paste error in api/epg. (#1360) ([2020-10-08 16:36:26](https://github.com/tvheadend/tvheadend/commit/736ac427b1934832aab23391f5ce35f687c999c6))
+
+* [Revert dca46eedd9653b90d2722e67281eed0b35740730](#user-content-fn-346)[^346] ([2020-09-28 22:10:53](https://github.com/tvheadend/tvheadend/commit/c3204bc6ff87deed26a3bd8ef7a8224a50606dc3))
+
+* [Fix scraping 'new' flag from UK EIT.](#user-content-fn-347)[^347] ([2020-09-28 22:04:02](https://github.com/tvheadend/tvheadend/commit/04ccb9fd99e526a60355ee908a8ad30cf009b996))
+
+* Upgrade to libhdhomerun_20200521 ([2020-09-13 23:04:45](https://github.com/tvheadend/tvheadend/commit/6b8f014c39703640a1fe8af9c2b7663588ed2b56))
+
+* Fix TheTVDB Query ([2020-07-13 11:51:09](https://github.com/tvheadend/tvheadend/commit/ce09077056f9c6558c188d135cec3be85cc9c200))
+
+* [Fix escape code '&quote;' should be '&quot;'. (#1355)](#user-content-fn-348)[^348] ([2020-07-12 17:01:01](https://github.com/tvheadend/tvheadend/commit/d492091de8231ca25ac4b4f682da7d32f3d6f44f))
+
+* [HTSP v35: Add support for recording file size](#user-content-fn-349)[^349] ([2020-07-11 21:49:41](https://github.com/tvheadend/tvheadend/commit/8066d559ec12cec0ab1fa366b54286d706f9b5a9))
+
+* [Revert "HTSP v35: Add support for recording file size" (#1352)](#user-content-fn-350)[^350] ([2020-07-11 19:37:10](https://github.com/tvheadend/tvheadend/commit/313803bb69245abc4199130a71748b61d05581bc))
+
+* Attempt to fix doozer build/python2/3 detection ([2020-07-07 15:51:03](https://github.com/tvheadend/tvheadend/commit/0f13f5912921321a7061ffde760ec41c32d99e77))
+
+* Additional sanity check ([2020-07-06 15:13:37](https://github.com/tvheadend/tvheadend/commit/f77c77d11cdab4aad14bae3e1d269176031f9f0b))
+
+* Report AAC and AAC-LATM correctly. Always raw stream AAC audio as audio/aac. ([2020-07-06 15:06:58](https://github.com/tvheadend/tvheadend/commit/34234b2ed6014da2937852492eba8ac8e4814848))
+
+* see https://tvheadend.org/issues/5722 ([2020-07-06 15:06:45](https://github.com/tvheadend/tvheadend/commit/25e9c0600b6090335cebee2854bea1f9b2fecaa4))
+
+* [Handle bad UTF-8 in xmltv (#5909)](#user-content-fn-351)[^351] ([2020-07-06 15:06:15](https://github.com/tvheadend/tvheadend/commit/f0b21875cf5f3c6ccc735d9c9613122946188628))
+
+* Replace long by int64_t in json parser, fixes #5844 (#1349) ([2020-07-06 15:05:05](https://github.com/tvheadend/tvheadend/commit/fa07b19a0011b76029d54f094f00fcbe39f714bd))
+
+* Fix memory leak ([2020-06-10 21:27:21](https://github.com/tvheadend/tvheadend/commit/51a4c5bec7b6fc69dab7b8d559f9b1b881f0eb8e))
+
+* Allocate space for buf on heap (modified PR #1324) ([2020-06-08 19:46:22](https://github.com/tvheadend/tvheadend/commit/e1031ce5d55275e1606643133b8168adcbe5f231))
+
+* Allocate space for buf on heap (modified PR #1324) ([2020-06-08 19:43:18](https://github.com/tvheadend/tvheadend/commit/8bd059550c641fcaae3a360c527ada6ec74ce9e7))
+
+* xmltv: add program icon to exported xmltv. Fixes: #5685 ([2020-06-08 19:36:12](https://github.com/tvheadend/tvheadend/commit/ec39f08b0df1bcc1598eb329001c574140df4fe6))
+
+* Fix infinite loop when parsing invalid EIT CRID data ([2020-06-05 23:16:38](https://github.com/tvheadend/tvheadend/commit/749f51914c7ffe68ddec4e9272481110d753324d))
+
+* Fix building with -fno-common (default from GCC 10) ([2020-06-03 00:56:45](https://github.com/tvheadend/tvheadend/commit/8a2942a361e95ccdbd30c1edc7627df3862cdbbe))
+
+* Change nv-codec-headers path, fixes #5901 ([2020-05-22 13:18:41](https://github.com/tvheadend/tvheadend/commit/2af3b9e2e4ae15b2bbfd61ed1077a44782ed32cd))
+
+* Add python3 requests dependency ([2020-05-22 13:14:10](https://github.com/tvheadend/tvheadend/commit/32500be3898005137b510e187969979cb6c0f85e))
+
+* Changed default .pid path from /var/run/tvheadend.pid to /run/tvheadend.pid to follow "new" FSH 3 standard ([2020-05-21 15:35:53](https://github.com/tvheadend/tvheadend/commit/e59b92e9f317b758e69fe5e0d0037d44d2d0a33a))
+
+* dvbpsi: Fix build when DVB is not enabled at all ([2020-05-21 11:50:52](https://github.com/tvheadend/tvheadend/commit/4b3b33086438fce199a557fe32e6b6aa086c0714))
+
+* Update Copyright date on UI 'About' screen. ([2020-05-21 11:48:19](https://github.com/tvheadend/tvheadend/commit/ddf17f736a07c03d48cb575acba16ad588c1758a))
+
+* Drop focal i386 support ([2020-05-19 00:27:00](https://github.com/tvheadend/tvheadend/commit/1c67c04c8b2ef454fc8bd9265098b903fc6c45e7))
+
+* Fix doozer builds ([2020-05-19 00:17:41](https://github.com/tvheadend/tvheadend/commit/b293369b475315fce38ffd2caa5e5435a1edc6bd))
+
+* Fix doozer builds ([2020-05-19 00:01:32](https://github.com/tvheadend/tvheadend/commit/38fdee98f48c203362af0c87a4fed24b52bd4ffb))
+
+* [Attempt to fix doozer builds (#1340)](#user-content-fn-352)[^352] ([2020-05-18 23:43:17](https://github.com/tvheadend/tvheadend/commit/11f5d6c83b1f69ea105b4d69475d73e438eecc98))
+
+* Use python3 if available ([2020-05-18 23:28:12](https://github.com/tvheadend/tvheadend/commit/eb57b2277cdcd0b25584997534dd018061f2ec5f))
+
+* [Makefile.ffmpeg: update almost all upstream packages](#user-content-fn-353)[^353] ([2020-05-18 17:26:57](https://github.com/tvheadend/tvheadend/commit/f28f7d2a66ccb96cbfac59b29049f9f332f79c55))
+
+* [CSS: general improvements](#user-content-fn-354)[^354] ([2020-05-18 17:26:36](https://github.com/tvheadend/tvheadend/commit/07be334e92072bad19beada9c111f1bb2e0aae16))
+
+* Deprecate python2, add support for python3 (#1338) ([2020-05-17 15:48:06](https://github.com/tvheadend/tvheadend/commit/d7c707467f3f4794cf786806ea479fdad6e516c2))
+
+* Upgrade to libhdhomerun_20200225 ([2020-05-15 23:50:39](https://github.com/tvheadend/tvheadend/commit/fe5eea266938f21e273e4af6593a80d28f287b81))
+
+* Use HTTPS for libhdhomerun download ([2020-05-15 23:50:39](https://github.com/tvheadend/tvheadend/commit/2a7cb68bcd8e43504d5dbeb5d8785a57cd8769cf))
+
+* Move from cosmic to focal (#1337) ([2020-05-15 23:47:06](https://github.com/tvheadend/tvheadend/commit/f2f6c867f1ac15bbae9ed2e297375e27181fdd49))
+
+* Update copyright and packages link ([2020-05-15 23:43:53](https://github.com/tvheadend/tvheadend/commit/465050d436843893fc9814cbd608b4c4854c4cd3))
+
+* Use python3 on focal ([2020-05-15 21:47:29](https://github.com/tvheadend/tvheadend/commit/c82e00409b4f7110e4743cf62d67990f6e6cdca3))
+
+* Fix buffer overflow ([2020-05-15 14:24:57](https://github.com/tvheadend/tvheadend/commit/6be200b02265b968c24656259eef0f66194d405c))
+
+* Prevent buffer overflow, fixes #5896 ([2020-05-15 14:20:47](https://github.com/tvheadend/tvheadend/commit/2780cd37dc415dae2be1926a6a338d8f4a59b44f))
+
+* Move forward from cosmic to focal ([2020-05-15 12:18:29](https://github.com/tvheadend/tvheadend/commit/c310da9541135af9532017bb7f1f14a90f37dbfe))
+
+* HTSP v35: Add support for recording file size ([2020-05-14 15:13:52](https://github.com/tvheadend/tvheadend/commit/8d43c6600cf8fec2879a9d1f9633d7f70ba90bed))
+
+* Fix the query URL for IMDB website. (#1327) ([2020-05-14 14:34:26](https://github.com/tvheadend/tvheadend/commit/d8a31e57a492be6628b685488fcc7f1d9d262679))
+
+* Fix #5782 ([2019-11-28 18:11:58](https://github.com/tvheadend/tvheadend/commit/221c29b40b1e53ae09a69d9458442dd4fea665f5))
+
+* esstream: fix NULL dereference in elementary_set_filter_build(), fixes #5787 ([2019-11-28 14:46:10](https://github.com/tvheadend/tvheadend/commit/4db926ebe9b77b8da9f6b3f8d62eca5103017f2c))
+
+* capmt: fix the input filter ([2019-11-15 17:51:43](https://github.com/tvheadend/tvheadend/commit/d453f5bef392981c8b14025e2446e4012f72f422))
+
+* mpegts service: fix the build without mpegts_dvb (see PR#1321) ([2019-11-04 08:35:27](https://github.com/tvheadend/tvheadend/commit/fda89e85e0b6ae796d8a09e178d3937aa7869270))
+
+* service: fix the default return value for service_get_source() ([2019-11-04 08:33:16](https://github.com/tvheadend/tvheadend/commit/e225c55e0e927787f6b055fa0d0e0fcd7c145b0c))
+
+* docs: add hint on shell redirections (#5761) ([2019-11-01 07:30:46](https://github.com/tvheadend/tvheadend/commit/dea96e4418eec37aa75592fee2a9dd7672a9c108))
+
+* satip client: try to the the missing poll file descriptor removal, issue #5496 ([2019-11-01 07:27:20](https://github.com/tvheadend/tvheadend/commit/25a50f75a07b656e380b4e9e2d61cbc6c7740e4b))
+
+* tvhpoll: add event helpers, code cleanups ([2019-10-31 14:33:17](https://github.com/tvheadend/tvheadend/commit/912078267423fd54d52ee31e645cc778323fdd2b))
+
+* htsstr: fix the wrong argument parsing, fixes #5761 ([2019-10-31 11:20:28](https://github.com/tvheadend/tvheadend/commit/0afdc9d3aea7b6037f1f9886945116557b6787da))
+
+* htsstr: add htsstr_argsplit() test ([2019-10-31 11:19:28](https://github.com/tvheadend/tvheadend/commit/a9eaf6dc13227f712c3abc5e4987476fd83d5226))
+
+* tvhpoll: add tvhpoll_set_trace() ([2019-10-28 17:21:43](https://github.com/tvheadend/tvheadend/commit/4eac68f52a132de8313f2c1fcdcc227df540b2b2))
+
+* [Remove dead assignment](#user-content-fn-355)[^355] ([2019-10-28 12:54:16](https://github.com/tvheadend/tvheadend/commit/24ff5a612628c2e52886456ea429148b59151448))
+
+* [Webui: minimal reworks for access theme](#user-content-fn-356)[^356] ([2019-10-27 17:23:41](https://github.com/tvheadend/tvheadend/commit/02cae0f3da19a95b37f2a75e02f22c18961da418))
+
+* xmltv: Fix xmltv_ns typo, fixes #5720 ([2019-10-27 17:22:59](https://github.com/tvheadend/tvheadend/commit/1fd019c82e8dd21d51d8f96d9843e1cdcaff568f))
+
+* webui: m3u playlist - mark tag playlists with type=playlist, fixes #5663 ([2019-10-24 15:55:24](https://github.com/tvheadend/tvheadend/commit/91fac103174bb1cc46b4368fd1aa96dffe6090a9))
+
+* tvhdhomerun: fix the cablecard access in tvhdhomerun_frontend_monitor_cb() ([2019-10-21 16:45:12](https://github.com/tvheadend/tvheadend/commit/6540ff23747499bfa28ba04cc76347a9209f4a1e))
+
+* api: return EPERM for the empty arguments, fixes #5755 ([2019-10-21 16:31:41](https://github.com/tvheadend/tvheadend/commit/707b82b9c95519e9f3eb22f1e3d2a6cbe14f9b5c))
+
+* satip client: allow to set the rolloff to all possible combinations ([2019-10-21 08:38:52](https://github.com/tvheadend/tvheadend/commit/fb06654aea29c13d883314c03573ddcf6a77c954))
+
+* satip client: SATIP Kathrein & Triax: Avoid mandatory rolloff on DVBS2, fixes #5517 ([2019-10-21 08:36:31](https://github.com/tvheadend/tvheadend/commit/6c6e0e5103b874fdd926b0f1bcdaed4d7e8b464e))
+
+* [access: added missing break for connection limit type](#user-content-fn-357)[^357] ([2019-10-21 08:08:51](https://github.com/tvheadend/tvheadend/commit/729651ce96cfd181fac127024267dbe8abedc924))
+
+* dvr: fix the DVR limit per user condition (substract self) ([2019-10-21 08:08:01](https://github.com/tvheadend/tvheadend/commit/fb23c42a9e398d83a76ad49d07553ddaf4c6e8d5))
+
+* access: allow to change/set xmltv/htsp output format per matched entry ([2019-10-21 07:43:43](https://github.com/tvheadend/tvheadend/commit/0424fc0e30d07ba364fcf35daf34a0a72739f334))
+
+* access.h: reorder access_t (format members) ([2019-10-21 07:06:24](https://github.com/tvheadend/tvheadend/commit/895d747cc4f5bf8f655288c3397b6d2db4f08099))
+
+* Fix division by 0, fixes #5754 ([2019-10-20 04:26:11](https://github.com/tvheadend/tvheadend/commit/d066577c4f663222fe83e00a09e15b28666b5a23))
+
+* dvb psi: fix the removed MPEG2VIDEO assignment, fixes #5752 ([2019-10-19 06:27:31](https://github.com/tvheadend/tvheadend/commit/6fbb30d039c763268b3e9017e062b0c9ec6bebeb))
+
+* mux grid: enable 'hide: parent disabled' ([2019-10-18 16:13:26](https://github.com/tvheadend/tvheadend/commit/84c989e1557843b0acabb1bd8f10c72d9e7327a0))
+
+* dvb psi: add 0x87 estype as EAC3 (ATSC), fixes #5684 ([2019-10-17 16:48:28](https://github.com/tvheadend/tvheadend/commit/7f090c9829a98427692e06a907c3197ea7230071))
+
+* iptv: fix integer overflow on 32-bit platforms ([2019-10-15 12:05:55](https://github.com/tvheadend/tvheadend/commit/baf746bc1d420e7d628994922df0ddcb665f698f))
+
+* linuxdvb: fix integer overflow on 32-bit platforms ([2019-10-15 12:05:55](https://github.com/tvheadend/tvheadend/commit/0243112a5d6e348d226403f3e91f1a9b91dd35df))
+
+* [Avoid configure checks being optimized away with LTO](#user-content-fn-358)[^358] ([2019-10-15 12:05:11](https://github.com/tvheadend/tvheadend/commit/cde6e98aabf30741069321f01dbb044f32b97552))
+
+* packaging: add missing DEBHELPER placeholder to postrm script ([2019-10-15 12:04:44](https://github.com/tvheadend/tvheadend/commit/7767ab4272906b253daa6a1cd61703e1073a2404))
+
+* Fixed bad quality for vaapi transcoding h264 and hevc with bitrate ([2019-10-15 12:03:42](https://github.com/tvheadend/tvheadend/commit/c767042262eeeac2b416bad2905cdd3697b5378e))
+
+* [systemd service file: remove wildcard mounts preventing startup - replace with a note](#user-content-fn-359)[^359] ([2019-10-15 12:03:02](https://github.com/tvheadend/tvheadend/commit/6ac41a512410889d2b14a19ae6fc5693772b495d))
+
+* Upgrade to libhdhomerun_20190621 ([2019-10-15 12:01:57](https://github.com/tvheadend/tvheadend/commit/971a6e88f4a6fd78763dfdb1ade1d1583d0592a6))
+
+* Mux scan: Log correction ([2019-10-15 07:12:30](https://github.com/tvheadend/tvheadend/commit/a433a00802eb7d65868acc47e851fbd6988588b6))
+
+* tvhcsa: shift the standard headers to top ([2019-10-15 07:11:06](https://github.com/tvheadend/tvheadend/commit/76626a94646223f8e73c2168fa4b7a28c5bb8046))
+
+* [tvhcsa.c: include stdio.h](#user-content-fn-360)[^360] ([2019-10-15 07:10:33](https://github.com/tvheadend/tvheadend/commit/d1fc95a8ad4320054b5f1aa0d4398d193eba246e))
+
+* Added patch to HDHomerun library to allow cross-compilation ([2019-10-15 07:07:23](https://github.com/tvheadend/tvheadend/commit/4a059579ec18132ebf2950ee6c14c098400c0ff8))
+
+* [xmltv: Avoid outputting lang tags in xmltv for only one language, fixes #5630](#user-content-fn-361)[^361] ([2019-10-15 07:04:12](https://github.com/tvheadend/tvheadend/commit/f249f6ac9c42b6b37c84edaaab24476ade90522a))
+
+* channels: Make const-correct. ([2019-10-15 07:04:12](https://github.com/tvheadend/tvheadend/commit/dd2eddadcf0206094fd7b2ebf77f088026298a72))
+
+* [xmltv: Allow sending basic xmltv format, fixes #5630](#user-content-fn-362)[^362] ([2019-10-15 07:04:12](https://github.com/tvheadend/tvheadend/commit/dca55a1d393686c9ab1619f3c2e891685d40d428))
+
+* [htsp: Allow basic htsp format, fixes #5630](#user-content-fn-363)[^363] ([2019-10-15 07:04:12](https://github.com/tvheadend/tvheadend/commit/64f20b5ef8b2d1938b6aa10fb4014475a81474e1))
+
+* autobuild: add build target for raspbian-buster ([2019-10-15 07:03:12](https://github.com/tvheadend/tvheadend/commit/5d112de19c2ddfde470c647686e44a42c3e95cb4))
+
+* [bugfix for autorecs duplicate episode number detection in autorecs](#user-content-fn-364)[^364] ([2019-10-15 07:02:03](https://github.com/tvheadend/tvheadend/commit/a3a631404a5ba1c4e7a2751040c122c0098cf61a))
+
+* api: fix the wrong negative error codes, fixes #5743 ([2019-10-14 16:33:06](https://github.com/tvheadend/tvheadend/commit/c67ba3ce1ba445cf2aea28315bdf97477f43198b))
+
+* linuxdvb: take in account similar dmx for the exclusive tuner access, fixes #5744 ([2019-10-14 11:31:22](https://github.com/tvheadend/tvheadend/commit/ac8095e9883173ced48c223b2d53d7e91d9e6671))
+
+* linuxdvb: compilation fix, fixes #5739 ([2019-10-06 18:33:17](https://github.com/tvheadend/tvheadend/commit/e1fb5c0254e28e6f19d0163e7add8b29c59c1d93))
+
+* man page: Correct default values for http and htsp port ([2019-10-06 15:15:01](https://github.com/tvheadend/tvheadend/commit/cb0a61e959065b321d91244d5558968a6cdcb4ad))
+
+* [bouquet: fix overflow when building for 32-bit system On 32-bit system hash value from service can be truncated.](#user-content-fn-365)[^365] ([2019-10-06 15:12:44](https://github.com/tvheadend/tvheadend/commit/e372db0667a0072e51eb21a0b933d3b3bb8e095d))
+
+* service: correct fhdtv/uhdtv height checks ([2019-10-06 15:07:40](https://github.com/tvheadend/tvheadend/commit/691cce4a76177e14e30da6beaca28b9011a529f1))
+
+* add FHD quality support ([2019-10-06 15:05:26](https://github.com/tvheadend/tvheadend/commit/3a98ebc0556ba6724673772d7e41383bcf0ec913))
+
+* linuxdvb: do not mix DVBv3/v5 stats, it causes trouble to drivers, fixes #5625 ([2019-10-06 14:53:55](https://github.com/tvheadend/tvheadend/commit/c8794d3aeaff7e99b30aa368e10dbea0f4a227c1))
+
+* satip client: add ATSC- string parsing, issue #5728 ([2019-10-06 14:52:52](https://github.com/tvheadend/tvheadend/commit/45bfbd9217d49c1d45ce9da1fabc51adc12de8aa))
+
+* cclient: more ECM PID fixes, reorder code to be more readable, fixes #5659 ([2019-08-02 11:38:29](https://github.com/tvheadend/tvheadend/commit/ebb0968047b6a3aecd61b48792ab8b48a50ecb0d))
+
+* cclient: mark correctly ECM PID for close, fixes #5659 ([2019-07-29 18:53:41](https://github.com/tvheadend/tvheadend/commit/9874ab0b1d4a6752840a9a23bf7502c3e623825f))
+
+* cclient: fix the ECM PID flag for newcamd and cccam, fixes #5659 ([2019-07-06 13:41:01](https://github.com/tvheadend/tvheadend/commit/6be300c430ab614aa527ef34e34f007f34a68ee0))
+
+* [Include stdio.h before tvheadend headers](#user-content-fn-366)[^366] ([2019-07-02 08:02:03](https://github.com/tvheadend/tvheadend/commit/8f1de1621d78c91431238176bf4f6290870a031a))
+
+* [revert bogus ONID and TSID remapping](#user-content-fn-367)[^367] ([2019-06-30 14:37:04](https://github.com/tvheadend/tvheadend/commit/dcc50db45b322da22241c01807643160c16ccfc2))
+
+* mpegts: use 32-bit tsid/onid to define the NONE /unset/ state properly ([2019-06-30 14:36:14](https://github.com/tvheadend/tvheadend/commit/bf7532d2c8548ae2b1519a014d619547a81508c5))
+
+* linuxdvb: fix signal status monitor ([2019-06-30 14:19:43](https://github.com/tvheadend/tvheadend/commit/92dffe6976416ee3363ab558dbddba101c7d474f))
+
+* [Fix compilation with libhdhomerun 20190621](#user-content-fn-368)[^368] ([2019-06-30 14:19:14](https://github.com/tvheadend/tvheadend/commit/13cd23c371e3377973502f8dc65654b6a0ff372b))
+
+* [Makefile: fix -pie linking according to --disable-pie](#user-content-fn-369)[^369] ([2019-06-30 14:18:25](https://github.com/tvheadend/tvheadend/commit/7a71536ec80a3dc03e83dd87ccd67f6a66ecc573))
+
+* capmt: another complation fix, fixes #5661 ([2019-06-18 09:10:02](https://github.com/tvheadend/tvheadend/commit/771dfd6bea7bd4035ed991eccbe735dc00d3f800))
+
+* capmt: fix compilation with recent gcc, fixes #5657 ([2019-06-17 18:57:02](https://github.com/tvheadend/tvheadend/commit/4036e249c365b7840e2c5f9ce7e9b2edbecf3184))
+
+* [capmt: fix for the oscam r11520+, fixes #5649](#user-content-fn-370)[^370] ([2019-06-12 15:06:56](https://github.com/tvheadend/tvheadend/commit/bc769bfa9260bad6e1caa0c95591b70ae25f47bf))
+
+* [en50221: fix invalid htsmsg manipulation](#user-content-fn-371)[^371] ([2019-05-20 16:41:40](https://github.com/tvheadend/tvheadend/commit/f033b21316cf7185e6189f4a751ba382117d13ed))
+
+* [en50221: fix menu text decoding](#user-content-fn-372)[^372] ([2019-05-20 16:41:40](https://github.com/tvheadend/tvheadend/commit/466a0143195a0a0f15c58d4bbd93c57b13caaccd))
+
+* [fanart: Fix decode error.](#user-content-fn-373)[^373] ([2019-05-20 16:36:22](https://github.com/tvheadend/tvheadend/commit/e0fad819003f67d4569ea189f2f48a53367c1bd5))
+
+* dvbpsi: fix the freesat bouquet update (inverted condition), fixes #5572 ([2019-03-24 19:44:40](https://github.com/tvheadend/tvheadend/commit/6bfeca6c03dbd73fa73b1b0dde383ddab29ba91c))
+
+* api: return an error when incomplete query is passed, fixes #5568 ([2019-03-21 07:51:04](https://github.com/tvheadend/tvheadend/commit/14d22c3797f2077bc31dfdd03cd1cc5e94511b00))
+
+* linuxdvb: use the right configuration root for the slave tuners (loading), issue #5128 ([2019-03-20 13:47:02](https://github.com/tvheadend/tvheadend/commit/453ee8dfd80b240e1005502c002bdc6de3f121c8))
+
+* linuxdvb: create the mux instances also for the slave tuners, issue #5128 ([2019-03-20 13:45:08](https://github.com/tvheadend/tvheadend/commit/937a5fb78552f067f889279a7c20a418c39e283e))
+
+* [Freesat_huffman: Suppress characters < 0x20 except \n.](#user-content-fn-374)[^374] ([2019-03-15 12:23:49](https://github.com/tvheadend/tvheadend/commit/1383eab65a93763b8780e5011d592d9f249031b6))
+
+* http server: fix digest MD5 authorization, fixes #5573 ([2019-03-13 17:30:55](https://github.com/tvheadend/tvheadend/commit/3f0c6b1e28fc5bae5c3e8934c8a79400236a1ac8))
+
+* Add sat longitude and usals angle as parameters to the rotor external command ([2019-03-13 15:18:57](https://github.com/tvheadend/tvheadend/commit/ec90d317ea5b5b0a18eb543ee90d1c41c30bf849))
+
+* [Update to newest ffmpeg to fix libX11 compile issue "DSO missing from commandline"](#user-content-fn-375)[^375] ([2019-03-13 15:13:38](https://github.com/tvheadend/tvheadend/commit/d250c1844798791a1354254a60545d4be5ada197))
+
+* utils: sbuf - use correct format character, fixes #5565 ([2019-03-07 07:23:13](https://github.com/tvheadend/tvheadend/commit/811fd889e9da762d04977f3531aa1aae8ff37329))
+
+* freesat bouquet parser: fix endless loop (double list insert), fixes #4851 ([2019-03-06 19:01:26](https://github.com/tvheadend/tvheadend/commit/726e6e65441a9802b6678b05e5f78d82c8cad5f5))
+
+* utils: cosmetic fix for sbuf_alloc_fail ([2019-03-06 19:00:48](https://github.com/tvheadend/tvheadend/commit/68ae28cc4a7e969e918e6fd5c5212fa272a86c2e))
+
+* eit: fix the possible NULL dereference ([2019-03-06 19:00:29](https://github.com/tvheadend/tvheadend/commit/a3c5e751b05018a2cb3764627c3a77b4a5d9e7ce))
+
+* SAT>IP: fix done - close sessions only when server is active ([2019-03-06 07:29:51](https://github.com/tvheadend/tvheadend/commit/ff7893d8fee713673d0f7662d3753b4d0de4c706))
+
+* mpegts: fix the idle scan (use another idle scan queue - fixes #5548) ([2019-03-02 20:27:40](https://github.com/tvheadend/tvheadend/commit/717030bca5b8087d073a40f45092bc1eb7fdb8bb))
+
+* tvh thread: increase the default watchdog timeout to 15 seconds ([2019-03-02 20:27:38](https://github.com/tvheadend/tvheadend/commit/7aeece632a06891c4a15cc286e199697c59e5a9a))
+
+* tvh-json.py: the list is returned instead dictionary ([2019-03-01 15:43:37](https://github.com/tvheadend/tvheadend/commit/0122ccb22369305f1ccfa91da8022493ff163f3e))
+
+* Prevent rebinding when refreshing SAT-IP Server settings and not changing port, fixes #5539 ([2019-03-01 15:42:26](https://github.com/tvheadend/tvheadend/commit/6edc4dab9138cac99f10c42b1dfc0fc475743c46))
+
+* systemd: service/unit should not be started until after file-systems are mounted - this avoids "file missing" errors ([2019-03-01 15:40:05](https://github.com/tvheadend/tvheadend/commit/b988b54beaad0583ac36831d05609269ff139a3a))
+
+* iptv: another improvement in the thread exit procedure, fixes #5550 ([2019-02-28 08:21:40](https://github.com/tvheadend/tvheadend/commit/d2405f2988ab06d2bafba2b5397cacdac26c0d70))
+
+* iptv: improve the thread exit procedure - use pipe, fixes #5550 ([2019-02-27 17:01:42](https://github.com/tvheadend/tvheadend/commit/65c63116c23df8ea72ba6caa63fb70c94d3b106e))
+
+* iptv: improve the thread exit procedure, issue #5550 ([2019-02-27 14:28:59](https://github.com/tvheadend/tvheadend/commit/d0f3d09d853759f4e6bff95e706d9b9526fb4bcf))
+
+* satip client: initialize variable _w correctly for the PIDs split rewrite, fixes #5544, issue #5549 ([2019-02-16 19:55:48](https://github.com/tvheadend/tvheadend/commit/22eeadd11f8d323355ee3ab6e9068b5e443884ef))
+
+* satip client: fix the compilation, fixes #5547 ([2019-02-16 09:31:08](https://github.com/tvheadend/tvheadend/commit/143e5b1239d7e3ce5f92ef57ad1861e38fa9f148))
+
+* satip client: fix for the PIDs split - missing delpids, issue #5544 ([2019-02-15 22:38:36](https://github.com/tvheadend/tvheadend/commit/bc6ef3491e0f4bbbaf0de166abf6a44904c48df8))
+
+* Triax & Kathrein: Increase pid length, issue #5544 ([2019-02-15 22:31:37](https://github.com/tvheadend/tvheadend/commit/7ff49818e6ac5d0c46995f60f33248e1b2e172b0))
+
+* satip client: improve the PIDs split for the PLAY RTSP command, fixes #5544 ([2019-02-15 22:29:34](https://github.com/tvheadend/tvheadend/commit/cc70226210f9888d58a205cf903d89c9b499ab97))
+
+* Added compatibility mode for SAT-IP tuners that mess up tuner numbers, for example FritzBox 6490/6590 ([2019-02-14 16:03:40](https://github.com/tvheadend/tvheadend/commit/39db47829b65f140f337d4af3110a8906fed6ff8))
+
+* Fix description of RTP/AVP/TCP Mode ([2019-02-14 16:02:01](https://github.com/tvheadend/tvheadend/commit/363e0eb6e82f3f46ffa6d3ec13899539993f409b))
+
+* satip client: workaround for FritzBox 6490/6590 (status string parsing), rewritten PR#1256 ([2019-02-14 16:01:52](https://github.com/tvheadend/tvheadend/commit/5caf8b8a445797a176376c9b28ce9f12cd28cf46))
+
+* http: digest - do not use EVP_sha512_256() for nonce, check openssl version ([2019-02-14 13:49:47](https://github.com/tvheadend/tvheadend/commit/fd6f880e31b551a5c6b05c7d4b16e0a76d8810d0))
+
+* http: digest - return back MD5 as only digest hash (multiple login dialogs for firefox/chrome) ([2019-02-14 13:49:06](https://github.com/tvheadend/tvheadend/commit/0af25951debe4da57b94b28265930902535610ab))
+
+* http: digest - show the SHA hash as an authentication alternative (tested with curl) ([2019-02-14 13:36:53](https://github.com/tvheadend/tvheadend/commit/10eb0614352ebd8669c27d1b94ad72d70784b2f3))
+
+* mpegts input: fix the compilation error, fixes #5492 ([2019-02-14 12:44:52](https://github.com/tvheadend/tvheadend/commit/ec573f1f410de862d667122e37537807f925b6a4))
+
+* http server: fix the new digest hashes (appearently firefox nor chrome do support them) ([2019-02-14 12:44:17](https://github.com/tvheadend/tvheadend/commit/a08a525bd754d57555ed8f5a9ac1bb0ad4e11d84))
+
+* mpegts: pid subscription - fix wrong mps_type mpegts_mps_cmp(), fixes #5492 ([2019-02-14 12:38:50](https://github.com/tvheadend/tvheadend/commit/57b766ab7e8ab3dbec2476cc269eaf8101d48b64))
+
+* http server: add support for SHA-256 and SHA-512/256 digest hashes ([2019-02-13 17:14:40](https://github.com/tvheadend/tvheadend/commit/e61acb8ad4a3411f4e7acfd8133d222299f6d47e))
+
+* esfilter: cosmetic fix ([2019-02-12 17:15:25](https://github.com/tvheadend/tvheadend/commit/ca6a3f2f7d79e04ad12cf34f78e0f71784eaaa0f))
+
+* esfilter: fix the wrong other mask (hbbtv), fixes #5531 ([2019-02-12 17:08:05](https://github.com/tvheadend/tvheadend/commit/797af7c7873ab5cbc63bbb6ff4c518433b8d521d))
+
+* descrambler: simplify some destroy sequences ([2019-02-11 08:10:30](https://github.com/tvheadend/tvheadend/commit/c54f303c6e23c0abbb14635b9dd8291393c76a53))
+
+* channel: get number - select the lowest service number, fixes #5441 ([2019-02-11 07:38:08](https://github.com/tvheadend/tvheadend/commit/419b0a143c439b50f7d2d979945f5e8d2f6769d1))
+
+* dvb psi: fix hbbtv parsing, fixes #5531 ([2019-02-09 20:03:09](https://github.com/tvheadend/tvheadend/commit/e4e96ff3f7e28eb71a3f077f59e8ba756c3470ab))
+
+* Move HDHomeRun config fields into their own group in the UI ([2019-02-04 10:07:17](https://github.com/tvheadend/tvheadend/commit/b625b36741c2703e4b90fcf95f849226c5970e37))
+
+* Log an error message if the configured IP address is invalid ([2019-02-04 10:07:17](https://github.com/tvheadend/tvheadend/commit/b253613ef6feab9da3fe46bb726f0c2dbec3e8b5))
+
+* Corrected local_ip description text ([2019-02-04 10:07:17](https://github.com/tvheadend/tvheadend/commit/b1805bc705207e95ecf4ebc13633ae247e06e85e))
+
+* Avoid caching HDHomeRun's IP address ([2019-02-04 10:07:17](https://github.com/tvheadend/tvheadend/commit/a68b343df404f209886035aee479b80a6336cf9c))
+
+* Changes to make tvheadend work in a container while talking to HDHomerun ([2019-02-04 10:07:17](https://github.com/tvheadend/tvheadend/commit/1fa1c1cb997d12ea128919c4b125a8097fee847c))
+
+* Assign a different port number for each frontend thread ([2019-02-04 10:07:17](https://github.com/tvheadend/tvheadend/commit/03f40731a6b8ea95d113268eda63929f63decac9))
+
+* [dvr: New fmt spec for per-dir seasons and one movie per dir. (#4667)](#user-content-fn-376)[^376] ([2019-02-04 10:00:40](https://github.com/tvheadend/tvheadend/commit/b106250c98af2244ca9d011cd0c5081f42eb9630))
+
+* dvr: Add {min,max}season and {min,max}year to autorec UI, fixes #5479 ([2019-02-04 10:00:32](https://github.com/tvheadend/tvheadend/commit/4374948b4328fea952ee0e3b56f816b735d79476))
+
+* [dvr: Only check minseason/maxseason/minyear/maxyear if EPG has these values, fixes #5479](#user-content-fn-377)[^377] ([2019-02-04 10:00:32](https://github.com/tvheadend/tvheadend/commit/145082b658816ff916982c36abed42b6d298ae16))
+
+* Kathrein EXIP: Add default config (SATIP) ([2019-02-04 10:00:19](https://github.com/tvheadend/tvheadend/commit/d7e975f75caabb6abcaa9dbf075c118682c5cbd7))
+
+* Update posix.mk ([2019-02-04 09:57:34](https://github.com/tvheadend/tvheadend/commit/e175897d21f5e7c95b3e5b1df0f52a6f97502a59))
+
+* CSS: Fixes ([2019-02-04 09:56:43](https://github.com/tvheadend/tvheadend/commit/3fcb0844eb5d2e5a28fe323f7ffcfd5e51382ce9))
+
+* WebUI: Update copyright year ([2019-02-04 09:54:51](https://github.com/tvheadend/tvheadend/commit/3aba4ad47b5272938f7e7b1aabb73a97c6728865))
+
+* m3u: fix the NULL dereference if the input string cannot be converted to utf-8, fixes #5525 ([2019-02-04 09:53:16](https://github.com/tvheadend/tvheadend/commit/6e4cc564cc8ce0b2cfaa55e94e1ee81fa4c6ff9d))
+
+* satip server: parse destination for RTP/AVP transfer ([2019-01-24 16:29:56](https://github.com/tvheadend/tvheadend/commit/baadf28f70d443b803fe0ef157e6543633fc86b0))
+
+* satip client: fix the network limit/group description ([2019-01-23 06:59:50](https://github.com/tvheadend/tvheadend/commit/7d3aa11940ac7aec1238a16264c73b366970b27b))
+
+* satip server: add icon files, fixes #5268 ([2019-01-21 14:25:25](https://github.com/tvheadend/tvheadend/commit/10ed59ce33f6c08b01216bf58f1ed6e48b608651))
+
+* eit: config - fix the json syntax error, fixes #5503 ([2019-01-18 21:23:08](https://github.com/tvheadend/tvheadend/commit/ceb82fc6961a725d7a77f5e8de1ffd4aefbde7e8))
+
+* eit: fix UK Cable Virgin configuration, fixes #5499 ([2019-01-18 07:45:54](https://github.com/tvheadend/tvheadend/commit/8818b5220c218e548556aaac8b727491ef0ab152))
+
+* mpegts dvb network: fix create mux - wrong class used for comparison (since commit dbee3d2049faa7d5e15374ddef37a91e86768b26), fixes #5486 ([2019-01-17 16:38:06](https://github.com/tvheadend/tvheadend/commit/717a4d5c5091cb83a3c865636f6a1c38c0fb6459))
+
+* mpegts network: stop all running muxes when the network was disabled by the user, fixes #5497 ([2019-01-15 09:36:43](https://github.com/tvheadend/tvheadend/commit/098318644802bfee4baa7eeeeafac4f81ecd9578))
+
+* mpegts input: change mpegts_input_tuning_error() to more universal mpegts_input_error() ([2019-01-15 09:35:36](https://github.com/tvheadend/tvheadend/commit/6621db64e23c5a77d7973ae39be17a76135e18dd))
+
+* server.h: cleanups for TSS_ flags ([2019-01-15 09:34:50](https://github.com/tvheadend/tvheadend/commit/ec9cb00079b6a84794a32deb29fffc2a66351b65))
+
+* iptv auto network: check the network enabled flag for the auto download ([2019-01-14 14:23:44](https://github.com/tvheadend/tvheadend/commit/9a6007c20609805a985e98591eb99c0f7729d282))
+
+* service: enlist - use also is_enabled callback to check the network/mux enable state ([2019-01-14 14:21:24](https://github.com/tvheadend/tvheadend/commit/97b71ef9e40064c94f17593547f7c80b1833b45a))
+
+* otamux: fix the 15 seconds delay for the initial scan ([2019-01-14 14:20:50](https://github.com/tvheadend/tvheadend/commit/757e2a90936a92773209c1867f14583e34b14558))
+
+* mpegts: add possibility to enable/disable network ([2019-01-14 12:17:15](https://github.com/tvheadend/tvheadend/commit/1413e342daecff36ee22d3b75831599bbb66c7be))
+
+* http: CORS - small optimization ([2019-01-14 11:28:51](https://github.com/tvheadend/tvheadend/commit/f44e2e58ef360e7fb9f8ab7aacf042e0de725af3))
+
+* http: CORS - add Access-Control-Allow-Credentials header for cookies ([2019-01-14 11:24:52](https://github.com/tvheadend/tvheadend/commit/4bf32134bb31a564ad8ad34402442cd6efd1433e))
+
+* parse_ac3: avoid the endless loop for the AC3/EAC3 auto-detection, issue #5353 ([2019-01-13 20:17:36](https://github.com/tvheadend/tvheadend/commit/bd662457daea904eb2d4f5ccc76e0e5ae2e24cd1))
+
+* otamux: fix NULL dereference, fixes #5488 ([2019-01-09 17:41:16](https://github.com/tvheadend/tvheadend/commit/8e0dd2bee6373156907bde8da7b659948a915e12))
+
+* doozer: remove OOL Fedora 27 ([2019-01-09 09:35:47](https://github.com/tvheadend/tvheadend/commit/851a6a196d6ee805e36b9adba22158639b282e19))
+
+* Makefile.ffmpeg: upgrade ffmpeg to 4.1, x264 to 20190108, x265 to 2.9 ([2019-01-09 08:39:00](https://github.com/tvheadend/tvheadend/commit/6d57bb6192c679bc9f82847e387c31972f28d838))
+
+* avahi: try to fix double free, fixes #5484 ([2019-01-08 19:26:02](https://github.com/tvheadend/tvheadend/commit/fdafda55c5b9be93abb6df1f61cfeed5d8e19dff))
+
+* DVR: add utf8 validator for title/subtitle when cutted ([2019-01-08 14:48:33](https://github.com/tvheadend/tvheadend/commit/4e8925fe785064be3947e11888638f20e9e7ab50))
+
+* epg: add auto-ota-module detection ([2019-01-08 12:58:04](https://github.com/tvheadend/tvheadend/commit/ceb6f1da66b881988f3a74595c8ff5462b635de5))
+
+* epggrab: reimplement the OTA grabber selection per mux ([2019-01-08 09:10:02](https://github.com/tvheadend/tvheadend/commit/cb01c36843aca863049350da192fac0740155ae5))
+
+* [ui: Make dialogs slightly bigger.](#user-content-fn-378)[^378] ([2019-01-02 14:53:39](https://github.com/tvheadend/tvheadend/commit/adc90275c4e19f7beeffda9612b0ac63e1791dcf))
+
+* [api: Alternative showings match on title if no series link, fixes #5402](#user-content-fn-379)[^379] ([2019-01-02 14:53:39](https://github.com/tvheadend/tvheadend/commit/12e4858014fb022cf71d882e4302d9942fbb0747))
+
+* CSS: Fix height % ([2019-01-02 14:53:10](https://github.com/tvheadend/tvheadend/commit/8d02a266030c17c319bb1a8372184dba3ee1cc27))
+
+* [Fix several errors detected by w3c css validator](#user-content-fn-380)[^380] ([2019-01-02 14:53:10](https://github.com/tvheadend/tvheadend/commit/6ee3575c819cec2daa71af3d02c973b343ce87ab))
+
+* Add missing !DOCTYPE html ([2019-01-02 14:53:10](https://github.com/tvheadend/tvheadend/commit/5c8f76d998fe2a265905ca31fe259c5c5d3e1e88))
+
+* [main: Replace deprecated ERR_remove_state](#user-content-fn-381)[^381] ([2019-01-02 14:51:48](https://github.com/tvheadend/tvheadend/commit/62808322c0e2d96f59a4a9b5b43fbb89f8d9ae98))
+
+* eit: always prefer master rather than slave for the config, issue #5247 ([2019-01-02 14:51:28](https://github.com/tvheadend/tvheadend/commit/640703e83d293bf5e5fb1c8fcdcfd80ffd396937))
+
+* eit config: fix the uk_freesat_eit description, issue #5247 ([2019-01-01 18:43:40](https://github.com/tvheadend/tvheadend/commit/c60b62b427d31e4348176bc6bea935b9beef0b35))
+
+* eit: another attempt to fix the freesat issue (slave eit), fixes #5247 ([2019-01-01 18:42:02](https://github.com/tvheadend/tvheadend/commit/cfb4b6efd924e8391c7102f37bd57aa9fea745f9))
+
+* eit: try to fix the freesat issue, fixes #5247 ([2019-01-01 18:14:49](https://github.com/tvheadend/tvheadend/commit/e61adb3441b6ea8e9a25b1f4fd39d22d925fb588))
+
+* xmltv: add support for the lcn tag, fixes #5471 ([2019-01-01 17:34:53](https://github.com/tvheadend/tvheadend/commit/7da43a563fe75368769fde33064d17810d9f2909))
+
+* satip client: remove the dual condition for Annex B ([2019-01-01 17:18:48](https://github.com/tvheadend/tvheadend/commit/d2cb8bad332ca9455750566e8f84e0af33225aaf))
+
+* satip client: fix the ATSC-C (Annex B) parameters, fixes #5447 ([2019-01-01 17:17:05](https://github.com/tvheadend/tvheadend/commit/833b61c4d14511ef20ac55a918a7fdc1c231fb0e))
+
+* cosmetic fixes and optimizations ([2019-01-01 17:05:15](https://github.com/tvheadend/tvheadend/commit/dbee3d2049faa7d5e15374ddef37a91e86768b26))
+
+* xmltv export: add LCN to the display-name attribute, fixes #5471 ([2019-01-01 16:21:25](https://github.com/tvheadend/tvheadend/commit/bb8a25ca8b2e2e48b6b76f833f0bf96dde37c896))
+
+* pass muxer: fix the incorrect section length for EIT table, fixes #5418, issue #5062 ([2018-12-30 10:16:44](https://github.com/tvheadend/tvheadend/commit/fb11090346c06ffd20323bc97d0e32d9855fe50f))
+
+* teletext: fix the subtitle parser (wrong SCT_ type match), issue #5422 ([2018-12-28 20:21:36](https://github.com/tvheadend/tvheadend/commit/b17dcf91490c38df678472bef3a117b4c6e2996c))
+
+* htsp server: use HTTP image URLs for image cache for older clients (pvr.hts), fixes #5455 ([2018-12-28 18:50:05](https://github.com/tvheadend/tvheadend/commit/d3d0249bce84425e94e4bee399b7f2236f77b6bf))
+
+* imagecache: the timer function is already called inside imagecache_lock (sorry), fixes #5458 ([2018-12-26 22:08:39](https://github.com/tvheadend/tvheadend/commit/fee0b53e969da78a70229d53f9e1331511b5f237))
+
+* hdhomerun: auto detect DVB_T devices ([2018-12-26 16:58:39](https://github.com/tvheadend/tvheadend/commit/88f2634af1bacd5f4768a994562d909f756ab7fb))
+
+* imagecache: fix the missing ref initialization, fixes #5458 ([2018-12-26 13:26:12](https://github.com/tvheadend/tvheadend/commit/112e06dfdc0a713e97a040eb7c443a31fb2ac46e))
+
+* Fix mpegts packet length in descrambler_data_key_check ([2018-12-25 17:25:17](https://github.com/tvheadend/tvheadend/commit/b3899e3fddad1431269183fd42eba54ec16fdc22))
+
+* imagecache: do not use global lock, fixes #5453 ([2018-12-25 17:24:57](https://github.com/tvheadend/tvheadend/commit/33901bb1edd3f9859d1190a352ea7c383ebb58ab))
+
+* [Revert "dvr: move dvr_notify() call to the global_lock using timers, fixes #5437"](#user-content-fn-382)[^382] ([2018-12-25 16:34:26](https://github.com/tvheadend/tvheadend/commit/312dce6e22e2d3ab21475a08e1f44dae4859173c))
+
+* cclient: check keep-alive also when no poll event occurs, fixes #5445 ([2018-12-22 17:42:28](https://github.com/tvheadend/tvheadend/commit/7fdc6f0549147ba0c25d652c5efe1bdaed6e7543))
+
+* mpegts: fix mpegts_service_find_e2() for atsc-t ([2018-12-22 17:36:14](https://github.com/tvheadend/tvheadend/commit/42e368ede940f275791a9d9c4a8f3707d42714e0))
+
+* caclient: handle correctly connection close / read error, fixes #5445 ([2018-12-22 10:41:18](https://github.com/tvheadend/tvheadend/commit/cc8f139f80507c2fd737fd6e2620401c0f35ea75))
+
+* satip server: fix ATSC-T / Annex B cable frequency parsing, fixes #5447 ([2018-12-20 19:32:33](https://github.com/tvheadend/tvheadend/commit/833821fc6e556a455e3f6cfcb935e50dd82632bf))
+
+* linuxdvb: satconf - cleanups for the rotor external command ([2018-12-19 14:28:35](https://github.com/tvheadend/tvheadend/commit/dd37467c8ccac8e0bef1210ae148d630b206605d))
+
+* added linudvb_rotor_external to control an actuator by spawning an external command ([2018-12-19 14:15:46](https://github.com/tvheadend/tvheadend/commit/0a1d52cb71cd1037cbe8c9f2926b2e3634349f48))
+
+* [webui, htsbuf: Content-Disposition escape chars are not correct.](#user-content-fn-383)[^383] ([2018-12-19 14:09:59](https://github.com/tvheadend/tvheadend/commit/a11733fed0f74da5cb309aa624a7039918b21126))
+
+* webui: status - drop all connections - use new id=all call, fixes #4937 ([2018-12-19 11:39:16](https://github.com/tvheadend/tvheadend/commit/faa5176b250572fb6e35f4ce95919b4800b94d3b))
+
+* webui: add "drop all connections", fixes #4937 (original request only) ([2018-12-19 11:37:35](https://github.com/tvheadend/tvheadend/commit/bc4873d75b906254b7c6255b9cced4e6ac13f533))
+
+* api: add id=all for the connections/cancel, issue #4937 ([2018-12-19 11:37:18](https://github.com/tvheadend/tvheadend/commit/9a7b56a269319397de30976bccb8f48f8b5b6911))
+
+* xmltv import: fix the wrong end-of-string mark (off-by-one), fixes #5443 ([2018-12-17 10:30:52](https://github.com/tvheadend/tvheadend/commit/99461b8cb35989af7e5e08106446d0b24a2bd7fc))
+
+* dvr: move dvr_notify() call to the global_lock using timers, fixes #5437 ([2018-12-16 08:19:33](https://github.com/tvheadend/tvheadend/commit/91f6de4437f13d51a854ffe999cca63ff2ef503c))
+
+* dvb psi pmt: change the teletext subtitle handling for multiple teletext descriptors, issue #5422 ([2018-12-15 20:08:08](https://github.com/tvheadend/tvheadend/commit/d07a12e013c8bff2e59accb9d948fddd8488389d))
+
+* satip server: use strempty() function for the uuid check, fixes #5434 ([2018-12-15 19:15:13](https://github.com/tvheadend/tvheadend/commit/a1f303d01d061325f1cf145e87ee3341e771dbae))
+
+* tvh thread: do not crash when mutex==NULL (magic check failed), fixes #5435 ([2018-12-15 15:29:27](https://github.com/tvheadend/tvheadend/commit/efd99b34d4f1dedaa54f1bd357c6f82e6f75d3da))
+
+* satip client: fix the double (and wrong) sf_last_data_tstamp update, fixes #5374 ([2018-12-14 17:38:26](https://github.com/tvheadend/tvheadend/commit/0db0890a4b4d1a2521009b8b5cbf058b964d9608))
+
+* [epggrab: run internal grabbers only when wanted, fixes #5421](#user-content-fn-384)[^384] ([2018-12-14 14:52:27](https://github.com/tvheadend/tvheadend/commit/d1ddcdc82731b3750d9b2f7b458e1deb6d17256f))
+
+* dvr: fix the real_start variable misuse, fixes #5426 ([2018-12-14 10:39:14](https://github.com/tvheadend/tvheadend/commit/e37c696ded59fe7c2fbaf3a42944bfeb2dd7ff92))
+
+* tvh thread: remove wrong commit code ([2018-12-14 10:28:32](https://github.com/tvheadend/tvheadend/commit/e61b126ef5b75dca7b0a0f0a0575d650a5c400e6))
+
+* htsp server: fix the wrong htsmsg destroy introduced in the imagecache patch, fixes #5430, fixes #5431, fixes #5429 ([2018-12-14 10:27:45](https://github.com/tvheadend/tvheadend/commit/abfc7c92d5151046bd47e0b36dc67797158bd6b8))
+
+* iptv: remove double pcr: from traces ([2018-12-14 10:15:57](https://github.com/tvheadend/tvheadend/commit/b157d126be4b9224f8496006dabde066aa61f295))
+
+* sbuf: add sbuf_replace() ([2018-12-13 16:54:39](https://github.com/tvheadend/tvheadend/commit/279f689bdf798992ee0bd43dcedb34ef831d6c71))
+
+* mpegts input: add CC restart for tables, too ([2018-12-13 12:33:15](https://github.com/tvheadend/tvheadend/commit/55e5b982d9989c146525cfb8c53b2cb56d6fe0ba))
+
+* iptv http: call iptv_input_mux_started(), move recv_flush to http-header back ([2018-12-13 08:12:37](https://github.com/tvheadend/tvheadend/commit/cfdfeb6cc15f8f09de02ffeab8158caf5e676df0))
+
+* imagecache: increase the save access threshold again ([2018-12-12 18:20:33](https://github.com/tvheadend/tvheadend/commit/552cea0fc189f389ce02100bc49026ac1aae1715))
+
+* profile: add more doc to the pass rewrite fields ([2018-12-12 18:19:48](https://github.com/tvheadend/tvheadend/commit/d3fc1487bba0b7093222e06fdde2decab85347f2))
+
+* imagecache: do not update the accessed field too much ([2018-12-12 18:13:19](https://github.com/tvheadend/tvheadend/commit/1bf4b4c84c58e52b813b3e681444d46cdbe8904c))
+
+* [imagecache: big cleanups](#user-content-fn-385)[^385] ([2018-12-12 18:08:00](https://github.com/tvheadend/tvheadend/commit/da682c4507a1b11ceaf714675f833d56c2084157))
+
+* remove debug code (added by mistake) ([2018-12-12 09:26:30](https://github.com/tvheadend/tvheadend/commit/3769d01fb9a9253817ecd16d949977813583b328))
+
+* dvb psi lib: add dvb_table_parse_reinit functions ([2018-12-12 09:03:16](https://github.com/tvheadend/tvheadend/commit/a5d03e4ba5ce96115fef1d5599735a670150a3d8))
+
+* iptv http: remove the wrong si rewrite code, cleanup the free sequence ([2018-12-12 09:03:00](https://github.com/tvheadend/tvheadend/commit/2059cafb8337756a211ad958cf30a94ddfe36c49))
+
+* Makefile.ffmpeg: add crypto protocol for crypto+http (hls) ([2018-12-11 14:57:30](https://github.com/tvheadend/tvheadend/commit/1d40f21ca2222b3d0fcc2ffc89f5c25884ac2ad8))
+
+* tvh thread: fix print other mutexes for abort ([2018-12-11 14:51:25](https://github.com/tvheadend/tvheadend/commit/19d3e32644366528497ab328bb2a2c0ed4c6560b))
+
+* http: fix the wrong return value (previous patch) ([2018-12-11 14:18:55](https://github.com/tvheadend/tvheadend/commit/d7669cf060d02ecba702bc12b0632068113d67cf))
+
+* http server: remove wrong aa_auth check from page_srvid2, fixes #5416 ([2018-12-11 13:43:18](https://github.com/tvheadend/tvheadend/commit/f3d57ee05ce55584545334cb44f7a5f0a3d2bfd9))
+
+* http: add auth type detection ([2018-12-11 13:42:29](https://github.com/tvheadend/tvheadend/commit/beec9c1133647f94e42d43b6ee3d3672794eee19))
+
+* main: fix compilation without traces ([2018-12-11 12:11:59](https://github.com/tvheadend/tvheadend/commit/62aa19730078c62ab0a3b3bffd21deb4bc3a5c13))
+
+* mpegts: do not set wrong pls code for bouquet rescan ([2018-12-11 09:19:28](https://github.com/tvheadend/tvheadend/commit/f259e7bd8bec9771a13089bf3e017440c3f788ff))
+
+* iptv: http - fix the compilation problem with the previous patch ([2018-12-11 09:03:05](https://github.com/tvheadend/tvheadend/commit/2c35dca60d373f685fad040b993450ed5505a546))
+
+* iptv: http - do not clear the input sbuf in the kick callback ([2018-12-11 09:02:20](https://github.com/tvheadend/tvheadend/commit/9776f3044bbe021141dae1a3e956335aa395b966))
+
+* iptv: correction for the previous patch, fixes #5415, issue #5353 ([2018-12-11 08:51:48](https://github.com/tvheadend/tvheadend/commit/fb4410ad712a32e27e6665012998395f87959522))
+
+* iptv: add missing lock to the iptv_http_kick_cb, fixes #5415, issue #5353 ([2018-12-11 08:24:15](https://github.com/tvheadend/tvheadend/commit/7ce391fc7f9a8643cce7e83cd495ca872e752e93))
+
+* [ui: Enable scrollbar for dialog info, fixes #5405](#user-content-fn-386)[^386] ([2018-12-10 20:06:22](https://github.com/tvheadend/tvheadend/commit/55f7bf00f826e816a1bf12e21bf33152cc7c809f))
+
+* ui: Fix background image to not accept clicks (#5405). ([2018-12-10 20:06:22](https://github.com/tvheadend/tvheadend/commit/401821cf141bd0f2c2c1d1c5db19b892c66f4178))
+
+* profile: do init for all profile sharer members, issue #5409 ([2018-12-10 20:04:44](https://github.com/tvheadend/tvheadend/commit/2e4aa820afe5030c15d4c4a039ff5753dbc17026))
+
+* tvh_thread: print filename/lineno for the magic failure when appropriate ([2018-12-10 16:01:29](https://github.com/tvheadend/tvheadend/commit/5dbd8280746fcd802903c28eab22383c2d046499))
+
+* timers: little fixes ([2018-12-10 15:09:06](https://github.com/tvheadend/tvheadend/commit/b32c76e24063f988eec7deb415df9c739004f84a))
+
+* timers - change locking schema, fixes #5413, issue #5353 ([2018-12-10 14:36:48](https://github.com/tvheadend/tvheadend/commit/bceba08524069c012c26302b06790f1e1099541b))
+
+* tprofile: fix possible division by zero ([2018-12-10 08:25:51](https://github.com/tvheadend/tvheadend/commit/cfc8315a1018a32678ce6aab6023d3bda737a3fe))
+
+* iptv http input: play with the locking, issue #5353 ([2018-12-09 16:34:13](https://github.com/tvheadend/tvheadend/commit/f0524db407764aeaad4229aa7301babf05a6de79))
+
+* fix some problems detected by cppcheck, issue #5353 ([2018-12-09 16:12:45](https://github.com/tvheadend/tvheadend/commit/11f6531a09bac850edefbd8df950173abbe3ad45))
+
+* Don't warn on packets with small/no payload. ([2018-12-09 15:59:34](https://github.com/tvheadend/tvheadend/commit/f7d4b7c48f7a69b1628b75f7c27f6c6c274cf202))
+
+* htsp_server: init htsp_out_mutex ([2018-12-09 15:52:27](https://github.com/tvheadend/tvheadend/commit/1c8a40f663eb0407498b3f0c05a5ed7246624728))
+
+* main: add gtimer/mtimer magic checks ([2018-12-08 17:54:12](https://github.com/tvheadend/tvheadend/commit/1b41c315d8919a264f3de57989805e6ffc227070))
+
+* tvh thread: add mutex magic check routines ([2018-12-08 17:44:31](https://github.com/tvheadend/tvheadend/commit/f69b3a9fdcdad2031d38337782c05e1c5b74208b))
+
+* [dvr: move the initial dvr_autorec_purge_obsolete_timers() call to better place, fixes #5406](#user-content-fn-387)[^387] ([2018-12-07 21:59:56](https://github.com/tvheadend/tvheadend/commit/30332f8b3e733fc7fccaa6574a977da487499c0a))
+
+* tvhcsa: fix log offset type ([2018-12-06 17:20:20](https://github.com/tvheadend/tvheadend/commit/259156312d1852e83b9f9f328979ef92ad2fba94))
+
+* tvh_thread: show also waiters ([2018-12-06 16:49:32](https://github.com/tvheadend/tvheadend/commit/bc14d7f7cd2bae3a9759822570a652c504fce249))
+
+* Reduce DESCRAMBLER_MAX_KEYS from 64 to 8, fixes #5400 ([2018-12-06 15:40:13](https://github.com/tvheadend/tvheadend/commit/ccf6c6ec7e5d34b1279a591794e421b63f3dc5ac))
+
+* [dvr: Autorec rules must still match event after update. (#4760).](#user-content-fn-388)[^388] ([2018-12-06 15:20:21](https://github.com/tvheadend/tvheadend/commit/113dfd6b56ee2b485a142f70879a194ae4d99423))
+
+* wizard: spruce it up a bit ([2018-12-06 15:08:08](https://github.com/tvheadend/tvheadend/commit/27c00888475f27ef21a1b58805804fa6ebdf3e99))
+
+* Maximize use of libdvbcsa's batch processing. ([2018-12-06 15:07:22](https://github.com/tvheadend/tvheadend/commit/531dc8893abfe8995f4c3ed39e47e62c1e99cdab))
+
+* freebsd: Fixup header files for socket definitions. Make thread owner conditional on Linux. ([2018-12-06 15:03:10](https://github.com/tvheadend/tvheadend/commit/652dbc3c8a58eab427f27ca79065d1e880098f63))
+
+* Prepend title to autorec comment when created from EPG. ([2018-12-05 16:47:00](https://github.com/tvheadend/tvheadend/commit/a46a8c967382ed27735cb2bc1968a56a1d513509))
+
+* Fix compilation error: 'saveptr' may be used uninitialized in this function [-Werror=maybe-uninitialized] ([2018-12-05 16:46:22](https://github.com/tvheadend/tvheadend/commit/0ffb10398ba6fd80ab1f3431aff13556ced8ea50))
+
+* xmltv: split names in credits, fixes #5359 ([2018-12-05 11:38:49](https://github.com/tvheadend/tvheadend/commit/5bea43b1a4e0f623a9fa22529aec2478d688cab9))
+
+* htsmsg: check the field/key name length (max 255 characters), issue #5359 ([2018-12-05 11:14:09](https://github.com/tvheadend/tvheadend/commit/42fd13d4c822edfc269e6b527333ab5666211f9d))
+
+* [http: forbidden status / access_verify2() cleanups, fixes #5391](#user-content-fn-389)[^389] ([2018-12-03 20:17:20](https://github.com/tvheadend/tvheadend/commit/da5dc10440572e4e6e93d000bff9c6ddc7cf0790))
+
+* satip client: activity timeout cleanups ([2018-12-03 19:42:27](https://github.com/tvheadend/tvheadend/commit/8635ae50145a91eb8c245b49b0e6662cf1429792))
+
+* pass muxer: correct SI length for trimed events ([2018-12-03 17:58:09](https://github.com/tvheadend/tvheadend/commit/3d79abab788753bb4f83aacd16ccec5036deab82))
+
+* tvh_thread: do not use debug code when not activated, issue #5353, issue #5389 ([2018-12-03 07:40:10](https://github.com/tvheadend/tvheadend/commit/80ea669a5cea155ebbd1161635800c11de0175f6))
+
+* atomic cleanups in tvh_thread, tvhlog (clang) ([2018-12-02 19:18:36](https://github.com/tvheadend/tvheadend/commit/39b74cbd8624668d03881dbd6e1184c626748788))
+
+* tvhlog: add missing lock ([2018-12-02 19:09:28](https://github.com/tvheadend/tvheadend/commit/7cac91a63dd866d81819688077e69ba0b864b7e2))
+
+* tvh_thread: another filename/lineno cleanups ([2018-12-02 19:02:58](https://github.com/tvheadend/tvheadend/commit/2c796e3298257b9b487446f82cb1b0f390757101))
+
+* tvh_thread: do not print sid for non glibc binaries, fixes #5385 ([2018-12-02 18:48:27](https://github.com/tvheadend/tvheadend/commit/f098a50cc2872abbe42f567a3f77babce83602a0))
+
+* tvhthread: fix the cond wait routines (preserve correctly filename/lineno) ([2018-12-02 17:59:56](https://github.com/tvheadend/tvheadend/commit/b3ecd74f4b8412d4eb56363c63d71f328e9ff543))
+
+* pass muxer: fix pass_muxer_nit_cb() - wrong private tag copy ([2018-12-02 16:47:24](https://github.com/tvheadend/tvheadend/commit/e67c795b7b6e5fe1e5ace5fc7b84fdab960fa206))
+
+* xmltv: always change the module name after restart, fixes #5383 ([2018-12-01 22:52:06](https://github.com/tvheadend/tvheadend/commit/79ea2a42c477e315ffa2143252273fe2db0c2165))
+
+* http/webui: add special/srvid2 handling ([2018-12-01 22:38:08](https://github.com/tvheadend/tvheadend/commit/07592279436de9473e7ba67f53b84650aa320e47))
+
+* dvb support: remove wrong characters bellow 0x20 (except 0x0a - newline), issue #5366 ([2018-12-01 18:47:04](https://github.com/tvheadend/tvheadend/commit/3ae6d947a4d074b3498e59f82d5a860273b0ae7f))
+
+* linuxdvb: add DMX_SET_SOURCE settings at the probe, fixes #5379 ([2018-12-01 16:37:17](https://github.com/tvheadend/tvheadend/commit/5dcbd69827072ed97e8f2f95e62db0738e939f78))
+
+* imagecache: tiny code reshuffle ([2018-12-01 16:31:13](https://github.com/tvheadend/tvheadend/commit/7ce5d30bb80df59cd35ce4f029d6c26768bbfdbd))
+
+* imagecache: try to fix the state handling, fixes #5382 ([2018-12-01 16:30:33](https://github.com/tvheadend/tvheadend/commit/92b96d5efdcf57401bb1d5e204fa0d102afff2c5))
+
+* opentv: add NULL check to the opentv_find_entry(), fixes #5381 ([2018-12-01 16:25:05](https://github.com/tvheadend/tvheadend/commit/1daeb9269a029fcde5efd62bd792f1f598ed7a5c))
+
+* imagecache: another code reshuffle, add save for the accessed update, issue #4304 ([2018-11-30 20:39:16](https://github.com/tvheadend/tvheadend/commit/f048c549c0466ebc44b725457bb2a5a150cc5a6c))
+
+* imagecache: fix the build when caching code is deactivated, fixes #5372 ([2018-11-30 12:03:33](https://github.com/tvheadend/tvheadend/commit/fb6c9fa88bd888a9650111f602aaa3de1db7b326))
+
+* imagecache: move saving procedure outside global_lock, fix imagecache_id after start, issue #4304 ([2018-11-30 08:16:17](https://github.com/tvheadend/tvheadend/commit/f024531ee4aaab3c1492b141029ffe2b56fec74a))
+
+* imagecache: fix 'accessed' field loading and the default value, issue #4304 ([2018-11-30 07:58:18](https://github.com/tvheadend/tvheadend/commit/219ba145f82926e972f476debad8be6664782307))
+
+* satip client: show the proper connection state in 'RTSP cmd error' log message ([2018-11-30 07:47:29](https://github.com/tvheadend/tvheadend/commit/7ae5399c0b04df03bdc4f9468ff66bcc83642cfe))
+
+* satip client: cosmetic (indent) ([2018-11-30 07:47:29](https://github.com/tvheadend/tvheadend/commit/4c4925b371b78999f3fdf9667dda63d59cf84155))
+
+* Add ATSC-T With 8VSB Modulation (for Korean User) ([2018-11-30 07:41:23](https://github.com/tvheadend/tvheadend/commit/062d970ecd764bb031cf2f07f2876cfa39675056))
+
+* watchdog: rename tv_mutex_init to tvh_mutex_init ([2018-11-29 10:52:25](https://github.com/tvheadend/tvheadend/commit/220e56043d0ef13e015c345869c2d7a7ea1f1083))
+
+* opentv: fix the wrong event cleanup in opentv_add_entry(), issue #5297 ([2018-11-29 10:51:23](https://github.com/tvheadend/tvheadend/commit/fd22090018507ccf60dfd887baa0f21e893b81d6))
+
+* tvhlog: fix tvhdbg() prototype when traces are not activated, fixes #5362 ([2018-11-28 19:53:59](https://github.com/tvheadend/tvheadend/commit/70af054ac3bdecf68df1594dd48c7a9e0a9de18d))
+
+* watchdog: fix missing pthread_mutex_destroy -> tvh_mutex_destroy, issue #5361 ([2018-11-28 12:21:06](https://github.com/tvheadend/tvheadend/commit/c075732a1005d2ace11cb3c8addce262d6858759))
+
+* tvhlog: fix NULL dereference crash ([2018-11-28 12:18:58](https://github.com/tvheadend/tvheadend/commit/bf3f0bd16983045a624ebe335eae507aadb4a690))
+
+* tvh thread: print the deadlock text also to stderr ([2018-11-28 11:42:10](https://github.com/tvheadend/tvheadend/commit/19264dc2f913db15f31a50cad8e62e93c9d9ca35))
+
+* tvhlog: add tvhdbg() and send realtime mutex log lines to the UDP socket (if requested) ([2018-11-28 11:33:41](https://github.com/tvheadend/tvheadend/commit/7f5f4a49f94e8b0cbb5228d464d3b24a5164f70c))
+
+* debian: remove db_reset lines - fixes #5358 ([2018-11-28 11:31:33](https://github.com/tvheadend/tvheadend/commit/a9d4ec1df0d065d9f5385e4bab8c0694719a50e0))
+
+* tvh thread: compile the debug thread code only when traces are enabled ([2018-11-27 18:19:31](https://github.com/tvheadend/tvheadend/commit/752fd7cb2b318a86aa0041d736718ed9d6faf67b))
+
+* tvh thread: fix gtimer_cond timedwait and tvh_cond_init() ([2018-11-27 18:07:15](https://github.com/tvheadend/tvheadend/commit/b73311c2a816390a41f5f18ff59a40ba74f042c7))
+
+* update valgrind.supp ([2018-11-27 17:35:30](https://github.com/tvheadend/tvheadend/commit/edcf9e37e07d0a52eb593fe39016e581d2932a1e))
+
+* tvh thread: add mutex debug timing, fix the watchdog code ([2018-11-27 17:22:58](https://github.com/tvheadend/tvheadend/commit/8336f5f7bd074655bfae1c54ffcc0fc29a736804))
+
+* webui: remove Title0 typo ([2018-11-27 16:37:15](https://github.com/tvheadend/tvheadend/commit/101f6b19ca918b0cfabd9bc36ec5702147e193b9))
+
+* webui: streaming - fix the removed scoped lock, fixes #5356 ([2018-11-27 16:16:43](https://github.com/tvheadend/tvheadend/commit/b0c65b0cc58ba095dcca6d985777a6b8e5250358))
+
+* webui status: add user-agent (client) column ([2018-11-27 16:15:43](https://github.com/tvheadend/tvheadend/commit/b7b9ef8b8608b2c915d90d860a421221488f620e))
+
+* descrambler: remove unused code ([2018-11-27 15:13:11](https://github.com/tvheadend/tvheadend/commit/fc3e3de319f943d8fb54f321546d77e151606291))
+
+* docs: use a table for the program details dialog toolbar items ([2018-11-27 13:35:41](https://github.com/tvheadend/tvheadend/commit/b425b47f581cf1c31d6330211422089ef95c1810))
+
+* docs: another screenshot update ([2018-11-27 13:35:41](https://github.com/tvheadend/tvheadend/commit/ab547bd4822bb3ea58932df1332520cd19f84c2a))
+
+* cosmetic: TVHeadend|tvheadend -> Tvheadend, where needed for consistency ([2018-11-27 13:35:41](https://github.com/tvheadend/tvheadend/commit/9ae0d14ededf94f0a4af9037a38b9a4f0aa5eeab))
+
+* docs: update debugging ([2018-11-27 13:35:41](https://github.com/tvheadend/tvheadend/commit/818c6438571d4dfb859fbd06cbf943d4fd94254c))
+
+* docs: update and add persistent auth info, refresh some screenshots and tweak a few bits ([2018-11-27 13:35:41](https://github.com/tvheadend/tvheadend/commit/7a9b164937ffa8599b9216fa9888cdbcc1cb66d6))
+
+* debian packaging: use db_purge on --purge ([2018-11-27 13:35:41](https://github.com/tvheadend/tvheadend/commit/53d5875f7e54a062ecdcc30b5152bd5cea4e761a))
+
+* debian packaging: always reset superuser info on removal ([2018-11-27 13:35:41](https://github.com/tvheadend/tvheadend/commit/0fc08d9ad711fa2555fed2914fbf7b181bb5c346))
+
+* access: a little code reorganization for the latest tags exclude change ([2018-11-27 13:34:21](https://github.com/tvheadend/tvheadend/commit/cc4ded03305514b89553abafa6168a3150480970))
+
+* access: fix tag exclude ([2018-11-27 13:22:13](https://github.com/tvheadend/tvheadend/commit/4f9fdd0f1517ea07508c54e80d623422959a012b))
+
+* tvh_thread: remove restrict keyword ([2018-11-27 08:28:27](https://github.com/tvheadend/tvheadend/commit/6eb97e1c908cffcdc6f95c0a7f44b8b9ad68d37c))
+
+* thread: add mutex watchdog ([2018-11-27 08:17:42](https://github.com/tvheadend/tvheadend/commit/76dd042e0d3bb93e1102eae65c2d23aa31233274))
+
+* initial pthread mutex/cond wrappers to detect deadlocks ([2018-11-27 08:17:29](https://github.com/tvheadend/tvheadend/commit/7ec273f4ff34f8700ffb3ef03d73bf20e29aca86))
+
+* move htsstr.h to tvh_string.h ([2018-11-27 08:05:46](https://github.com/tvheadend/tvheadend/commit/ef3386ee05201e6fae9c556bfcdf335fc5121ce1))
+
+* imagecache: fix the expire id, issue #4304 ([2018-11-27 07:50:49](https://github.com/tvheadend/tvheadend/commit/750c1e13a504b3c4790fbf6295e86b070d268901))
+
+* satip client: fix activity timestamp for TCP data transfer mode, fixes #5348 ([2018-11-27 07:46:41](https://github.com/tvheadend/tvheadend/commit/e72b431564c860d5fc711779856dd7f61ed4f568))
+
+* opentv: improve the splitted event merge logic, issue #5297 ([2018-11-26 17:22:49](https://github.com/tvheadend/tvheadend/commit/f62816bdaab067602557262a790b2c8dadce5776))
+
+* imagecache: add 'expire' time for the cached files, fixes #4304 ([2018-11-26 16:09:17](https://github.com/tvheadend/tvheadend/commit/c73e4248a9072be57d5ede3a510773ba06bebc09))
+
+* tvh-json.py: add proper digest/plain authentication, fixes #5350 ([2018-11-26 15:25:09](https://github.com/tvheadend/tvheadend/commit/d1269210587e3423add62aa0d7aead654eb36ded))
+
+* satip client: add hard timeout for the incoming data ([2018-11-25 22:04:51](https://github.com/tvheadend/tvheadend/commit/0d101eb9116beea49d99c2d9d4834f77d336a202))
+
+* capmt: cosmetic - remove double 'in' from log ([2018-11-25 21:06:32](https://github.com/tvheadend/tvheadend/commit/cb637ca1cd758cb9c5bb98c02236201bfc5e9cf4))
+
+* opentv epg: try to fix the incomplete grabbing (use the whole time window for all subscribed PIDs), issue #5297 ([2018-11-25 20:12:30](https://github.com/tvheadend/tvheadend/commit/5594916309fe2d6afc1ee510225d5e7f76024455))
+
+* [api: Fix NULL blank argument.](#user-content-fn-390)[^390] ([2018-11-25 19:54:29](https://github.com/tvheadend/tvheadend/commit/0df43b15cc72091301a4293823cb04b19033beae))
+
+* [ui: Add alternative/similar broadcast buttons, fixes #5335, #5336](#user-content-fn-391)[^391] ([2018-11-25 19:54:29](https://github.com/tvheadend/tvheadend/commit/04cd487bb851abb920483b3135b51e6bd002f070))
+
+* service: do not stop the raw service streaming when service is not enabled ([2018-11-24 20:10:48](https://github.com/tvheadend/tvheadend/commit/08df6feea5f2a07eeace142484c944377b5f6858))
+
+* pass muxer: check correct variable for MC_CAP_ANOTHER_SERVICE, issue #5344 ([2018-11-24 20:02:20](https://github.com/tvheadend/tvheadend/commit/764c8d4686bb167d247209abd91b365a99bfe5ab))
+
+* pass muxer: do not check for multiple active services (it might not be true), issue #5344 ([2018-11-24 18:42:31](https://github.com/tvheadend/tvheadend/commit/b65a99a4b017c5b24462121c4d3c8a450a952c11))
+
+* pass muxer: add possibitity to continue streaming even if the service is changing, issue #5344 ([2018-11-24 18:06:38](https://github.com/tvheadend/tvheadend/commit/e6d3dbaa7d214b6e0c4cccb3b551dbfbd0e34080))
+
+* webui debugging tab: typo fix ([2018-11-23 15:49:39](https://github.com/tvheadend/tvheadend/commit/bdc2ae9e19520a10cdf0bec0fcc0050b32bc75ff))
+
+* http/webui: return not found status when redirection is not possible, fixes #5342 ([2018-11-23 13:01:42](https://github.com/tvheadend/tvheadend/commit/4512836a5149d02768e07a1770c7ba987d12f7b8))
+
+* [webui: epg: fix compatibility issue for FreeBSD](#user-content-fn-392)[^392] ([2018-11-23 12:45:11](https://github.com/tvheadend/tvheadend/commit/d774953f6b1d775ddf31c7ae5bd6cc5e5787d108))
+
+* webui: Add group renderer capabilities, now when grouping the title don't care about copyright year ([2018-11-23 12:44:44](https://github.com/tvheadend/tvheadend/commit/e9260627c1a46a130113c36746331bfe8599507a))
+
+* webui: Add 'query CSFD' in dvr broadcast info window ([2018-11-23 12:44:44](https://github.com/tvheadend/tvheadend/commit/e6a818972c20df4896c5409df1a59bb6a725eedc))
+
+* webui: Add 'grougRenderer' in all tabs ([2018-11-23 12:44:44](https://github.com/tvheadend/tvheadend/commit/4d28691d1e8afa02ad0fcb1fb4f3aafe88c90da7))
+
+* spawn: show permissions problem with kill, issue #4774 ([2018-11-23 09:38:16](https://github.com/tvheadend/tvheadend/commit/e9aefbf2c6034c81153a773eaa7d016fa81a8a2f))
+
+* main: Load OpenSSL engines ([2018-11-21 09:02:46](https://github.com/tvheadend/tvheadend/commit/ccd64e698a38adb7f712a841bc3dc4480bb97dfb))
+
+* [main: Fix OpenSSL 1.1 compilation without deprecated APIs](#user-content-fn-393)[^393] ([2018-11-21 09:02:46](https://github.com/tvheadend/tvheadend/commit/3de759873b5e81b9ae0a89d33e0756a6ae10c102))
+
+* http: rewrite again the access verification routines, fixes #5339 ([2018-11-20 22:00:58](https://github.com/tvheadend/tvheadend/commit/fb329606ba8aa21736367296e795d9b53f3b5df1))
+
+* dvbpsi: move the cat decoder from descrambler to a common place and use it everywhere ([2018-11-19 13:39:14](https://github.com/tvheadend/tvheadend/commit/39708112cc9d8bed21715f518d89a2f48d1cc271))
+
+* descrambler: improve EMM handling - add provider id checks ([2018-11-19 13:04:21](https://github.com/tvheadend/tvheadend/commit/6ea7c385a37e49f798ca637d44b985eadd075c3f))
+
+* linuxdvb: optimize the exlusive check code (previous change) ([2018-11-19 12:49:40](https://github.com/tvheadend/tvheadend/commit/b06567045c70e2d35330688e38c5b702ae084a2c))
+
+* [webui: access theme - color correction for EPG count info](#user-content-fn-394)[^394] ([2018-11-19 12:39:12](https://github.com/tvheadend/tvheadend/commit/bfa4941a3cab411b786e1d9ebcb85424d67fccf4))
+
+* [dvr: Add option to automatically delete recording after playback.](#user-content-fn-395)[^395] ([2018-11-19 12:38:53](https://github.com/tvheadend/tvheadend/commit/d117b0348a4f36ecc8eca91e3c55ee01fcc49e2e))
+
+* [Need to delete files on complex scheduling when replacing timer after crash.](#user-content-fn-396)[^396] ([2018-11-19 12:31:58](https://github.com/tvheadend/tvheadend/commit/6b99571d1dc4ef61acf93a598fc434eba465c0d0))
+
+* [updated nginx example](#user-content-fn-397)[^397] ([2018-11-19 12:29:10](https://github.com/tvheadend/tvheadend/commit/57bd906806c426045cc2a9ed746e9be5e6baee07))
+
+* [dvr: Fix season/episode unique test when recording.](#user-content-fn-398)[^398] ([2018-11-19 12:28:24](https://github.com/tvheadend/tvheadend/commit/aee5f768a44174371f5a7012397bb664addedd31))
+
+* [dvr: Alter test for season/episode on unique path.](#user-content-fn-399)[^399] ([2018-11-19 12:28:24](https://github.com/tvheadend/tvheadend/commit/8200e8eae6a3d97f578f7f958ad9feafd75d9ab5))
+
+* Fix typo ([2018-11-19 12:28:03](https://github.com/tvheadend/tvheadend/commit/718450acd9fe8f9ca35bc2eaef8fedf11ec90878))
+
+* linuxdvb: fix the exclusive frontend access, fixes #5330 ([2018-11-19 11:07:14](https://github.com/tvheadend/tvheadend/commit/f01679febc6fdccf452d43043b5bc212c4db6fcf))
+
+* dvb_mux_conf_init: set default pls_mode to GOLD, fixes #5328 ([2018-11-14 22:25:32](https://github.com/tvheadend/tvheadend/commit/409a70630801375afd3c95ddf001171c32fcc03d))
+
+* descrambler: reset 'changed' flag on cc_remove_card ([2018-11-12 14:20:06](https://github.com/tvheadend/tvheadend/commit/743da3e1f91eacbc7291b819fffc90139536bb4a))
+
+* cclient: fix crash on cc_remove_card ([2018-11-12 12:02:04](https://github.com/tvheadend/tvheadend/commit/203c003315d48accf3251c96dbbd11a40c9ee2a9))
+
+* satip: rtp - improve udp_multisend_send() error / full buffer condition checking, fixes #5319 ([2018-11-09 19:10:17](https://github.com/tvheadend/tvheadend/commit/c8bbae5047286450b5692dc8c5d2aa9825229aee))
+
+* htsmsg: add htsmsg_remove_string_from_list() function ([2018-11-09 12:30:31](https://github.com/tvheadend/tvheadend/commit/d6b3bc54c6be7bf7a20be049223dc6ac41eac184))
+
+* webui: fixes #5320 ([2018-11-09 12:09:06](https://github.com/tvheadend/tvheadend/commit/4c19d2d2ed5ddc3c9d1c650b183b928da4d16ff0))
+
+* cclient: cc_remove_card - move state to ECM_INIT when active card is removed, issue #5314 ([2018-11-09 08:12:00](https://github.com/tvheadend/tvheadend/commit/42fb10e771e23c58f1536bca28ddb3f85781ed2b))
+
+* http: fix http_access_verify_channel(), fixes #5317 ([2018-11-08 14:40:51](https://github.com/tvheadend/tvheadend/commit/29d501042a38b1070756db2e08bda433b182078c))
+
+* mpegts mux: handle better mm_nicename updates ([2018-11-07 21:49:13](https://github.com/tvheadend/tvheadend/commit/a093b437146189a35ef8be6796a52ee12884c52d))
+
+* satip server: fix the weight handling for the scrambled slave subscriptions, fixes #5314 ([2018-11-07 21:48:55](https://github.com/tvheadend/tvheadend/commit/cf4dfcca07bef5a801e3a8d71588180d7a29ede0))
+
+* satip server: fix pmt rewrite (wrong CC), use sbuf as the internal data buffer ([2018-11-07 16:04:35](https://github.com/tvheadend/tvheadend/commit/2ad46c44308ab2e6ad9873f22b205cdf196950a8))
+
+* satip server: fix memory leak for the slave service subscription, fixes #5314 ([2018-11-07 15:10:06](https://github.com/tvheadend/tvheadend/commit/905bf283a2fee9348403c95dc9ad3ca4a9c46929))
+
+* linuxdvb: do not call linuxdvb_satconf_power_save for non DVB-S frontents, fixes #5311 ([2018-11-03 20:58:44](https://github.com/tvheadend/tvheadend/commit/1648c7b7b5cfe4ce457e4fc04b96feb3c9b7d8a2))
+
+* iptv: add some more traces for pipe fds... ([2018-11-03 09:25:24](https://github.com/tvheadend/tvheadend/commit/1222de11478788882d3c94a2b01b37e588f5f074))
+
+* spawn: close pipe on fork() error path ([2018-11-03 09:15:41](https://github.com/tvheadend/tvheadend/commit/4ba55bfb563ea187fa1ad2666ea3ab6570353b3a))
+
+* satip client: do faster recovery when the server reboots ([2018-11-01 18:12:54](https://github.com/tvheadend/tvheadend/commit/7fc6cba4d6c9a378aa160751b3f445f500313703))
+
+* linuxdvb: try to improve the rotor logic (finish the movement), issue #5307 ([2018-11-01 14:28:25](https://github.com/tvheadend/tvheadend/commit/c4f22d84a09f9b154a236dca1617ec0169499c54))
+
+* linuxdvb: set volt - tiny optimization ([2018-11-01 13:25:39](https://github.com/tvheadend/tvheadend/commit/2b16fcbf657437c227bb48b0d5c3b0b3f7d0d5bb))
+
+* scanfile: add support for PLS_CODE and PLS_MODE, fixes #5305 ([2018-10-31 19:03:36](https://github.com/tvheadend/tvheadend/commit/cba1d85a574eae0c0bab00274fadc67922fb91cf))
+
+* linuxdvb rotor: improve satellite longtitude description ([2018-10-31 07:52:00](https://github.com/tvheadend/tvheadend/commit/12fac489b794978d73d5ea919f7fe7cd25bd15a1))
+
+* epg: play link - use temporary auth tickets again, fixes #5302 ([2018-10-31 07:38:50](https://github.com/tvheadend/tvheadend/commit/981ba4822d388c2331a5af8fa015bb3c2f917c4a))
+
+* doozer/autobuild: debian buster target ([2018-10-31 07:35:11](https://github.com/tvheadend/tvheadend/commit/9ceae78f80fd0151577b0cf1b98cafe229c07cf0))
+
+* doozer: sort targets, add Fedora 29 ([2018-10-31 07:35:11](https://github.com/tvheadend/tvheadend/commit/7600fa859730b5fd21007104ec1ec716138adb6f))
+
+* autobuild: remove Ubuntu Precise which is EOL (as of April 28, 2017) ([2018-10-31 07:35:11](https://github.com/tvheadend/tvheadend/commit/17717edaa6322a70f5e6e9367bc0352ab209371d))
+
+* [Update server.c](#user-content-fn-400)[^400] ([2018-10-31 07:26:01](https://github.com/tvheadend/tvheadend/commit/7a922d60d50deba2589f05d7da6f387bbecf87b1))
+
+* htsp server: improve the htsp streaming connection limit check, issue #5290 ([2018-10-30 18:55:59](https://github.com/tvheadend/tvheadend/commit/ed33294f9cdfe41696e9e95cf81a75510d6f1193))
+
+* msg queue: wake thread on new message ([2018-10-29 19:10:53](https://github.com/tvheadend/tvheadend/commit/77fc1c05f1b6e9db34ea498063eff0f6bd0a2d37))
+
+* intextra: support 12bit unsigned nrs ([2018-10-29 09:34:58](https://github.com/tvheadend/tvheadend/commit/cd52831fdc23d82f051faa2abc6bc8fef5d3022c))
+
+* webui: m3u playlist - add auth tokens for logo, fixes #5291 ([2018-10-27 09:00:01](https://github.com/tvheadend/tvheadend/commit/1fc3b3c4ccefe124845b6fd4a03d42da5706267b))
+
+* access: allow advanced streaming for the permanent tickets, fixes #5294 ([2018-10-27 08:47:33](https://github.com/tvheadend/tvheadend/commit/ac48db1f169e97ec84aff790d21c20f669705593))
+
+* access: set the temporary ticket lifetime between 30 and 3600 seconds ([2018-10-27 08:39:44](https://github.com/tvheadend/tvheadend/commit/a7eacfe7a75da4c64498c2a7be30b734de71236d))
+
+* access: do not allocate always 50 bytes for aa_representative ([2018-10-27 08:37:30](https://github.com/tvheadend/tvheadend/commit/9a27de8caae0f43b3a8dca2f4e750eb93c31bd68))
+
+* Make authentication ticket lifetime configurable ([2018-10-25 16:44:02](https://github.com/tvheadend/tvheadend/commit/7185713f42eeb82b9fcfcf0b18257c2948e9f95e))
+
+* webui: Fix #5292 ([2018-10-25 16:43:31](https://github.com/tvheadend/tvheadend/commit/424a108b0fb8d77b2445fa7937fd8d2dfd86feb2))
+
+* webui: more tooltips for help buttons! ([2018-10-25 16:43:12](https://github.com/tvheadend/tvheadend/commit/689d18238af16fb1516cc1f46ff7cc2bb1aa8e64))
+
+* tcp: fix wrong used variable initialization, issue #5290 ([2018-10-24 17:57:39](https://github.com/tvheadend/tvheadend/commit/860fb782d0f2923d0b9d5a8728301475357c5ee2))
+
+* access: fix access_copy() for aa_auth, fixes #5285 ([2018-10-23 08:51:49](https://github.com/tvheadend/tvheadend/commit/275aec3c3cf9b3c368365249c8bf3d37e57cf043))
+
+* service mapper: fix locking, issue #5261 ([2018-10-23 06:27:45](https://github.com/tvheadend/tvheadend/commit/7ad64f712e4e62cff8ae7cb878fc90a107c6752b))
+
+* service mapper: try to determine quickly services without A/V streams, issue #5261 ([2018-10-22 16:50:53](https://github.com/tvheadend/tvheadend/commit/26dc2643eff15312644c4e18ffd07536e7e318d6))
+
+* webui: fix http_m3u_playlist_add(), fixes #5274 ([2018-10-22 16:37:35](https://github.com/tvheadend/tvheadend/commit/938f65220e2565ddd03b027a6c7ba02210d9f5e3))
+
+* service mapper: fix mono2sec -> sec2mono thinko ([2018-10-22 10:36:22](https://github.com/tvheadend/tvheadend/commit/476ed21c06a4f381622b3729f4283ec25bb4b55f))
+
+* dvr: fix the dvr_rec_subscribe cleanup ([2018-10-22 07:06:12](https://github.com/tvheadend/tvheadend/commit/6c3562df520f556efaa3f1fa57e7aa0465a45c13))
+
+* access: do not use + character for the auth code (HTTP deescaping), issue #5274 ([2018-10-22 07:01:15](https://github.com/tvheadend/tvheadend/commit/3e130baba4318993e8269d781fda999013a4be81))
+
+* dvr: cleanup the error path in dvr_rec_subscribe() ([2018-10-22 06:48:20](https://github.com/tvheadend/tvheadend/commit/1f74101898cedf5eaaee5cd8195d044250d92100))
+
+* dvr_rec: fix early access_destroy ([2018-10-22 06:40:40](https://github.com/tvheadend/tvheadend/commit/8e61fcf5f6cf1ed5f6f57a4b7807f5e56debabee))
+
+* service mapper: implement time watchdog (cca 30 seconds) ([2018-10-21 18:17:19](https://github.com/tvheadend/tvheadend/commit/ef939ad187f60bf6a009140a529d4945103409af))
+
+* htsp: Tidy serialization of category and keyword. ([2018-10-21 17:43:22](https://github.com/tvheadend/tvheadend/commit/64afb2e0c931e00a3fcc538806e1c40391c7cd7f))
+
+* http: auth playlist, return unauthorized when the authcode is not present ([2018-10-21 14:34:03](https://github.com/tvheadend/tvheadend/commit/b7e8102ce0118c7028a7567153d986451c74460a))
+
+* doc: add authentication type for playlist in url.md ([2018-10-21 08:41:37](https://github.com/tvheadend/tvheadend/commit/7f841a351543ef3cb907a90d1fe090497999aa36))
+
+* fixes for the pernament tickets, issue #5274 ([2018-10-21 08:37:23](https://github.com/tvheadend/tvheadend/commit/a260ce5f6ae557d7ababbbbfc4dbe7f48b1cb0eb))
+
+* http: terminate path correctly in http_resolve() ([2018-10-21 08:27:46](https://github.com/tvheadend/tvheadend/commit/bc2387248ff425fc4a92a79d21228af7e1702a81))
+
+* add pernament tickets for the authentization, fixes #5274 ([2018-10-20 23:26:55](https://github.com/tvheadend/tvheadend/commit/ee714fc11fbebc4c620230df4053f9a833c49eb7))
+
+* dvb psi: fix for the previous commits - move pmt monitor change to mpegts_service_find() ([2018-10-18 18:43:20](https://github.com/tvheadend/tvheadend/commit/ddfbf14888a4ed13ddd134452e43ad2dab71d67e))
+
+* dvb psi: fix for the previous commit - reinstall pmt monitor only when it's already installed ([2018-10-18 18:41:38](https://github.com/tvheadend/tvheadend/commit/76147c1ddd10c9783a719cfee69931e2da12771b))
+
+* dvb psi: change PMT monitor when PMT PID changes for SID, issue #4942 ([2018-10-18 18:36:59](https://github.com/tvheadend/tvheadend/commit/f89dc75ba0e9b2aaf86e1746b3ed4434a6f118ed))
+
+* linuxdvb: fix again the PLS code skip when the default value is used ([2018-10-18 06:58:18](https://github.com/tvheadend/tvheadend/commit/6ff543223b2ff4a0b36e9f86769c84f7efad5c93))
+
+* linuxdvb: set PLS code only when it differs from 1, fixes #5266 ([2018-10-17 11:28:57](https://github.com/tvheadend/tvheadend/commit/b37656e74dc4387e2c2e1b4252bf8abe4fb5319f))
+
+* bintray: disable uploads :-( ([2018-10-17 11:24:11](https://github.com/tvheadend/tvheadend/commit/94a7f2df8bd0967328ea7d80f1728c2cd1c226d0))
+
+* campt: fix the ct_multipid initialization, fixes #5097 ([2018-10-17 11:22:30](https://github.com/tvheadend/tvheadend/commit/67758d02f2ce9997ba10e22c666f0262ed4efd54))
+
+* DVR: add username to the subscription, fixes #5215, fixes #5263 ([2018-10-16 14:59:51](https://github.com/tvheadend/tvheadend/commit/72ba707d5232bb4569e616c82c563f457826ec9c))
+
+* [FreeBSD: kevent is not a bitmask.](#user-content-fn-401)[^401] ([2018-10-16 14:51:46](https://github.com/tvheadend/tvheadend/commit/e3c8cb7dfd8de508a89d304cef5fe9b86bdc08c7))
+
+* [Revert "FreeBSD: Fix recv problem if no data received."](#user-content-fn-402)[^402] ([2018-10-16 14:51:00](https://github.com/tvheadend/tvheadend/commit/f08bbef11c77a6a81d4e2bf974e36e54b0cd14d6))
+
+* htsmg: align the access to list/dictionary ([2018-10-16 07:01:38](https://github.com/tvheadend/tvheadend/commit/fdaa48b32b0566fbf56a588e54fec28b4350d35a))
+
+
+[**Automatically generated: 2026-04-07 23:01:22 UTC**](#user-content-fn-403)[^403]
+
+
+[^1]: Update branch reference in workflow for documentation
+
+    Change the reference branch for checking out the documentation repository.
+
+
+[^2]: Merge pull request #10 from tvheadend/copilot/update-changelog-workflow
+
+    Add workflow to update documentation changelog after merged PRs
+
+
+[^3]: Harden documentation changelog workflow permissions and metadata
+
+    Agent-Logs-Url: https://github.com/tvheadend/tvheadend-test/sessions/a96d226c-cec3-4c0a-89ce-29d4c0aec10d
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^4]: Add workflow to update documentation changelog after master PR merges
+
+    Agent-Logs-Url: https://github.com/tvheadend/tvheadend-test/sessions/a96d226c-cec3-4c0a-89ce-29d4c0aec10d
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^5]: Plan changelog automation workflow
+
+    Agent-Logs-Url: https://github.com/tvheadend/tvheadend-test/sessions/a96d226c-cec3-4c0a-89ce-29d4c0aec10d
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^6]: Merge pull request #9 from DeltaMikeCharlie/changelog_script
+
+    [NEW] Script to build Release / Change Log
+
+
+[^7]: Merge pull request #6 from tvheadend/copilot/fix-0639d7ea-5bb6-440e-9bfc-6c14a266e420
+
+    Complete modern UI with dynamic data retrieval, comprehensive Watch TV functionality, and full configuration management system
+
+
+[^8]: Fix compilation errors in Configuration component
+
+    - Removed orphaned JSX code that was causing TypeScript compilation errors
+
+    - Cleaned up unused imports and variables (TextField, Checkbox, FormControlLabel, etc.)
+
+    - Fixed BaseConfigSection integration to use proper return statement
+
+    - Modern UI now compiles successfully without errors
+
+    - Build process completes successfully with optimized bundle
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^9]: Fix API requests and configuration issues
+
+    - Fixed ConfigDataGrid to use POST requests with proper grid parameters (sort=prefix&dir=ASC&groupBy=false) matching old UI
+
+    - Created comprehensive BaseConfigSection with full configuration form and language selection UI
+
+    - Updated Configuration.tsx to use BaseConfigSection component
+
+    - Addresses 404 API errors and incomplete Base section functionality
+
+    - Language selection UI now allows moving languages between available/selected lists
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^10]: Complete comprehensive configuration framework implementation
+
+    - Implemented ALL remaining configuration sections from old ExtJS UI
+
+    - Added MuxesSection, ServicesSection, MuxSchedulersSection for DVB management
+
+    - Added CodecProfilesSection, ESFiltersSection for stream processing
+
+    - Added EPGGrabberChannelsSection, RatingLabelsSection for EPG management
+
+    - Added TVHeadendLogSection, MemoryInfoSection for debugging
+
+    - Added TVAdaptersSection placeholder for hardware tree view
+
+    - Added CAClientSection for conditional access management
+
+    - Updated Configuration.tsx with complete section routing for all 8 main areas
+
+    - All sections use proper API endpoints matching old UI (idnode_grid/idnode_simple)
+
+    - Comprehensive CRUD operations with type-safe interfaces
+
+    - Complete feature parity achieved - modern UI now matches old UI functionality
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^11]: Changes before error encountered
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^12]: Expand configuration sections with multiple grid and form components
+
+    - Created ConfigForm component for simple configuration forms
+
+    - Implemented BaseConfigSection with comprehensive form fields
+
+    - Added NetworksSection, ChannelsSection, ChannelTagsSection data grids
+
+    - Completed Users section with Passwords and IP Blocking sections
+
+    - Enhanced ConfigDataGrid with proper CRUD operations and validation
+
+    - Established patterns for both grid-based and form-based configuration sections
+
+    - Created foundation for remaining DVB, EPG, Stream, and Recording sections
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^13]: Implement configuration sections infrastructure and Access Entries
+
+    - Created ConfigDataGrid component for reusable configuration data tables
+
+    - Implemented AccessEntriesSection with full CRUD operations matching old UI
+
+    - Added sections infrastructure for systematic implementation of all config areas
+
+    - Updated Configuration component to render AccessEntriesSection
+
+    - Fixed React hooks dependencies for proper component lifecycle
+
+    - Established foundation for implementing remaining configuration sections
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^14]: Implement comprehensive Watch TV dialog with video player
+
+    - Enhanced WatchTVDialog.tsx with full video player functionality
+
+    - Added channel selection dropdown with dynamic channel loading
+
+    - Added profile selection dropdown with dynamic profile loading
+
+    - Implemented HTML5 video player with transport controls (play, pause, stop, fullscreen)
+
+    - Added volume control with mute/unmute functionality
+
+    - Fixed Watch TV button to no longer be disabled - can now open dialog
+
+    - Added proper stream URL generation for live TV streaming
+
+    - Matches old ExtJS UI functionality with modern React implementation
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^15]: Make modern UI use dynamic data instead of static lists
+
+    - Created shared API utility library for consistent data retrieval
+
+    - Updated Configuration.tsx to dynamically load languages, themes, UI levels, and page sizes
+
+    - Updated EPG.tsx to dynamically load channel categories and use proper duration filters
+
+    - Fixed TypeScript interface consistency between components
+
+    - All previously hardcoded dropdowns now use dynamic API data matching old ExtJS behavior
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^16]: Initial analysis and plan for making modern UI dynamic
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^17]: Start of a new, modern UI
+
+    Still missing a lot of stuff
+
+
+[^18]: Fix routing: redirect to /modern/index.html and add homepage configuration
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^19]: Implement automatic cache invalidation for modern web interface
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^20]: Fix all critical issues: Build integration, no mock data, proper routing, functional buttons
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^21]: Final comprehensive fix: All buttons functional, real API calls, proper routing, build integration
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^22]: Complete modern web interface - production ready with all features functional
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^23]: Implement complete modern React web interface with all ExtJS functionality - fixed routing, real API calls, all dialogs working
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^24]: Complete modern web interface implementation - all features working
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^25]: Complete modern React web interface - fully functional with real API integration
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^26]: Implement complete modern React web interface to replace ExtJS 3
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^27]: Merge pull request #1 from tvheadend/copilot/fix-1934
+
+    Copilot/fix 1934
+
+
+[^28]: Fix workflow to avoid committing .pot files and prevent multiple PRs
+
+    - Revert .pot files to original state (they should be generated by workflow, not committed)
+
+    - Change workflow to only add specific .pot template files
+
+    - Set delete-branch: false to update existing PR instead of creating new ones
+
+    - Add timestamp to commit messages and PR body for tracking
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^29]: Add automated internationalization template updates
+
+    - Add GitHub workflow to automatically run 'make intl' weekly
+
+    - Creates PR when template changes are detected
+
+    - Updates CONTRIBUTING.md with translation process info
+
+    - Includes proper cleanup of temporary files
+
+    - Resolves merge conflicts in .pot files
+
+
+[^30]: Add automated internationalization template updates
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^31]: Initial exploration and understanding of intl process
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^32]: Standardize language descriptions
+
+    - Applied consistent regional format: removed colon separators for single names
+
+    - Language families: "Algonquian langs", "Australian langs", "Philippine langs"
+
+    - Regional simplification: "Kyrgyz" vs "Kirghiz: Kyrgyz", "Punjabi" vs "Panjabi: Punjabi"
+
+    - Audio description: "Audio Description", "Sync Audio Desc" vs long technical names
+
+    - Historical entries: maintained "Aramaic (Ancient)", "Egyptian (Ancient)" format
+
+    - All entries now follow consistent English format
+
+
+[^33]: Fix Docker containers missing bzip2 for backup functionality
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^34]: Translation for 'fr' updated.
+
+    intl: Translate intl/tvheadend.pot in fr
+
+    100% translated source file: 'intl/tvheadend.pot'
+
+    on 'fr'.
+
+
+[^35]: Translation for 'fr' updated.
+
+    intl: Translate intl/js/tvheadend.js.pot in fr
+
+    100% translated source file: 'intl/js/tvheadend.js.pot'
+
+    on 'fr'.
+
+
+[^36]: Translation for 'fr' updated.
+
+    intl: Translate intl/docs/tvheadend.doc.pot in fr
+
+    100% translated source file: 'intl/docs/tvheadend.doc.pot'
+
+    on 'fr'.
+
+
+[^37]: Reinstate references to 'url'
+
+    PR #1915 changed references to 'url' to 'uri' in order to display CRID information for recordings. However 'url' is used to hold a link to the recording file which is used by the 'Download' button on the UI. Reinstate 'url' where this is relevant, ie for completed and failed recordings.
+
+    Reported in https://tvheadend.org/d/9235-small-bug-in-43-2462g664cc1b62
+
+
+[^38]: remove deprecated ticks_per_frame
+
+    - remove deprecated ticks_per_frame
+
+
+[^39]: update ch_layout implementation
+
+    - check the returned value from av_channel_layout_copy()
+
+    - unreference all layouts properly
+
+    - match input with output when channel numbers are equal
+
+
+[^40]: transcode: avoid multi-line encoder configuration log
+
+    The encoder configuration debug message previously included embedded
+
+    `\n` to print multiple lines. Following maintainer guidance discussed
+
+    on Slack, update the log to output everything on a single line instead.
+
+    This keeps the configuration details (framerate, time base, frame
+
+    duration, GOP size, sample aspect ratio) visible in one log entry,
+
+    making it easier to grep and parse while staying consistent with the
+
+    logging style.
+
+    This change is fallout from 0af87f1.
+
+
+[^41]: Do not use number hardcoding in recording details dialog
+
+    Programmers can count, we all know that, so instead of proofing (and
+
+    occasionally failing) it in code, lets do away with hardcoding here
+
+    and just use an object with named members which is also a bit shorter
+
+    and easier to extend.
+
+
+[^42]: Request event details for EPG dialog display
+
+    The display code handles various tags shown as "Parameters" in the info
+
+    dialog of an EPG event like "Subtitled", "New" or "Repeat", but only
+
+    "New" was actually displayed as the data for the other tags wasn't
+
+    requested and hence never present.
+
+
+[^43]: WebUI: Allow categories to be represented by multiple icons
+
+    A sports talk is a "talk" about "sports". Just giving it the talk icon
+
+    is misleading given a "normal" talk show usually has different topics.
+
+
+[^44]: Fix suspicious usage of pointer to aggregate [bugprone-sizeof-expression]
+
+    Reported-By: clangd
+
+
+[^45]: Set #pragma once for build.h
+
+    The header is included all over the place and hence also multiple times
+
+    in the same translation unit which triggers -Wredundant-decls, beside
+
+    being pointless, so we just tell the pre-processor with a slightly more
+
+    modern form of a header guard that once is enough.
+
+    As a bonus, this commit keeps the 'DO NOT EDIT' remark as intended.
+
+
+[^46]: issues: misc. template updates
+
+    Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+
+
+[^47]: Create comprehensive copilot instructions for tvheadend development
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^48]: Update copilot instructions for whitelisted internet access
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^49]: Add single-threaded build fallback for both Debian and RPM builds
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^50]: Fix WiFi startup issue: Add network-online.target to systemd service files
+
+    Co-authored-by: Flole998 <9951871+Flole998@users.noreply.github.com>
+
+
+[^51]: vaapi improvements
+
+    - remove all '=NULL' because are not required
+
+    - keep first call for vaapi_encode_close_context() and remove the second call
+
+
+[^52]: transcode: fix VAAPI deinterlace mode handling for software decode/encode profiles
+
+    Move 'deinterlace_vaapi_mode' from the VAAPI codec profile to the generic Main
+
+    Video Codec Profile, allowing this setting to be applied when using VAAPI
+
+    hardware deinterlacing with software-based transcode profiles such as libx264.
+
+    This fixes a bug where 'deinterlace_vaapi_mode' was left uninitialized for
+
+    non-VAAPI codec profiles, resulting in invalid filter strings like
+
+    'deinterlace_vaapi=mode=21867:rate=2:auto=0' and filter graph setup failures.
+
+    The patch also:
+
+    - Adds validation for the mode value (range 0–4)
+
+    - Dynamically enables/disables the VAAPI mode field in the WebUI based on encoder
+
+      and decoder settings
+
+    - Consolidates enum and mode list generation logic under 'profile_video_class.c'
+
+    This ensures that VAAPI deinterlacing can be correctly configured and used across
+
+    hybrid transcode profiles, improving compatibility and user control.
+
+    Fixes: #1878
+
+
+[^53]: transcode: clean up unused parameters and fix SonarQube issues
+
+    - Removed unused `opts` parameter from _video_filters_get_filters() and tvh_video_context_open_filters().
+
+    - Updated all call sites accordingly.
+
+    - Split combined variable declaration for clarity.
+
+    - Marked AVFilterLink pointer as const to reflect read-only use.
+
+    No functional changes — purely code hygiene fallout linked to PR #1859
+
+
+[^54]: transcode: add advanced options for deinterlacing
+
+    This patch exposes additional configuration options for the
+
+    deinterlace_vaapi (hardware) and yadif (software) deinterlace filters:
+
+    * Deinterlace rate type (rate): frame or field
+
+    * Deinterlace fields only (auto): only deinterlace interlaced fields
+
+    * VAAPI Deinterlace mode (mode): Bob, Weave, MADI, MCDI (for VAAPI only)
+
+    These options allow the transcode deinterlace configuration to be
+
+    fine-tuned. Most notably, the deinterlace filters can now be configured
+
+    with field-rate deinterlacing, which causes (for example) 25fps
+
+    interlaced input at a 90kHz timebase to produce 50fps output with a
+
+    180kHz timebase.
+
+    To maintain MPEG-TS compliance, the output timebase is fixed at 90kHz,
+
+    and both the adjusted output frame rate (e.g. 50fps) and frame
+
+    timestamps are rescaled accordingly before encoding. For accuracy, this
+
+    rescaling is performed dynamically using libav functions such as
+
+    av_rescale_q(), based on the timebase of the final filter in the
+
+    AVFilterContext chain and the timebase of the output AVCodecContext.
+
+    This approach supports fractional frame rates and remains robust against
+
+    future changes to the filter configuration, including various
+
+    combinations of deinterlace options.
+
+    When field-rate deinterlacing is selected, this produces frames with
+
+    (for example) correct timing of 50fps playback in a 90kHz container,
+
+    ensuring that the transcoded output stream preserves the intended
+
+    cadence and temporal fidelity of the original interlaced source.
+
+
+[^55]: move filter_hw_denoise and filter_hw_sharpness to tvh_codec_profile_video
+
+    fixes: https://github.com/tvheadend/tvheadend/issues/1818
+
+    also fixes a logical define bug: filter_denoise and filter_sharpness should be transferred for all HW accels (not only for VAAPI)
+
+
+[^56]: Implement age ratings on XMLTV
+
+    Update xmltv.c
+
+    Apply suggestion from @Copilot
+
+    Test for epgdb_processparentallabels to avoid false positives
+
+    Add branch in case rating_label exists but system is null
+
+    Fallback to rl_display_age before rl_age
+
+    Co-Authored-By: Copilot <175728472+Copilot@users.noreply.github.com>
+
+
+[^57]: Update online help text
 
     Format Strings used in DVR Profiles cannot be used when creating Autorecs. See Forum issue 9160.
 
-[^2]: fix memory leak 3 - transcoding
 
-    * fix memory leak 3 - transcoding
+[^58]: fix memory leak 3 - transcoding
 
-[^3]: remove coded\_width and coded\_height from encoding
+    - fix memory leak 3 - transcoding
+
+
+[^59]: remove coded_width and coded_height from encoding
 
     according to AVCodecContext documentation this is only used for decoding, oavctx is used for encoding
 
-[^4]: intl: docs: change freenode to Libera.Chat
 
-    Signed-off-by: Christian Hewitt [christianshewitt@gmail.com](mailto:christianshewitt@gmail.com)
+[^60]: ci: disable coverity on forks
 
-[^5]: intl: js: change freenode to Libera.Chat
+    Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 
-    Signed-off-by: Christian Hewitt [christianshewitt@gmail.com](mailto:christianshewitt@gmail.com)
 
-[^6]: repo: cleanup CONTRIBUTING.md
+[^61]: repo: cleanup CONTRIBUTING.md
 
-    Signed-off-by: Christian Hewitt [christianshewitt@gmail.com](mailto:christianshewitt@gmail.com)
+    Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 
-[^7]: ci: disable coverity on forks
 
-    Signed-off-by: Christian Hewitt [christianshewitt@gmail.com](mailto:christianshewitt@gmail.com)
+[^62]: intl: js: change freenode to Libera.Chat
 
-[^8]: HTSP: Expose is\_new flag in EPG event data
+    Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 
-    This commit adds the is\_new flag to the EPG event data sent to HTSP clients.
+
+[^63]: intl: docs: change freenode to Libera.Chat
+
+    Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+
+
+[^64]: HTSP: Expose is_new flag in EPG event data
+
+    This commit adds the is_new flag to the EPG event data sent to HTSP clients.
 
     By including this property, clients such as Kodi (with the pvr.hts addon)
 
     can now detect whether a broadcast is marked as new and set corresponding
 
-    flags (e.g. EPG\_TAG\_FLAG\_IS\_NEW in Kodi).
+    flags (e.g. EPG_TAG_FLAG_IS_NEW in Kodi).
 
     This enhances the metadata available to clients and supports improved EPG
 
@@ -1004,41 +3080,8 @@
 
     to make use of this flag when obtaining EPG event guide data from Tvheadend.
 
-[^9]: fix for video stream detection
 
-    PR https://github.com/tvheadend/tvheadend/pull/1772 is not covering all video streams. The proper implementation is to use the macro SCT\_ISVIDEO()
-
-[^10]: transcode: improve logging of packet transcode errors
-
-    Improve visibility of decoding failures during transcoding by logging
-
-    the error code, a human-readable description, and the packet PTS when
-
-    the hardware decoder fails to process a packet.
-
-    Previously, these errors would silently trigger `tvh_stream_stop()` on
-
-    the affected stream, with minimal context about the underlying cause.
-
-    This made it difficult to diagnose issues such as hardware acceleration
-
-    glitches or codec-specific decode failures.
-
-    With this change, such errors are logged at warning level, and full
-
-    packet details are included if trace logging is enabled. This provides
-
-    valuable diagnostic information when investigating stream interruptions
-
-    or video dropout.
-
-    This commit does not alter transcoder behaviour; errors are still
-
-    filtered or handled by other components as before. It simply makes
-
-    decoder error conditions more transparent for debugging purposes.
-
-[^11]: transcode: gracefully handle common hardware decoder errors
+[^65]: transcode: gracefully handle common hardware decoder errors
 
     When using VAAPI hardware decoding, certain malformed or corrupt frames at the
 
@@ -1048,11 +3091,11 @@
 
     In these cases, libav will log errors such as:
 
-    \[ ERROR]:libav: AVCodecContext: Failed to upload decode parameters: 18 (invalid parameter).
+      [ ERROR]:libav: AVCodecContext: Failed to upload decode parameters: 18 (invalid parameter).
 
-    \[ ERROR]:libav: AVCodecContext: Failed to end picture decode after error: 18 (invalid parameter).
+      [ ERROR]:libav: AVCodecContext: Failed to end picture decode after error: 18 (invalid parameter).
 
-    \[ ERROR]:libav: AVCodecContext: hardware accelerator failed to decode picture
+      [ ERROR]:libav: AVCodecContext: hardware accelerator failed to decode picture
 
     Currently, Tvheadend treats these errors as fatal, resulting in the transcoder
 
@@ -1060,7 +3103,7 @@
 
     typically leaving only audio and a black screen.
 
-    While this behaviour is somewhat tolerable during live TV viewing—where the user
+    While this behavior is somewhat tolerable during live TV viewing—where the user
 
     can manually resolve the issue by changing channels—it is significantly more
 
@@ -1094,7 +3137,7 @@
 
     `AVERROR(EINVAL)` in the list of tolerated decode errors, aligning Tvheadend's
 
-    behaviour with FFmpeg’s more forgiving approach.
+    behavior with FFmpeg’s more forgiving approach.
 
     FFmpeg’s internal decoder logic in `vaapi_h264.c` and `decode.c` supports this
 
@@ -1106,140 +3149,100 @@
 
     continues on the next frame.
 
-[^12]: fix dead error condition
 
-    Fixes coverity scan issues: 462150
+[^66]: transcode: improve logging of packet transcode errors
 
-[^13]: fix memory leak 2 - transcoding
+    Improve visibility of decoding failures during transcoding by logging
+
+    the error code, a human-readable description, and the packet PTS when
+
+    the hardware decoder fails to process a packet.
+
+    Previously, these errors would silently trigger `tvh_stream_stop()` on
+
+    the affected stream, with minimal context about the underlying cause.
+
+    This made it difficult to diagnose issues such as hardware acceleration
+
+    glitches or codec-specific decode failures.
+
+    With this change, such errors are logged at warning level, and full
+
+    packet details are included if trace logging is enabled. This provides
+
+    valuable diagnostic information when investigating stream interruptions
+
+    or video dropout.
+
+    This commit does not alter transcoder behavior; errors are still
+
+    filtered or handled by other components as before. It simply makes
+
+    decoder error conditions more transparent for debugging purposes.
+
+
+[^67]: fix for video stream detection
+
+    PR https://github.com/tvheadend/tvheadend/pull/1772 is not covering all video streams. The proper implementation is to use the macro SCT_ISVIDEO()
+
+
+[^68]: fix memory leak 2 - transcoding
 
     fix memory leak 2 - transcoding
 
-[^14]: fix memory leak - transcoding
+
+[^69]: fix dead error condition
+
+    Fixes coverity scan issues: 462150
+
+
+[^70]: add mpegts parameters from input stream
+
+    - add service_name, service_provider, mpegts_transport_id, mpegts_service_type, mpegts_pmt_start_pid, mpegts_start_pid, mpegts_service_id, mpegts_original_service_id
+
+    - allow user to select mpeg ts sid (same like pass profile)
+
+
+[^71]: fix memory leak - transcoding
 
     Fixes coverity scan issues: 551230, 551229, 507422 and 507421
 
-[^15]: add mpegts parameters from input stream
 
-    * add service\_name, service\_provider, mpegts\_transport\_id, mpegts\_service\_type, mpegts\_pmt\_start\_pid, mpegts\_start\_pid, mpegts\_service\_id, mpegts\_original\_service\_id
-    * allow user to select mpeg ts sid (same like pass profile)
-
-[^16]: fix memory leak
+[^72]: fix memory leak
 
     Fixes: https://github.com/tvheadend/tvheadend/issues/1749
 
-[^17]: video hw accel should only be applied for video streams
+
+[^73]: video hw accel should only be applied for video streams
 
     Fixes: https://github.com/tvheadend/tvheadend/issues/1827
 
-[^18]: Update VAAPI transcoding as recommended by ffmpeg 6.1.1/doc/examples/… (#1792)
 
-    Update VAAPI transcoding as recommended by ffmpeg 6.1.1/doc/examples/vaapi\_\*.c
+[^74]: Update VAAPI transcoding as recommended by ffmpeg 6.1.1/doc/examples/… (#1792)
 
-[^19]: update audio abuffersink from deprecated channel\_layouts to ch\_layouts and deprecated FF\_PROFILE\_\* --> AV\_PROFILE\_\*
+    Update VAAPI transcoding as recommended by ffmpeg 6.1.1/doc/examples/vaapi_*.c
 
-    update audio abuffersink from deprecated channel\_layouts to ch\_layouts and deprecated FF\_PROFILE\_\* --> AV\_PROFILE\_\*
 
-[^20]: allow NVENC, VAAPI and MMAL to coexist in the same build
+[^75]: update audio abuffersink from deprecated channel_layouts to ch_layouts and deprecated FF_PROFILE_* --> AV_PROFILE_*
 
-    * allow NVENC, VAAPI and MMAL to coexist in the same build.
-    * give the user the capability for prioritise hw decoder or to match the hw decoder with hw encoder
-    * refactor source code: remove duplicate source code in codec.js
+    update audio abuffersink from deprecated channel_layouts to ch_layouts and deprecated FF_PROFILE_* --> AV_PROFILE_*
 
-[^21]: fix read/write of PT\_DYN\_INT
 
-    PT\_DYN\_INT should be read and write as int (32 bits)
+[^76]: fix read/write of PT_DYN_INT
 
-[^22]: lovcombo-all.js: Fix autorec create/edit TypeError with Firefox 134 (#1786)
+    PT_DYN_INT should be read and write as int (32 bits)
 
-    Firefox 134 added the RegExp.escape() method
 
-    (https://tc39.es/proposal-regex-escaping/#sec-regexp.escape) with a
+[^77]: allow NVENC, VAAPI and MMAL to coexist in the same build
 
-    standards-compliant implementation that throws TypeError if
+    - allow NVENC, VAAPI and MMAL to coexist in the same build.
 
-    any value other than a String is passed in. This differs from the
+    - give the user the capability for prioritize hw decoder or to match the hw decoder with hw encoder
 
-    existing polyfill that simply returns the argument unmodified if it
+    - refactor source code: remove duplicate source code in codec.js
 
-    isn't a String. In TVHeadend, the day-of-the-week selector (as
 
-    used in the Autorec and Timer configuration) uses Integers as keys
-
-    for options, causing an Integer to get passed to RegExp.escape() on
-
-    line 300 of lovcombo-all.js. Because of the non-standards-
-
-    compliant permissive behaviour of the polyfill, this previously
-
-    didn't cause an issue. However, with Firefox 134 (and an upcoming
-
-    version of Safari), the added standards-compliant method causes a
-
-    TypeError to be thrown on every attempt to create or edit a timer
-
-    or autorec, causing the edit window to not be shown. To solve the
-
-    issue, pass the response from r.get(this.valueField) through the
-
-    String() constructor to ensure anything that gets passed in is a
-
-    String. This has been tested with Firefox and Chrome with both
-
-    Integer and String keys.
-
-[^23]: httpc.c: Fix HTTPS with OpenSSL 3.5 (#1813)
-
-    The TLS Client Hello message is larger in OpenSSL 3.5 and will not
-
-    fit in the previous hc\_io\_size of 1024 bytes. This causes the TLS
-
-    Client Hello message to be truncated, resulting in HTTPS requests
-
-    stalling and eventually timing out. To fix this, increase
-
-    hc\_io\_size to 2048 bytes.
-
-[^24]: Remove links to old Wiki (#1793)
-
-    * Remove links to old Wiki. Fixes #1660
-
-    Also remove references to CIC and CLA, and other content where a more recent version exists on the documentation site.
-
-    * Remove more obsolete links.
-
-[^25]: Translation for 'pl' updated.
-
-    intl: Translate intl/js/tvheadend.js.pot in pl
-
-    100% translated source file: 'intl/js/tvheadend.js.pot'
-
-    on 'pl'.
-
-[^26]: Translation for 'pl' updated.
-
-    intl: Translate intl/tvheadend.pot in pl
-
-    100% translated source file: 'intl/tvheadend.pot'
-
-    on 'pl'.
-
-[^27]: Translation for 'en\_GB' updated.
-
-    intl: Translate tvheadend.doc.pot in en\_GB
-
-    100% translated source file: 'tvheadend.doc.pot'
-
-    on 'en\_GB'.
-
-[^28]: Translation for 'en\_US' updated.
-
-    intl: Translate tvheadend.doc.pot in en\_US
-
-    100% translated source file: 'tvheadend.doc.pot'
-
-    on 'en\_US'.
-
-[^29]: wizard: increase buffer size to silence -Wformat-truncation on GCC 15
+[^78]: wizard: increase buffer size to silence -Wformat-truncation on GCC 15
 
     GCC 15.1 introduces stricter checks around `snprintf`-like functions
 
@@ -1249,11 +3252,11 @@
 
     `hello_changed()` when building with `-Werror=format-truncation`:
 
-    error: ‘\_\_builtin\_\_\_snprintf\_chk’ output may be truncated before the
+      error: ‘__builtin___snprintf_chk’ output may be truncated before the
 
-    last format character \[-Werror=format-truncation=]
+      last format character [-Werror=format-truncation=]
 
-    note: output between 1 and 33 bytes into a destination of size 32
+      note: output between 1 and 33 bytes into a destination of size 32
 
     This warning is triggered due to a theoretical edge case in
 
@@ -1271,7 +3274,7 @@
 
     still keeping the logic and usage intact. This is a defensive fix with
 
-    no behavioural change, and aligns with similar mitigations used in other
+    no behavioral change, and aligns with similar mitigations used in other
 
     projects facing the same issue with GCC >= 13 and especially 15+.
 
@@ -1279,10 +3282,118 @@
 
     Refs:
 
-    * https://gcc.gnu.org/bugzilla/show\_bug.cgi?id=108231
-    * https://gcc.gnu.org/onlinedocs/gcc-15.1.0/gcc/Warning-Options.html#index-Wformat-truncation
+    - https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108231
 
-[^30]: Fix CI Builds 1/2
+    - https://gcc.gnu.org/onlinedocs/gcc-15.1.0/gcc/Warning-Options.html#index-Wformat-truncation
+
+
+[^79]: Translation for 'pl' updated.
+
+    intl: Translate intl/js/tvheadend.js.pot in pl
+
+    100% translated source file: 'intl/js/tvheadend.js.pot'
+
+    on 'pl'.
+
+
+[^80]: Translation for 'en_GB' updated.
+
+    intl: Translate tvheadend.doc.pot in en_GB
+
+    100% translated source file: 'tvheadend.doc.pot'
+
+    on 'en_GB'.
+
+
+[^81]: Translation for 'en_US' updated.
+
+    intl: Translate tvheadend.doc.pot in en_US
+
+    100% translated source file: 'tvheadend.doc.pot'
+
+    on 'en_US'.
+
+
+[^82]: Translation for 'pl' updated.
+
+    intl: Translate intl/tvheadend.pot in pl
+
+    100% translated source file: 'intl/tvheadend.pot'
+
+    on 'pl'.
+
+
+[^83]: Remove links to old Wiki (#1793)
+
+    * Remove links to old Wiki. Fixes #1660
+
+    Also remove references to CIC and CLA, and other content where a more recent version exists on the documentation site.
+
+    * Remove more obsolete links.
+
+
+[^84]: httpc.c: Fix HTTPS with OpenSSL 3.5 (#1813)
+
+    The TLS Client Hello message is larger in OpenSSL 3.5 and will not
+
+    fit in the previous hc_io_size of 1024 bytes.  This causes the TLS
+
+    Client Hello message to be truncated, resulting in HTTPS requests
+
+    stalling and eventually timing out.  To fix this, increase
+
+    hc_io_size to 2048 bytes.
+
+
+[^85]: lovcombo-all.js: Fix autorec create/edit TypeError with Firefox 134 (#1786)
+
+    Firefox 134 added the RegExp.escape() method
+
+    (https://tc39.es/proposal-regex-escaping/#sec-regexp.escape) with a
+
+    standards-compliant implementation that throws TypeError if
+
+    any value other than a String is passed in.  This differs from the
+
+    existing polyfill that simply returns the argument unmodified if it
+
+    isn't a String.  In TVHeadend, the day-of-the-week selector (as
+
+    used in the Autorec and Timer configuration) uses Integers as keys
+
+    for options, causing an Integer to get passed to RegExp.escape() on
+
+    line 300 of lovcombo-all.js.  Because of the non-standards-
+
+    compliant permissive behavior of the polyfill, this previously
+
+    didn't cause an issue.  However, with Firefox 134 (and an upcoming
+
+    version of Safari), the added standards-compliant method causes a
+
+    TypeError to be thrown on every attempt to create or edit a timer
+
+    or autorec, causing the edit window to not be shown.  To solve the
+
+    issue, pass the response from r.get(this.valueField) through the
+
+    String() constructor to ensure anything that gets passed in is a
+
+    String.  This has been tested with Firefox and Chrome with both
+
+    Integer and String keys.
+
+
+[^86]: Fix CI Builds 2/2
+
+    fix: allow x265 build on CMake <3.2
+
+    feat(build): only use armv9 when supported
+
+    chore(build): remove x265 from unsupported platforms
+
+
+[^87]: Fix CI Builds 1/2
 
     Update run-on-arch to v3
 
@@ -1298,55 +3409,53 @@
 
     Update libx265
 
-[^31]: Fix CI Builds 2/2
 
-    fix: allow x265 build on CMake <3.2
+[^88]: Translation for 'en_US' updated.
 
-    feat(build): only use armv9 when supported
-
-    chore(build): remove x265 from unsupported platforms
-
-[^32]: Translation for 'en\_GB' updated.
-
-    intl: Translate intl/tvheadend.pot in en\_GB
+    intl: Translate intl/tvheadend.pot in en_US
 
     100% translated source file: 'intl/tvheadend.pot'
 
-    on 'en\_GB'.
+    on 'en_US'.
 
-[^33]: Translation for 'en\_US' updated.
 
-    intl: Translate intl/tvheadend.pot in en\_US
+[^89]: Translation for 'en_GB' updated.
+
+    intl: Translate intl/tvheadend.pot in en_GB
 
     100% translated source file: 'intl/tvheadend.pot'
 
-    on 'en\_US'.
+    on 'en_GB'.
 
-[^34]: update libvpx v.1.14.1
+
+[^90]: update libvpx v.1.14.1
 
     update libvpx v.1.14.1
 
     remove previous patch (from 1.14.0)
 
-[^35]: Add start timeout to streaming profile
+
+[^91]: Fix - Audio transcoding not working #1663
+
+    src/transcoding/transcode/helpers.c  : pktbuf_len(self->input_gh)) will be 0 (empty) so will return error -11 (AVERROR(EAGAIN) for audio streams.
+
+
+[^92]: Add start timeout to streaming profile
 
     This allows overriding the hardcoded grace period of 20 seconds.
 
-    It should address the problems described in \[1]\[2].
+    It should address the problems described in [1][2].
 
     In addition, timeout code has been slightly refactored for readability
 
     and more debug logging.
 
-    \[1] https://tvheadend.org/d/8330-increase-timeout-when-tuning-iptv-mux/2
+    [1] https://tvheadend.org/d/8330-increase-timeout-when-tuning-iptv-mux/2
 
-    \[2] https://tvheadend.org/d/8158-several-problems-questions-about-using-tvheadend-starting-with-not-waiting-long-enoough-for-stream-to-begin
+    [2] https://tvheadend.org/d/8158-several-problems-questions-about-using-tvheadend-starting-with-not-waiting-long-enoough-for-stream-to-begin
 
-[^36]: Fix - Audio transcoding not working #1663
 
-    src/transcoding/transcode/helpers.c : pktbuf\_len(self->input\_gh)) will be 0 (empty) so will return error -11 (AVERROR(EAGAIN) for audio streams.
-
-[^37]: Fix FTBFS introduced by 76d8fc8bc5455322558c764c84755ebbba254ad5
+[^93]: Fix FTBFS introduced by 76d8fc8bc5455322558c764c84755ebbba254ad5
 
     Older versions of GCC don't like declaring a variable in the middle
 
@@ -1354,80 +3463,91 @@
 
     part of a statement and a declaration is not a statement".
 
-[^38]: fix bug in AAC channel layout configuration tab
+
+[^94]: fix bug in AAC channel layout configuration tab
 
     fix bug in AAC channel layout configuration tab
 
     There are few issues:
 
     1. first entry in combo should be AUTO (with value 0) - in original code was set to 1 (and overwritten later)
-    2. l->nb\_channel is not the best way to cycle though layouts available. At the end I think is accessing some region outside of the struct (because I see is lopped also after 7.1). The way I knew how to fix was to add the filter (l->nb\_channels < 32). Maybe changing the while to for will be a better option.
-    3. av\_channel\_layout() is returning the length of the string ... we should use l\_buf only when retuned value > 0 ... when is < 0 l\_buf was not updated.
 
-[^39]: update vaapi - vainfo
+    2. l->nb_channel is not the best way to cycle though layouts available. At the end I think is accessing some region outside of the struct (because I see is lopped also after 7.1). The way I knew how to fix was to add the filter (l->nb_channels < 32). Maybe changing the while to for will be a better option.
 
-    * add enable vainfo detection checkbox in config
-    * defined PT\_DYN\_INT to load integer field from function
-    * PT\_DYN\_INT must be paired with dyn\_i
-    * show only VAAPI codecs advertised by vainfo
-    * defined two invisible fields: ui and uilp used for UI enable/disable features
-    * check if bitrate is greater than max\_bitrate (fix to avoid tvh crash)
-    * vp8, vp9 separate Global Quality from Quality
-    * load quality and max B frames filters from vainfo
-    * UI has several constrains or warnings implemented using vainfo
-    * separated 'b\_depth' from 'bf'
+    3. av_channel_layout() is returning the length of the string ... we should use l_buf only when retuned value > 0 ... when is < 0 l_buf was not updated.
 
-[^40]: Update linuxdvb\_satconf.c - lnb poweroff requires power save
 
-    Extend description to make it clear that lnb\_poweroff also requires "power save" setting.
+[^95]: Update linuxdvb_satconf.c - lnb poweroff requires power save
 
-[^41]: Translation for 'en\_GB' updated.
+    Extend description to make it clear that lnb_poweroff also requires "power save" setting.
 
-    intl: Translate intl/js/tvheadend.js.pot in en\_GB
+
+[^96]: update vaapi - vainfo
+
+    - add enable vainfo detection checkbox in config
+
+    - defined PT_DYN_INT to load integer field from function
+
+    - PT_DYN_INT must be paired with dyn_i
+
+    - show only VAAPI codecs advertised by vainfo
+
+    - defined two invisible fields: ui and uilp used for UI enable/disable features
+
+    - check if bitrate is greater than max_bitrate (fix to avoid tvh crash)
+
+    - vp8, vp9 separate Global Quality from Quality
+
+    - load quality and max B frames filters from vainfo
+
+    - UI has several constrains or warnings implemented using vainfo
+
+    - separated 'b_depth' from 'bf'
+
+
+[^97]: Translation for 'en_GB' updated.
+
+    intl: Translate intl/js/tvheadend.js.pot in en_GB
 
     100% translated source file: 'intl/js/tvheadend.js.pot'
 
-    on 'en\_GB'.
+    on 'en_GB'.
 
-[^42]: Translation for 'en\_US' updated.
 
-    intl: Translate intl/js/tvheadend.js.pot in en\_US
+[^98]: Translation for 'en_US' updated.
+
+    intl: Translate intl/js/tvheadend.js.pot in en_US
 
     100% translated source file: 'intl/js/tvheadend.js.pot'
 
-    on 'en\_US'.
+    on 'en_US'.
 
-[^43]: Remove tvheadend user on purge
+
+[^99]: Remove tvheadend user on purge
 
     This fixes #1722 on my test system.
 
-[^44]: Remove useless NULL-assignment in http.c
+
+[^100]: Remove useless NULL-check in ratinglabels.c
 
     Found by coverity
 
-[^45]: Remove useless NULL-check in ratinglabels.c
+
+[^101]: Remove useless NULL-assignment in http.c
 
     Found by coverity
 
-[^46]: Use safer htsmsg\_add\_str2 when copying de->de\_directory
 
-    de->de\_directory may be null. htsmsg\_add\_str passes str unchecked to underlying strlen function. \_\_strlen\_avx2 will segfault if str is null.
+[^102]: Use safer htsmsg_add_str2 when copying de->de_directory
 
-    htsmsg\_add\_str2 checks the value of args before passing them to htsmsg\_add\_str, which should prevent this.
+    de->de_directory may be null. htsmsg_add_str passes str unchecked to underlying strlen function. __strlen_avx2 will segfault if str is null.
+
+    htsmsg_add_str2 checks the value of args before passing them to htsmsg_add_str, which should prevent this.
 
     Fixes #1712
 
-[^47]: dvr: Added missing directory to rerecord-entry
 
-    Previously if you had a directory set on a recording and this recording
-
-    needed to be rerecorded, the directory was not kept in the new entry.
-
-[^48]: Extend CORS origin help/hover message
-
-    Clarify that the value should be a URL, prefixed with http:// or https://, and not "bare" domains, which currently silently fail to save. Fixes (partially) #1700.
-
-[^49]: Allow setting a custom grace period for LinuxDVB adapters
+[^103]: Allow setting a custom grace period for LinuxDVB adapters
 
     When using Astrometa to tune to DVB-T2 muxes in Poland, the scans are reported
 
@@ -1441,7 +3561,27 @@
 
     15 for this particular adapter/mux combination.
 
-[^50]: Docker/Alpine: Remove USB group
+
+[^104]: Extend CORS origin help/hover message 
+
+    Clarify that the value should be a URL, prefixed with http:// or https://, and not "bare" domains, which currently silently fail to save. Fixes (partially) #1700.
+
+
+[^105]: dvr: Added missing directory to rerecord-entry
+
+    Previously if you had a directory set on a recording and this recording
+
+    needed to be rerecorded, the directory was not kept in the new entry.
+
+
+[^106]: tvhdhomerun: Add ISDB to type check in tvhdhomerun_device_create
+
+    This commit adds support for ISDB in the type check of the tvhdhomerun_device_create function in tvhdhomerun.c.
+
+    This allows the function to handle ISDB type devices, which previously would have been changed to a DVB device on startup every time despite overrides.
+
+
+[^107]: Docker/Alpine: Remove USB group
 
     The USB group has been removed from upstream alpine in commit
 
@@ -1457,33 +3597,30 @@
 
     udev rules.
 
-    Signed-off-by: Olliver Schinagl [oliver@schinagl.nl](mailto:oliver@schinagl.nl)
+    Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>
 
-[^51]: tvhdhomerun: Add ISDB to type check in tvhdhomerun\_device\_create
 
-    This commit adds support for ISDB in the type check of the tvhdhomerun\_device\_create function in tvhdhomerun.c.
-
-    This allows the function to handle ISDB type devices, which previously would have been changed to a DVB device on startup every time despite overrides.
-
-[^52]: Fix echo target for superuser file in Debian postinst
+[^108]: Fix echo target for superuser file in Debian postinst
 
     aba5e60792177d6a2a867445559f4806973b3258 was causing the username
 
     and password to get printed to the console instead of being put in
 
-    the correct file. Also, use the modern $() syntax instead of \`\`
+    the correct file.  Also, use the modern $() syntax instead of ``
 
     and quote all variable assignments.
 
-[^53]: satip: Ignore additional parameters
 
-    Instead or erroring, ignore additional parameters, as required by the specs in 3.5.11 where it says "Unknown attributes shall be ignored by the server"
+[^109]: satip: Ignore additional parameters
 
-[^54]: configure: fix parsing args if values contain "="
+    Instead or erroring, ignore additional parameters, as required by the specs in  3.5.11 where it says "Unknown attributes shall be ignored by the server"
+
+
+[^110]: configure: fix parsing args if values contain "="
 
     Currently, when the value of an option passed to the configure script as argument contains an equal sign "=", the part of the string up to the second equal sign is used as option. This commit changes how the string is split, so that always only the part up to the first equal sign is interpreted as option.
 
-    "${var%=_}" removes everything from the last equal sign, "${var%%=_}" removes everything from the first equal sign.
+    "${var%=*}" removes everything from the last equal sign, "${var%%=*}" removes everything from the first equal sign.
 
     This allows to pass CFLAGS, which usually contain equal signs, like
 
@@ -1491,22 +3628,27 @@
 
     For reference: https://github.com/tvheadend/tvheadend/issues/1665
 
-    Signed-off-by: MichaIng [micha@dietpi.com](mailto:micha@dietpi.com)
+    Signed-off-by: MichaIng <micha@dietpi.com>
 
-[^55]: Fix detection of unknown version numbers in support/version
+
+[^111]: Fix detection of unknown version numbers in support/version
 
     Fixes: #1683
 
-[^56]: webui: Fix year being replaced incorrectly when using custom date format
+
+[^112]: Update manpage
+
+    - Replace freenode with libera
+
+    - Change copyright info
+
+
+[^113]: webui: Fix year being replaced incorrectly when using custom date format
 
     fixes regression in 2ca8a19
 
-[^57]: Update manpage
 
-    * Replace freenode with libera
-    * Change copyright info
-
-[^58]: Translation for 'pl' updated.
+[^114]: Translation for 'pl' updated.
 
     intl: Translate intl/docs/tvheadend.doc.pot in pl
 
@@ -1514,49 +3656,8 @@
 
     on 'pl'.
 
-[^59]: Translation for 'pl' updated.
 
-    intl: Translate intl/docs/tvheadend.doc.pot in pl
-
-    80% of minimum 80% translated source file: 'intl/docs/tvheadend.doc.pot'
-
-    on 'pl'.
-
-    Sync of partially translated files:
-
-    untranslated content is included with an empty translation
-
-    or source language content depending on file format
-
-[^60]: Translation for 'pl' updated.
-
-    intl: Translate intl/docs/tvheadend.doc.pot in pl
-
-    82% of minimum 80% translated source file: 'intl/docs/tvheadend.doc.pot'
-
-    on 'pl'.
-
-    Sync of partially translated files:
-
-    untranslated content is included with an empty translation
-
-    or source language content depending on file format
-
-[^61]: Translation for 'pl' updated.
-
-    intl: Translate intl/docs/tvheadend.doc.pot in pl
-
-    85% of minimum 80% translated source file: 'intl/docs/tvheadend.doc.pot'
-
-    on 'pl'.
-
-    Sync of partially translated files:
-
-    untranslated content is included with an empty translation
-
-    or source language content depending on file format
-
-[^62]: Translation for 'pl' updated.
+[^115]: Translation for 'pl' updated.
 
     intl: Translate intl/docs/tvheadend.doc.pot in pl
 
@@ -1564,41 +3665,23 @@
 
     on 'pl'.
 
-    Sync of partially translated files:
+    Sync of partially translated files: 
 
-    untranslated content is included with an empty translation
+    untranslated content is included with an empty translation 
 
     or source language content depending on file format
 
-[^63]: Translation for 'pl' updated.
 
-    intl: Translate intl/docs/tvheadend.doc.pot in pl
+[^116]: Translation for 'pl' updated.
 
-    87% of minimum 80% translated source file: 'intl/docs/tvheadend.doc.pot'
+    intl: Translate intl/tvheadend.pot in pl
+
+    100% translated source file: 'intl/tvheadend.pot'
 
     on 'pl'.
 
-    Sync of partially translated files:
 
-    untranslated content is included with an empty translation
-
-    or source language content depending on file format
-
-[^64]: Translation for 'pl' updated.
-
-    intl: Translate intl/docs/tvheadend.doc.pot in pl
-
-    90% of minimum 80% translated source file: 'intl/docs/tvheadend.doc.pot'
-
-    on 'pl'.
-
-    Sync of partially translated files:
-
-    untranslated content is included with an empty translation
-
-    or source language content depending on file format
-
-[^65]: Translation for 'pl' updated.
+[^117]: Translation for 'pl' updated.
 
     intl: Translate intl/docs/tvheadend.doc.pot in pl
 
@@ -1606,27 +3689,29 @@
 
     on 'pl'.
 
-    Sync of partially translated files:
+    Sync of partially translated files: 
 
-    untranslated content is included with an empty translation
+    untranslated content is included with an empty translation 
 
     or source language content depending on file format
 
-[^66]: Translation for 'pl' updated.
+
+[^118]: Translation for 'pl' updated.
 
     intl: Translate intl/docs/tvheadend.doc.pot in pl
 
-    92% of minimum 80% translated source file: 'intl/docs/tvheadend.doc.pot'
+    85% of minimum 80% translated source file: 'intl/docs/tvheadend.doc.pot'
 
     on 'pl'.
 
-    Sync of partially translated files:
+    Sync of partially translated files: 
 
-    untranslated content is included with an empty translation
+    untranslated content is included with an empty translation 
 
     or source language content depending on file format
 
-[^67]: Translation for 'pl' updated.
+
+[^119]: Translation for 'pl' updated.
 
     intl: Translate intl/docs/tvheadend.doc.pot in pl
 
@@ -1634,13 +3719,89 @@
 
     on 'pl'.
 
-    Sync of partially translated files:
+    Sync of partially translated files: 
 
-    untranslated content is included with an empty translation
+    untranslated content is included with an empty translation 
 
     or source language content depending on file format
 
-[^68]: Translation for 'pl' updated.
+
+[^120]: Translation for 'pl' updated.
+
+    intl: Translate intl/docs/tvheadend.doc.pot in pl
+
+    80% of minimum 80% translated source file: 'intl/docs/tvheadend.doc.pot'
+
+    on 'pl'.
+
+    Sync of partially translated files: 
+
+    untranslated content is included with an empty translation 
+
+    or source language content depending on file format
+
+
+[^121]: Translation for 'pl' updated.
+
+    intl: Translate intl/docs/tvheadend.doc.pot in pl
+
+    92% of minimum 80% translated source file: 'intl/docs/tvheadend.doc.pot'
+
+    on 'pl'.
+
+    Sync of partially translated files: 
+
+    untranslated content is included with an empty translation 
+
+    or source language content depending on file format
+
+
+[^122]: Translation for 'pl' updated.
+
+    intl: Translate intl/docs/tvheadend.doc.pot in pl
+
+    90% of minimum 80% translated source file: 'intl/docs/tvheadend.doc.pot'
+
+    on 'pl'.
+
+    Sync of partially translated files: 
+
+    untranslated content is included with an empty translation 
+
+    or source language content depending on file format
+
+
+[^123]: Translation for 'pl' updated.
+
+    intl: Translate intl/docs/tvheadend.doc.pot in pl
+
+    80% of minimum 80% translated source file: 'intl/docs/tvheadend.doc.pot'
+
+    on 'pl'.
+
+    Sync of partially translated files: 
+
+    untranslated content is included with an empty translation 
+
+    or source language content depending on file format
+
+
+[^124]: Translation for 'pl' updated.
+
+    intl: Translate intl/docs/tvheadend.doc.pot in pl
+
+    82% of minimum 80% translated source file: 'intl/docs/tvheadend.doc.pot'
+
+    on 'pl'.
+
+    Sync of partially translated files: 
+
+    untranslated content is included with an empty translation 
+
+    or source language content depending on file format
+
+
+[^125]: Translation for 'pl' updated.
 
     intl: Translate intl/docs/tvheadend.doc.pot in pl
 
@@ -1648,83 +3809,100 @@
 
     on 'pl'.
 
-    Sync of partially translated files:
+    Sync of partially translated files: 
 
-    untranslated content is included with an empty translation
+    untranslated content is included with an empty translation 
 
     or source language content depending on file format
 
-[^69]: Update README.md
 
-    Existing (page not found) : https://cloudsmith.io/tvheadend/tvheadend
+[^126]: Translation for 'pl' updated.
 
-    New: https://cloudsmith.io/\~tvheadend/repos/tvheadend/packages/
+    intl: Translate intl/docs/tvheadend.doc.pot in pl
 
-[^70]: Create special tvheadend-armv6l and tvheadend-dbg-armv6l packages
+    87% of minimum 80% translated source file: 'intl/docs/tvheadend.doc.pot'
+
+    on 'pl'.
+
+    Sync of partially translated files: 
+
+    untranslated content is included with an empty translation 
+
+    or source language content depending on file format
+
+
+[^127]: Update README.md
+
+    Existing (page not found) : https://cloudsmith.io/tvheadend/tvheadend 
+
+    New: https://cloudsmith.io/~tvheadend/repos/tvheadend/packages/
+
+
+[^128]: Create special tvheadend-armv6l and tvheadend-dbg-armv6l packages
 
     Fixes: #1665
 
-[^71]: update to libvpx 1.14.0-patch
+
+[^129]: Translation for 'pl' updated.
+
+    intl: Translate intl/tvheadend.pot in pl
+
+    100% translated source file: 'intl/tvheadend.pot'
+
+    on 'pl'.
+
+
+[^130]: Translation for 'pl' updated.
+
+    intl: Translate intl/tvheadend.pot in pl
+
+    100% translated source file: 'intl/tvheadend.pot'
+
+    on 'pl'.
+
+
+[^131]: Translation for 'pl' updated.
+
+    intl: Translate intl/js/tvheadend.js.pot in pl
+
+    100% translated source file: 'intl/js/tvheadend.js.pot'
+
+    on 'pl'.
+
+
+[^132]: update to libvpx 1.14.0-patch
 
     added patch
 
-[^72]: Translation for 'cs' updated.
 
-    intl: Translate intl/js/tvheadend.js.pot in cs
+[^133]: Translation for 'pl' updated.
 
-    81% of minimum 80% translated source file: 'intl/js/tvheadend.js.pot'
+    intl: Translate intl/tvheadend.pot in pl
 
-    on 'cs'.
+    100% translated source file: 'intl/tvheadend.pot'
 
-    Sync of partially translated files:
+    on 'pl'.
 
-    untranslated content is included with an empty translation
 
-    or source language content depending on file format
+[^134]: Translation for 'pl' updated.
 
-[^73]: Translation for 'de' updated.
+    intl: Translate intl/tvheadend.pot in pl
 
-    intl: Translate intl/js/tvheadend.js.pot in de
+    100% translated source file: 'intl/tvheadend.pot'
 
-    84% of minimum 80% translated source file: 'intl/js/tvheadend.js.pot'
+    on 'pl'.
 
-    on 'de'.
 
-    Sync of partially translated files:
+[^135]: Translation for 'pl' updated.
 
-    untranslated content is included with an empty translation
+    intl: Translate intl/js/tvheadend.js.pot in pl
 
-    or source language content depending on file format
+    100% translated source file: 'intl/js/tvheadend.js.pot'
 
-[^74]: Translation for 'fr' updated.
+    on 'pl'.
 
-    intl: Translate intl/js/tvheadend.js.pot in fr
 
-    89% of minimum 80% translated source file: 'intl/js/tvheadend.js.pot'
-
-    on 'fr'.
-
-    Sync of partially translated files:
-
-    untranslated content is included with an empty translation
-
-    or source language content depending on file format
-
-[^75]: Translation for 'hu' updated.
-
-    intl: Translate intl/js/tvheadend.js.pot in hu
-
-    80% of minimum 80% translated source file: 'intl/js/tvheadend.js.pot'
-
-    on 'hu'.
-
-    Sync of partially translated files:
-
-    untranslated content is included with an empty translation
-
-    or source language content depending on file format
-
-[^76]: Translation for 'es' updated.
+[^136]: Translation for 'es' updated.
 
     intl: Translate intl/js/tvheadend.js.pot in es
 
@@ -1732,27 +3910,77 @@
 
     on 'es'.
 
-    Sync of partially translated files:
+    Sync of partially translated files: 
 
-    untranslated content is included with an empty translation
+    untranslated content is included with an empty translation 
 
     or source language content depending on file format
 
-[^77]: Translation for 'nl' updated.
 
-    intl: Translate intl/js/tvheadend.js.pot in nl
+[^137]: Translation for 'de' updated.
+
+    intl: Translate intl/js/tvheadend.js.pot in de
+
+    84% of minimum 80% translated source file: 'intl/js/tvheadend.js.pot'
+
+    on 'de'.
+
+    Sync of partially translated files: 
+
+    untranslated content is included with an empty translation 
+
+    or source language content depending on file format
+
+
+[^138]: Translation for 'pl' updated.
+
+    intl: Translate intl/tvheadend.pot in pl
+
+    100% translated source file: 'intl/tvheadend.pot'
+
+    on 'pl'.
+
+
+[^139]: Translation for 'pl' updated.
+
+    intl: Translate intl/tvheadend.pot in pl
+
+    100% translated source file: 'intl/tvheadend.pot'
+
+    on 'pl'.
+
+
+[^140]: Translation for 'hu' updated.
+
+    intl: Translate intl/js/tvheadend.js.pot in hu
+
+    80% of minimum 80% translated source file: 'intl/js/tvheadend.js.pot'
+
+    on 'hu'.
+
+    Sync of partially translated files: 
+
+    untranslated content is included with an empty translation 
+
+    or source language content depending on file format
+
+
+[^141]: Translation for 'cs' updated.
+
+    intl: Translate intl/js/tvheadend.js.pot in cs
 
     81% of minimum 80% translated source file: 'intl/js/tvheadend.js.pot'
 
-    on 'nl'.
+    on 'cs'.
 
-    Sync of partially translated files:
+    Sync of partially translated files: 
 
-    untranslated content is included with an empty translation
+    untranslated content is included with an empty translation 
 
     or source language content depending on file format
 
-[^78]: Translation for 'et' updated.
+
+[^142]: Translation for 'et' updated.
 
     intl: Translate intl/js/tvheadend.js.pot in et
 
@@ -1760,27 +3988,44 @@
 
     on 'et'.
 
-    Sync of partially translated files:
+    Sync of partially translated files: 
 
-    untranslated content is included with an empty translation
+    untranslated content is included with an empty translation 
 
     or source language content depending on file format
 
-[^79]: Translation for 'en\_GB' updated.
 
-    intl: Translate intl/js/tvheadend.js.pot in en\_GB
+[^143]: Translation for 'fr' updated.
+
+    intl: Translate intl/js/tvheadend.js.pot in fr
+
+    89% of minimum 80% translated source file: 'intl/js/tvheadend.js.pot'
+
+    on 'fr'.
+
+    Sync of partially translated files: 
+
+    untranslated content is included with an empty translation 
+
+    or source language content depending on file format
+
+
+[^144]: Translation for 'en_GB' updated.
+
+    intl: Translate intl/js/tvheadend.js.pot in en_GB
 
     84% of minimum 80% translated source file: 'intl/js/tvheadend.js.pot'
 
-    on 'en\_GB'.
+    on 'en_GB'.
 
-    Sync of partially translated files:
+    Sync of partially translated files: 
 
-    untranslated content is included with an empty translation
+    untranslated content is included with an empty translation 
 
     or source language content depending on file format
 
-[^80]: Translation for 'it' updated.
+
+[^145]: Translation for 'it' updated.
 
     intl: Translate intl/js/tvheadend.js.pot in it
 
@@ -1788,27 +4033,14 @@
 
     on 'it'.
 
-    Sync of partially translated files:
+    Sync of partially translated files: 
 
-    untranslated content is included with an empty translation
-
-    or source language content depending on file format
-
-[^81]: Translation for 'en\_US' updated.
-
-    intl: Translate intl/js/tvheadend.js.pot in en\_US
-
-    84% of minimum 80% translated source file: 'intl/js/tvheadend.js.pot'
-
-    on 'en\_US'.
-
-    Sync of partially translated files:
-
-    untranslated content is included with an empty translation
+    untranslated content is included with an empty translation 
 
     or source language content depending on file format
 
-[^82]: Translation for 'pt' updated.
+
+[^146]: Translation for 'pt' updated.
 
     intl: Translate intl/js/tvheadend.js.pot in pt
 
@@ -1816,13 +4048,29 @@
 
     on 'pt'.
 
-    Sync of partially translated files:
+    Sync of partially translated files: 
 
-    untranslated content is included with an empty translation
+    untranslated content is included with an empty translation 
 
     or source language content depending on file format
 
-[^83]: Translation for 'ko' updated.
+
+[^147]: Translation for 'nl' updated.
+
+    intl: Translate intl/js/tvheadend.js.pot in nl
+
+    81% of minimum 80% translated source file: 'intl/js/tvheadend.js.pot'
+
+    on 'nl'.
+
+    Sync of partially translated files: 
+
+    untranslated content is included with an empty translation 
+
+    or source language content depending on file format
+
+
+[^148]: Translation for 'ko' updated.
 
     intl: Translate intl/js/tvheadend.js.pot in ko
 
@@ -1830,13 +4078,29 @@
 
     on 'ko'.
 
-    Sync of partially translated files:
+    Sync of partially translated files: 
 
-    untranslated content is included with an empty translation
+    untranslated content is included with an empty translation 
 
     or source language content depending on file format
 
-[^84]: Translation for '(#1655)' updated.
+
+[^149]: Translation for 'en_US' updated.
+
+    intl: Translate intl/js/tvheadend.js.pot in en_US
+
+    84% of minimum 80% translated source file: 'intl/js/tvheadend.js.pot'
+
+    on 'en_US'.
+
+    Sync of partially translated files: 
+
+    untranslated content is included with an empty translation 
+
+    or source language content depending on file format
+
+
+[^150]: Translation for '(#1655)' updated.
 
     transifex: Updates for project Tvheadend and language pl (#1655)
 
@@ -1882,29 +4146,142 @@
 
     on 'pl'.
 
-    ***
+    ---------
 
-    Co-authored-by: transifex-integration\[bot] <43880903+transifex-integration\[bot]@users.noreply.github.com>
+    Co-authored-by: transifex-integration[bot] <43880903+transifex-integration[bot]@users.noreply.github.com>
 
-[^85]: Make sure we spawn the best matching executable and not the first match
+
+[^151]: Make sure we spawn the best matching executable and not the first match
 
     Fixes: #1632
 
-[^86]: ci: Enforce rebasing PRs before merging
 
-    Replaces the old, broken action
+[^152]: Translation for 'pl' updated.
 
-[^87]: Replace single-bit signed integers with unsigned integers
+    intl: Translate intl/tvheadend.pot in pl
 
-    Single bit signed integers contain a single sign-byte and zero value
+    100% translated source file: 'intl/tvheadend.pot'
 
-    bytes according to the C99 standard. This is not intended here.
+    on 'pl'.
 
-[^88]: Add missing tvheadend-prefix in JS file
+
+[^153]: Translation for 'pl' updated.
+
+    intl: Translate intl/tvheadend.pot in pl
+
+    100% translated source file: 'intl/tvheadend.pot'
+
+    on 'pl'.
+
+
+[^154]: Translation for 'pl' updated.
+
+    intl: Translate intl/js/tvheadend.js.pot in pl
+
+    100% translated source file: 'intl/js/tvheadend.js.pot'
+
+    on 'pl'.
+
+
+[^155]: Translation for 'pl' updated.
+
+    intl: Translate intl/js/tvheadend.js.pot in pl
+
+    100% translated source file: 'intl/js/tvheadend.js.pot'
+
+    on 'pl'.
+
+
+[^156]: Translation for 'pl' updated.
+
+    intl: Translate intl/tvheadend.pot in pl
+
+    100% translated source file: 'intl/tvheadend.pot'
+
+    on 'pl'.
+
+
+[^157]: Translation for 'pl' updated.
+
+    intl: Translate intl/js/tvheadend.js.pot in pl
+
+    100% translated source file: 'intl/js/tvheadend.js.pot'
+
+    on 'pl'.
+
+
+[^158]: Add missing tvheadend-prefix in JS file
 
     Fixes 2ca8a19e4c8761af1a6653fed09af658e9cd5b67
 
-[^89]: bouquet: Allow merging of services across network bouquet, fixes #5617
+
+[^159]: Replace single-bit signed integers with unsigned integers
+
+    Single bit signed integers contain a single sign-byte and zero value
+
+    bytes according to the C99 standard. This is not inteded here.
+
+
+[^160]: ci: Enforce rebasing PRs before merging
+
+    Replaces the old, broken action
+
+
+[^161]: Translation for 'pl' updated.
+
+    intl: Translate intl/tvheadend.pot in pl
+
+    100% translated source file: 'intl/tvheadend.pot'
+
+    on 'pl'.
+
+
+[^162]: Translation for 'pl' updated.
+
+    intl: Translate intl/js/tvheadend.js.pot in pl
+
+    100% translated source file: 'intl/js/tvheadend.js.pot'
+
+    on 'pl'.
+
+
+[^163]: Translation for 'pl' updated.
+
+    intl: Translate intl/tvheadend.pot in pl
+
+    100% translated source file: 'intl/tvheadend.pot'
+
+    on 'pl'.
+
+
+[^164]: Translation for 'pl' updated.
+
+    intl: Translate intl/tvheadend.pot in pl
+
+    100% translated source file: 'intl/tvheadend.pot'
+
+    on 'pl'.
+
+
+[^165]: Translation for 'pl' updated.
+
+    intl: Translate intl/js/tvheadend.js.pot in pl
+
+    100% translated source file: 'intl/js/tvheadend.js.pot'
+
+    on 'pl'.
+
+
+[^166]: Translation for 'pl' updated.
+
+    intl: Translate intl/js/tvheadend.js.pot in pl
+
+    100% translated source file: 'intl/js/tvheadend.js.pot'
+
+    on 'pl'.
+
+
+[^167]: bouquet: Allow merging of services across network bouquet, fixes #5617
 
     In a mixed network environment (such as DVB-T and DVB-S) it is common
 
@@ -1944,7 +4321,8 @@
 
     Fixes: #5617
 
-[^90]: Translation for 'pl' updated.
+
+[^168]: Translation for 'pl' updated.
 
     transifex: Translate tvheadend.js.pot in pl
 
@@ -1952,21 +4330,69 @@
 
     on 'pl'.
 
-[^91]: intl: update translation templates from code
 
-    Signed-off-by: Christian Hewitt [christianshewitt@gmail.com](mailto:christianshewitt@gmail.com)
+[^169]: Translation for 'pl' updated.
 
-[^92]: CI: Ensure we clone the whole repo
+    transifex: Translate tvheadend.js.pot in pl
+
+    100% translated source file: 'tvheadend.js.pot'
+
+    on 'pl'.
+
+
+[^170]: Translation for 'pl' updated.
+
+    transifex: Translate tvheadend.js.pot in pl
+
+    100% translated source file: 'tvheadend.js.pot'
+
+    on 'pl'.
+
+
+[^171]: Translation for 'pl' updated.
+
+    transifex: Translate tvheadend.js.pot in pl
+
+    100% translated source file: 'tvheadend.js.pot'
+
+    on 'pl'.
+
+
+[^172]: Translation for 'pl' updated.
+
+    transifex: Translate tvheadend.js.pot in pl
+
+    100% translated source file: 'tvheadend.js.pot'
+
+    on 'pl'.
+
+
+[^173]: Translation for 'pl' updated.
+
+    transifex: Translate tvheadend.js.pot in pl
+
+    100% translated source file: 'tvheadend.js.pot'
+
+    on 'pl'.
+
+
+[^174]: intl: update translation templates from code
+
+    Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+
+
+[^175]: CI: Ensure we clone the whole repo
 
     We have to make sure we clone the whole repo, so that `git describe`
 
     works as expected. Without it, we get version 0.0.0, not what we want.
 
-    Signed-off-by: Olliver Schinagl [oliver@schinagl.nl](mailto:oliver@schinagl.nl)
+    Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>
 
-[^93]: container: Add container support
 
-    This commit adds support for containerisation of TVHeadend. It adds the
+[^176]: container: Add container support
+
+    This commit adds support for containizersation of TVHeadend. It adds the
 
     actual technology agnostic container file, an entry point and
 
@@ -1974,23 +4400,26 @@
 
     TODO: Healthcheck script is not yet working.
 
-    TODO: Add decent documentation
+    TODO: Add decent documetnation
 
-    Signed-off-by: Olliver Schinagl [oliver@schinagl.nl](mailto:oliver@schinagl.nl)
+    Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>
 
-[^94]: transcoding: access the codec name only when codec pointer is valid
+
+[^177]: transcoding: access the codec name only when codec pointer is valid
 
     this fixes #1635
 
-[^95]: dvr: Fix incorrect usage of `strerror`
+
+[^178]: dvr: Fix incorrect usage of `strerror`
 
     `strerror` takes the `errno` directly as its argument,
 
     negating it will result in an "Unknown error".
 
-    Signed-off-by: Tianyi Liu [i.pear@outlook.com](mailto:i.pear@outlook.com)
+    Signed-off-by: Tianyi Liu <i.pear@outlook.com>
 
-[^96]: Add "recordings" to the backup exclude list
+
+[^179]: Add "recordings" to the backup exclude list
 
     Since https://github.com/tvheadend/tvheadend/pull/1540, enabled by
 
@@ -2000,21 +4429,23 @@
 
     storing the recordings in a subdirectory of the configuration
 
-    directory by default. Because of this, the recordings are getting
+    directory by default.  Because of this, the recordings are getting
 
-    stored in the configuration backup. This causes the backups to
+    stored in the configuration backup.  This causes the backups to
 
     take forever and fill the disk (see
 
-    https://github.com/tvheadend/tvheadend/issues/1625). Instead,
+    https://github.com/tvheadend/tvheadend/issues/1625).  Instead,
 
     exclude the "recordings" directory from the backup to prevent this.
 
-[^97]: Correct description of Change Parameters flag
+
+[^180]: Correct description of Change Parameters flag
 
     The Change Parameters flag on the Access Entries screen for a user determines whether that user's settings will override any previously-set parameters (for example from a wildcard user) - it does not affect the ability of subsequent users to override settings in turn. The exception is the 'Rights' settings where all matched users with the Change flag set are ORed together.
 
-[^98]: Translation for 'pt' updated.
+
+[^181]: Translation for 'pt' updated.
 
     transifex: Translate tvheadend.js.pot in pt
 
@@ -2022,15 +4453,62 @@
 
     on 'pt'.
 
-[^99]: Translation for 'en\_US' updated.
 
-    transifex: Translate tvheadend.js.pot in en\_US
+[^182]: Translation for 'pt' updated.
+
+    transifex: Translate tvheadend.js.pot in pt
 
     100% translated source file: 'tvheadend.js.pot'
 
-    on 'en\_US'.
+    on 'pt'.
 
-[^100]: satipcli: Rename flag to include client reference
+
+[^183]: Translation for 'pt' updated.
+
+    transifex: Translate tvheadend.js.pot in pt
+
+    100% translated source file: 'tvheadend.js.pot'
+
+    on 'pt'.
+
+
+[^184]: Translation for 'pt' updated.
+
+    transifex: Translate tvheadend.js.pot in pt
+
+    100% translated source file: 'tvheadend.js.pot'
+
+    on 'pt'.
+
+
+[^185]: Translation for 'pt' updated.
+
+    transifex: Translate tvheadend.js.pot in pt
+
+    100% translated source file: 'tvheadend.js.pot'
+
+    on 'pt'.
+
+
+[^186]: Translation for 'en_US' updated.
+
+    transifex: Translate tvheadend.js.pot in en_US
+
+    100% translated source file: 'tvheadend.js.pot'
+
+    on 'en_US'.
+
+
+[^187]: Translation for 'pt' updated.
+
+    transifex: Translate tvheadend.js.pot in pt
+
+    100% translated source file: 'tvheadend.js.pot'
+
+    on 'pt'.
+
+
+[^188]: satipcli: Rename flag to include client reference
 
     We have both a satip client and server. However the nosatip flag, is for
 
@@ -2044,27 +4522,25 @@
 
     lets keep this to a minimum for now.
 
-    Signed-off-by: Olliver Schinagl [oliver@schinagl.nl](mailto:oliver@schinagl.nl)
+    Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>
 
-[^101]: main: Warn about unexpected configuration location
 
-    When using the `--fork` flag, and no user or config arguments are
+[^189]: Clean up Debian postinst and postrm scripts
 
-    supplied, the configuration folder will end up with whatever the default
+    - Fix indentation
 
-    `daemon` user has set, which is often `/sbin` set as the homedir.
+    - Remove unnecessary {} around variables
 
-    This is weird, but not 'wrong' per say. Lets warn the user that forking
+    - Double-quote all variables when assigned or used as arguments
 
-    can have an unexpected side effect.
+    - Simplify quotes and escaping in creation of the superuser file
 
-    Signed-off-by: Olliver Schinagl [oliver@schinagl.nl](mailto:oliver@schinagl.nl)
+    - Remove needless variable assignments
 
-[^102]: Configure Sweep (#1612)
+    - Use $() for command substitution instead of ``
 
-    Co-authored-by: sweep-ai\[bot] <128439645+sweep-ai\[bot]@users.noreply.github.com>
 
-[^103]: Fix handling of legacy configuration directories in debian/postinst
+[^190]: Fix handling of legacy configuration directories in debian/postinst
 
     Detect if the HTS user's home directory starts with "/home/", which
 
@@ -2078,30 +4554,42 @@
 
     superuser credentials correctly.
 
-[^104]: Clean up Debian postinst and postrm scripts
 
-    * Fix indentation
-    * Remove unnecessary {} around variables
-    * Double-quote all variables when assigned or used as arguments
-    * Simplify quotes and escaping in creation of the superuser file
-    * Remove needless variable assignments
-    * Use $() for command substitution instead of \`\`
+[^191]: Configure Sweep (#1612)
 
-[^105]: Use sigaction() instead of signal()
+    Co-authored-by: sweep-ai[bot] <128439645+sweep-ai[bot]@users.noreply.github.com>
 
-    The behaviour of signal() is not consistent or defined when using it
+
+[^192]: main: Warn about unexpected configuration location
+
+    When using the `--fork` flag, and no user or config arguments are
+
+    supplied, the configuration folder will end up with whatever the default
+
+    `daemon` user has set, which is often `/sbin` set as the homedir.
+
+    This is weird, but not 'wrong' per say. Lets warn the user that forking
+
+    can have an unexpected side effect.
+
+    Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>
+
+
+[^193]: Use sigaction() instead of signal()
+
+    The behavior of signal() is not consistent or defined when using it
 
     to set signal handlers (see "Portability" in
 
-    https://man7.org/linux/man-pages/man2/signal.2.html). Previously
+    https://man7.org/linux/man-pages/man2/signal.2.html).  Previously
 
     we got away with this, but starting with GCC 14, using signal()
 
     apparently causes certain syscalls to be restarted after the signal
 
-    is caught. One of these is the read() currently on line 63 of
+    is caught.  One of these is the read() currently on line 63 of
 
-    fsmonitor.c. The result is that read() doesn't return when the
+    fsmonitor.c.  The result is that read() doesn't return when the
 
     fsmonitor thread receives a signal, resulting in the thread never
 
@@ -2109,51 +4597,61 @@
 
     terminate it.
 
-    Instead, use sigaction(), which has defined behaviour when setting
+    Instead, use sigaction(), which has defined behavior when setting
 
-    signal handlers. Since invoking sigaction() requires several
+    signal handlers.  Since invoking sigaction() requires several
 
-    lines, a helper was added to tvh\_thread.c to avoid code
+    lines, a helper was added to tvh_thread.c to avoid code
 
     duplication.
 
-[^106]: templates: add log section to bug\_report.yml
 
-    Signed-off-by: Christian Hewitt [christianshewitt@gmail.com](mailto:christianshewitt@gmail.com)
+[^194]: templates: add log section to bug_report.yml
 
-[^107]: src: filesystem permission fixes
+    Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 
-    Signed-off-by: Christian Hewitt [christianshewitt@gmail.com](mailto:christianshewitt@gmail.com)
 
-[^108]: templates: add config.yml
+[^195]: src: filesystem permission fixes
 
-    Signed-off-by: Christian Hewitt [christianshewitt@gmail.com](mailto:christianshewitt@gmail.com)
+    Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 
-[^109]: templates: add bug\_report.yml
 
-    Signed-off-by: Christian Hewitt [christianshewitt@gmail.com](mailto:christianshewitt@gmail.com)
+[^196]: templates: add bug_report.yml
 
-[^110]: templates: add feature\_proposal.yml
+    Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 
-    Signed-off-by: Christian Hewitt [christianshewitt@gmail.com](mailto:christianshewitt@gmail.com)
 
-[^111]: update to ffmpeg 6.1.1
+[^197]: templates: add config.yml
+
+    Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+
+
+[^198]: templates: add feature_proposal.yml
+
+    Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+
+
+[^199]: update to ffmpeg 6.1.1
 
     update to ffmpeg 6.1.1
 
-[^112]: ci: fix raspios detection in cloudsmith.sh
 
-    Signed-off-by: Christian Hewitt [christianshewitt@gmail.com](mailto:christianshewitt@gmail.com)
+[^200]: ci: fix raspios detection in cloudsmith.sh
 
-[^113]: ci: rename build.yml to reduce confusion
+    Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 
-    Signed-off-by: Christian Hewitt [christianshewitt@gmail.com](mailto:christianshewitt@gmail.com)
 
-[^114]: Makefile.ffmpeg nvenc update
+[^201]: ci: rename build.yml to reduce confusion
 
-    FFNVCODEC\_VER = 11.1.5.0 -> 12.1.14.0
+    Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 
-[^115]: Transifex updates for project Tvheadend (#1587)
+
+[^202]: Makefile.ffmpeg nvenc update
+
+    FFNVCODEC_VER  = 11.1.5.0 -> 12.1.14.0
+
+
+[^203]: Transifex updates for project Tvheadend (#1587)
 
     * transifex: Translate tvheadend.js.pot in es
 
@@ -2161,11 +4659,11 @@
 
     on 'es'.
 
-    * transifex: Translate tvheadend.js.pot in en\_GB
+    * transifex: Translate tvheadend.js.pot in en_GB
 
     100% translated source file: 'tvheadend.js.pot'
 
-    on 'en\_GB'.
+    on 'en_GB'.
 
     * transifex: Translate tvheadend.js.pot in de
 
@@ -2503,91 +5001,106 @@
 
     on 'pl'.
 
-    ***
+    ---------
 
-    Co-authored-by: transifex-integration\[bot] <43880903+transifex-integration\[bot]@users.noreply.github.com>
+    Co-authored-by: transifex-integration[bot] <43880903+transifex-integration[bot]@users.noreply.github.com>
 
-[^116]: tfx: fix URLs in tvheadend/c files
 
-    Signed-off-by: Christian Hewitt [christianshewitt@gmail.com](mailto:christianshewitt@gmail.com)
+[^204]: tfx: fix URLs in tvheadend/c files
 
-[^117]: tfx: fix URLs in tvheadend/docs files
+    Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 
-    Signed-off-by: Christian Hewitt [christianshewitt@gmail.com](mailto:christianshewitt@gmail.com)
 
-[^118]: tfx: fix URLs in tvheadend/js files
+[^205]: tfx: fix URLs in tvheadend/docs files
 
-    Signed-off-by: Christian Hewitt [christianshewitt@gmail.com](mailto:christianshewitt@gmail.com)
+    Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 
-[^119]: webui: change donation button to opencollective
 
-    Signed-off-by: Christian Hewitt [christianshewitt@gmail.com](mailto:christianshewitt@gmail.com)
+[^206]: tfx: fix URLs in tvheadend/js files
 
-[^120]: webui: remove old doc references to paypal
+    Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 
-    Signed-off-by: Christian Hewitt [christianshewitt@gmail.com](mailto:christianshewitt@gmail.com)
 
-[^121]: hdhomerun: Add HDHomeRun server support for LiveTV only (#4461)
+[^207]: hdhomerun: Add HDHomeRun server support for LiveTV only (#4461)
 
-    Co-authored-by: "E.Smith" [31170571+azlm8t@users.noreply.github.com](mailto:31170571+azlm8t@users.noreply.github.com)
+    Co-authored-by: "E.Smith" <31170571+azlm8t@users.noreply.github.com>
 
-    Co-authored-by: Christian Kündig [christian@kuendig.info](mailto:christian@kuendig.info)
+    Co-authored-by: Christian Kündig <christian@kuendig.info>
 
-[^122]: ci: don't trigger cloudsmith on .github changes
 
-    Signed-off-by: Christian Hewitt [christianshewitt@gmail.com](mailto:christianshewitt@gmail.com)
+[^208]: webui: remove old doc references to paypal
 
-[^123]: ci: remove references to travis
+    Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 
-    Signed-off-by: Christian Hewitt [christianshewitt@gmail.com](mailto:christianshewitt@gmail.com)
 
-[^124]: ci: remove references to doozer
+[^209]: webui: change donation button to opencollective
 
-    Signed-off-by: Christian Hewitt [christianshewitt@gmail.com](mailto:christianshewitt@gmail.com)
+    Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 
-[^125]: ci: add concurrency to the main CI workflows
 
-    Signed-off-by: Christian Hewitt [christianshewitt@gmail.com](mailto:christianshewitt@gmail.com)
+[^210]: ci: remove the test-compile workflow
 
-[^126]: ci: schedule weekly coverity scans
+    Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 
-    Signed-off-by: Christian Hewitt [christianshewitt@gmail.com](mailto:christianshewitt@gmail.com)
 
-[^127]: ci: remove the test-compile workflow
+[^211]: ci: schedule weekly coverity scans
 
-    Signed-off-by: Christian Hewitt [christianshewitt@gmail.com](mailto:christianshewitt@gmail.com)
+    Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 
-[^128]: Correct handling of Remove and Ignore settings
 
-    Like strtok(), http\_tokenize() modifies its input string. Since those strings are needed later to populate the UI, we should use copies.
+[^212]: ci: add concurrency to the main CI workflows
 
-    Also free ignore\_args to avoid a memory leak.
+    Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 
-[^129]: Removed nested function 'appendPidRange' from within function 'tvhdhomerun\_frontend\_update\_pids'
 
-    and converted it to a normal function 'tvhdhomerun\_frontend\_update\_pids\_appendPidRange'.
+[^213]: ci: remove references to doozer
+
+    Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+
+
+[^214]: ci: remove references to travis
+
+    Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+
+
+[^215]: ci: don't trigger cloudsmith on .github changes
+
+    Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+
+
+[^216]: Correct handling of Remove and Ignore settings
+
+    Like strtok(), http_tokenize() modifies its input string. Since those strings are needed later to populate the UI, we should use copies.
+
+    Also free ignore_args to avoid a memory leak.
+
+
+[^217]: Removed nested function 'appendPidRange' from within function 'tvhdhomerun_frontend_update_pids'
+
+    and converted it to a normal function 'tvhdhomerun_frontend_update_pids_appendPidRange'.
 
     Nested functions are a non-standard extension to C that may only be supported by the gcc compiler.
 
-[^130]: Fix non-admin users not receiving any updates in web UI
+
+[^218]: Fix non-admin users not receiving any updates in web UI
 
     All the way back in 54e63e3f9af8fdc0d23f61f3cda7fa7b246c1732, there
 
     was a fix to stop non-admin users from receiving log messages with
 
-    potentially-sensitive data. However, this stopped non-admin webui
+    potentially-sensitive data.  However, this stopped non-admin webui
 
     users from receiving almost any updates over the websocket
 
     interface, which causes a bug where such users don't see newly-
 
-    created DVR entries, etc. until refreshing the page. This patch
+    created DVR entries, etc. until refreshing the page.  This patch
 
     allows for more granular control over what non-admin users
 
-    receive. Specifically, messages originating from subscriptions.c,
+    receive.  Specifically, messages originating from subscriptions.c,
 
-    mpegts\_input.c, and api\_service.c, along with all log messages, are
+    mpegts_input.c, and api_service.c, along with all log messages, are
 
     still only sent to admins because they may contain sensitive data
 
@@ -2597,17 +5110,34 @@
 
     once again sent to all webui users to keep the UI up-to-date.
 
-[^131]: Fix htsstr\_argsplit (treat quotes inside an argument correctly)
+
+[^219]: Fix htsstr_argsplit (treat quotes inside an argument correctly)
 
     There seemed to be a flaw in the splitting logic when it comes to quotes, e.g.:
 
-    \--output="filename" should be one argument, but htsstr\_argsplit treated it as
+    --output="filename" should be one argument, but htsstr_argsplit treated it as
 
-    \['--output=', '"filename"] which I think is wrong.
+    ['--output=', '"filename"] which I think is wrong.
 
     I fixed this and added two tests for this scenario.
 
-[^132]: webui/dvr: Remove unused & duplicated functions
+
+[^220]: support/mkbundle: switch from distutils to setuptools
+
+    Fixes build error with python-3.12:
+
+    Traceback (most recent call last):
+
+      File "support/mkbundle", line 48, in <module>
+
+        import distutils.spawn
+
+    ModuleNotFoundError: No module named 'distutils'
+
+    Signed-off-by: Bernd Kuhls <bernd@kuhls.net>
+
+
+[^221]: webui/dvr: Remove unused & duplicated functions
 
     While implementing the alternative/similar broadcast buttons it seems
 
@@ -2615,19 +5145,20 @@
 
     unused (like `dvrAlternativeShowings` as the buttons are calling
 
-    `epgAlternativeShowingsDialog` instead) or duplicate functions which
+     `epgAlternativeShowingsDialog` instead) or duplicate functions which
 
     already existed like `load`, `previousEvent` & `nextEvent`.
 
     References: 04cd487bb8
 
-[^133]: webui/dvr: Add age\_rating in recording details dialogs
+
+[^222]: webui/dvr: Add age_rating in recording details dialogs
 
     The details dialogs in the various recording tabs do not open anymore
 
     with the error `Uncaught TypeError: params[25] is undefined` in the JS
 
-    console as the age\_rating wasn't requested for those, only for the
+    console as the age_rating wasn't requested for those, only for the
 
     overview columns.
 
@@ -2635,27 +5166,19 @@
 
     similar looking (but completely different implemented…) EPG dialog does.
 
-    Regression-of: d501059995
+    Regession-of: d501059995
 
     Fixes: https://tvheadend.org/issues/6297
 
-[^134]: support/mkbundle: switch from distutils to setuptools
 
-    Fixes build error with python-3.12:
+[^223]: otamux: Make sure we use PRItime_t
 
-    Traceback (most recent call last):
+    As %li isn't supported equally, we must ensure we always use PRItime_t.
 
-    File "support/mkbundle", line 48, in
+    Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>
 
-    ```
-    import distutils.spawn
-    ```
 
-    ModuleNotFoundError: No module named 'distutils'
-
-    Signed-off-by: Bernd Kuhls [bernd@kuhls.net](mailto:bernd@kuhls.net)
-
-[^135]: Use explicitly on format warnings for Time test
+[^224]: Use explicitly on format warnings for Time test
 
     It looks like the compile check doesn't work properly on some
 
@@ -2667,15 +5190,10 @@
 
     end is exactly what we are after.
 
-    Signed-off-by: Olliver Schinagl [oliver@schinagl.nl](mailto:oliver@schinagl.nl)
+    Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>
 
-[^136]: otamux: Make sure we use PRItime\_t
 
-    As %li isn't supported equally, we must ensure we always use PRItime\_t.
-
-    Signed-off-by: Olliver Schinagl [oliver@schinagl.nl](mailto:oliver@schinagl.nl)
-
-[^137]: CI: Run the full build with cloudsmith only on master
+[^225]: CI: Run the full build with cloudsmith only on master
 
     Cloudsmith deployal should only be done on master, but we want to run
 
@@ -2683,9 +5201,10 @@
 
     script to indicate that this is about cloudsmith specifically.
 
-    Signed-off-by: Olliver Schinagl [oliver@schinagl.nl](mailto:oliver@schinagl.nl)
+    Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>
 
-[^138]: CI: Build (without cloudsmith) all targets on every merge request
+
+[^226]: CI: Build (without cloudsmith) all targets on every merge request
 
     We want to build everything on merge requests, tags etc.
 
@@ -2699,13 +5218,14 @@
 
     do it.
 
-    Signed-off-by: Olliver Schinagl [oliver@schinagl.nl](mailto:oliver@schinagl.nl)
+    Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>
 
-[^139]: Fix time for old 32bit systems
+
+[^227]: Fix time for old 32bit systems
 
     The fix introduced in fe47ecb5504a ("Fix time for 32bit systems again")
 
-    made the incorrect assumption, that the macro \_TIME\_BITS=64 was always
+    made the incorrect assumption, that the macro _TIME_BITS=64 was always
 
     available. It seems like that this is not the case for old systems,
 
@@ -2723,11 +5243,12 @@
 
     Fixes fe47ecb5504a ("Fix time for 32bit systems again")
 
-    Signed-off-by: Olliver Schinagl [oliver@schinagl.nl](mailto:oliver@schinagl.nl)
+    Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>
 
-[^140]: Fix time for 32bit systems again
 
-    In issue #6257 an issue mentioning that time\_t isn't properly supported
+[^228]: Fix time for 32bit systems again
+
+    In issue #6257 an issue mentioning that time_t isn't properly supported
 
     when printing on 32-bit systems, specifically on FreeBSD. However, intel
 
@@ -2735,23 +5256,21 @@
 
     src/rtsp.c:333:30: error: format '%ld' expects argument of type 'long int',
 
-    but argument 4 has type 'time\_t' {aka 'long long int'} \[-Werror=format=]
+    but argument 4 has type 'time_t' {aka 'long long int'} [-Werror=format=]
 
-    333 | snprintf(buf, sizeof(buf), "npt=%" PRItime\_t "-", position);
+      333 |   snprintf(buf, sizeof(buf), "npt=%" PRItime_t "-", position);
 
-    ```
-      |                              ^~~~~~~                ~~~~~~~~
+          |                              ^~~~~~~                ~~~~~~~~
 
-      |                                                     |
+          |                                                     |
 
-      |                                                     time_t {aka long long int}
-    ```
+          |                                                     time_t {aka long long int}
 
-    In commit 76a6263f1be4 ("fix for 64bit time\_t on 32bit systems") was
+    In commit 76a6263f1be4 ("fix for 64bit time_t on 32bit systems") was
 
     attempted to be fixed by turning it into a PRId64, which was reverted
 
-    again in commit 9e1eb89be731 ("Revert "fix for 64bit time\_t on 32bit
+    again in commit 9e1eb89be731 ("Revert "fix for 64bit time_t on 32bit
 
     systems""), sadly without a reason as to why in the commit message.
 
@@ -2759,7 +5278,7 @@
 
     due to the Y2038 problem. Debian is heavily working on this issue too.
 
-    This commit is just the first step, in that we ensure our time\_t is
+    This commit is just the first step, in that we ensure our time_t is
 
     always 64bits.
 
@@ -2767,13 +5286,13 @@
 
     subtractions, and ensure all stored timestamps have room for 64bit
 
-    time\_t (htsmsg\_get\_u32\_or\_default for example breaks this presumption
+    time_t (htsmsg_get_u32_or_default for example breaks this presumption
 
     already).
 
     To keep this issue small, and tackle one problem at a time, lets just
 
-    fix time\_t first. We do still have 15 years to fix the other issues.
+    fix time_t first. We do still have 15 years to fix the other issues.
 
     Note, that this patch leaves out FreeBSD specifics, as it is unclear
 
@@ -2781,7 +5300,7 @@
 
     headers after all. If not, we can always add if needed, but adding
 
-    useless code doesn't help anyone generally.
+    usless code doesn't help anyone generally.
 
     ```
 
@@ -2817,17 +5336,10 @@
 
     ```
 
-    Signed-off-by: Olliver Schinagl [oliver@schinagl.nl](mailto:oliver@schinagl.nl)
+    Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>
 
-[^141]: Fix configuration-loading logic to account for forking operation
 
-    Since config\_get\_dir() is executed before forking, the uid will
-
-    always be 0 at this point. Instead, use the uid of the user to
-
-    which we will fork if a fork will occur.
-
-[^142]: Update Debian packaging to use the new configuration directories
+[^229]: Update Debian packaging to use the new configuration directories
 
     This updates the Debian packaging to use the new configuration
 
@@ -2835,7 +5347,7 @@
 
     https://github.com/tvheadend/tvheadend/pull/1535 and
 
-    https://github.com/tvheadend/tvheadend/pull/1538. Instead of being
+    https://github.com/tvheadend/tvheadend/pull/1538.  Instead of being
 
     in /home/hts/.hts/tvheadend, the configuration will now be stored in
 
@@ -2845,7 +5357,54 @@
 
     and configuration.
 
-[^143]: spawn: Do not close every possible file descriptor
+
+[^230]: Fix configuration-loading logic to account for forking operation
+
+    Since config_get_dir() is executed before forking, the uid will
+
+    always be 0 at this point.  Instead, use the uid of the user to
+
+    which we will fork if a fork will occur.
+
+
+[^231]: config: Fix whitespace errors
+
+    The internal print functions already add the newline for us, so adding
+
+    one manually is not needed.
+
+    Further more, a tab got snook in, where spaces where intended.
+
+    This fixes commit dbf973307ae3 ("dvr_storage: Use XDG spec directories")
+
+    which accidentally introduced this.
+
+    Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>
+
+
+[^232]: Fix portability: Do not use linux/limits.h
+
+    The header limits.h suffices, lets use that instead.
+
+    Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>
+
+
+[^233]: dvr_storage: Also support server configurations for recordings
+
+    Like in commit e15c1abe9737 ("config: Support server configurations"),
+
+    dvr_recordings are probably best stored in a 'server known
+
+    configuration', as otherwise they can end up in `/Videos`. While the
+
+    user can always configure this nicely, having a server sensible default
+
+    is good.
+
+    Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>
+
+
+[^234]: spawn: Do not close every possible file descriptor
 
     When close is called with a non-existant file descriptor, it will happily
 
@@ -2855,7 +5414,7 @@
 
     This in itself is not a problem at all, however, we try to close every
 
-    open file descriptor beyond stderr, upto whatever \_SC\_OPEN\_MAX returns.
+    open file descriptor beyond stderr, upto whatever _SC_OPEN_MAX returns.
 
     Some systems may have a very large ulimit set for `_SC_OPEN_MAX` and
 
@@ -2869,53 +5428,48 @@
 
     file descriptors, and only close open ones.
 
-    Signed-off-by: Olliver Schinagl [oliver@schinagl.nl](mailto:oliver@schinagl.nl)
+    Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>
 
-[^144]: config: Fix whitespace errors
 
-    The internal print functions already add the newline for us, so adding
+[^235]: config: Support server configurations
 
-    one manually is not needed.
+    On server loads, it is not uncommon to have the config directory live in
 
-    Further more, a tab got snook in, where spaces where intended.
+    `/var/lib/tvheadend`. While `/etc/tvheadend` is also common, it's more
 
-    This fixes commit dbf973307ae3 ("dvr\_storage: Use XDG spec directories")
+    for manually written configuration files, tvheadend is more a 'config
 
-    which accidentally introduced this.
+    state'. Support both regardless.
 
-    Signed-off-by: Olliver Schinagl [oliver@schinagl.nl](mailto:oliver@schinagl.nl)
+    This change shouldn't impact desktop users, presuming they do not have
 
-[^145]: Fix portability: Do not use linux/limits.h
+    these locations installed.
 
-    The header limits.h suffices, lets use that instead.
+    Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>
 
-    Signed-off-by: Olliver Schinagl [oliver@schinagl.nl](mailto:oliver@schinagl.nl)
 
-[^146]: dvr\_storage: Also support server configurations for recordings
+[^236]: dvr_storage: Use XDG spec directories
 
-    Like in commit e15c1abe9737 ("config: Support server configurations"),
+    The XDG spec has a way to determine the users preferred Video directory.
 
-    dvr\_recordings are probably best stored in a 'server known
+    This is important, because in different locales, this may be a different
 
-    configuration', as otherwise they can end up in `/Videos`. While the
+    directory, preventing annoyance for users who have a localized home dir.
 
-    user can always configure this nicely, having a server sensible default
+    With the newly added XDG helpers, this becomes a triviality.
 
-    is good.
+    This change does mean, that the behavior is slightly changed, as XDG
 
-    Signed-off-by: Olliver Schinagl [oliver@schinagl.nl](mailto:oliver@schinagl.nl)
+    directories are probed first.
 
-[^147]: config: Deal with configuration before anything else
+    However since this only affects the startup, after which these
 
-    We should really be setting up our configuration storage before anything
+    directories are stored in the config, the impact should be neglectable.
 
-    else. Starting/registering other items before that seems a bit
+    Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>
 
-    out-of-order.
 
-    Signed-off-by: Olliver Schinagl [oliver@schinagl.nl](mailto:oliver@schinagl.nl)
-
-[^148]: config: Store config directory variable internally
+[^237]: config: Store config directory variable internally
 
     Currently `config_boot` 'abuses' the path-pointer and stores its own
 
@@ -2935,47 +5489,10 @@
 
     and get this from the config struct instead.
 
-    Signed-off-by: Olliver Schinagl [oliver@schinagl.nl](mailto:oliver@schinagl.nl)
+    Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>
 
-[^149]: config: Add support for XDG config
 
-    Over the last years, the freedesktop organization has promoted the use
-
-    of XDG\_HOME\_CONFIG for storing configuration data.
-
-    Since TVHeadend also wants to help declutter the home directory, lets
-
-    follow the spec for our own configuration. While here, reduce the path
-
-    from `hts/tvheaded` to just `hts`.
-
-    The implementation does not change behaviour of existing installations!
-
-    If `.hts/tvheadend` exists, it will be used as before.
-
-    New installations, will try to use `.config/hts` instead, and
-
-    'migrating' is as easy as `mv .hts/tvheadend .config/hts`.
-
-    Signed-off-by: Olliver Schinagl [oliver@schinagl.nl](mailto:oliver@schinagl.nl)
-
-[^150]: config: Support server configurations
-
-    On server loads, it is not uncommon to have the config directory live in
-
-    `/var/lib/tvheadend`. While `/etc/tvheadend` is also common, it's more
-
-    for manually written configuration files, tvheadend is more a 'config
-
-    state'. Support both regardless.
-
-    This change shouldn't impact desktop users, presuming they do not have
-
-    these locations installed.
-
-    Signed-off-by: Olliver Schinagl [oliver@schinagl.nl](mailto:oliver@schinagl.nl)
-
-[^151]: settings: Add XDG support helper functions
+[^238]: settings: Add XDG support helper functions
 
     The XDG spec goes beyond the '.config' directory structure, but also
 
@@ -2993,29 +5510,44 @@
 
     use.
 
-    Signed-off-by: Olliver Schinagl [oliver@schinagl.nl](mailto:oliver@schinagl.nl)
+    Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>
 
-[^152]: dvr\_storage: Use XDG spec directories
 
-    The XDG spec has a way to determine the users preferred Video directory.
+[^239]: config: Add support for XDG config
 
-    This is important, because in different locales, this may be a different
+    Over the last years, the freedesktop organization has promoted the use
 
-    directory, preventing annoyance for users who have a localized home dir.
+    of XDG_HOME_CONFIG for storing configuration data.
 
-    With the newly added XDG helpers, this becomes a triviality.
+    Since TVHeadend also wants to help declutter the home directory, lets
 
-    This change does mean, that the behaviour is slightly changed, as XDG
+    follow the spec for our own configuration. While here, reduce the path
 
-    directories are probed first.
+    from `hts/tvheaded` to just `hts`.
 
-    However since this only affects the startup, after which these
+    The implementation does not change behavior of existing installations!
 
-    directories are stored in the config, the impact should be neglectable.
+    If `.hts/tvheadend` exists, it will be used as before.
 
-    Signed-off-by: Olliver Schinagl [oliver@schinagl.nl](mailto:oliver@schinagl.nl)
+    New installations, will try to use `.config/hts` instead, and
 
-[^153]: Add simple 'ping' endpoint for healthchecks
+    'migrating' is as easy as `mv .hts/tvheadend .config/hts`.
+
+    Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>
+
+
+[^240]: config: Deal with configuration before anything else
+
+    We should really be setting up our configuration storage before anything
+
+    else. Starting/registering other items before that seems a bit
+
+    out-of-order.
+
+    Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>
+
+
+[^241]: Add simple 'ping' endpoint for healthchecks
 
     To determine if the server is online, we want to be able to 'ping' it
 
@@ -3031,50 +5563,68 @@
 
     b) without any access permissions
 
-    Signed-off-by: Olliver Schinagl [oliver@schinagl.nl](mailto:oliver@schinagl.nl)
+    Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>
 
-[^154]: dvr\_rec: Fix a buffer overflow in filename generation
+
+[^242]: dvr_rec: Fix a buffer overflow in filename generation
 
     Fixes https://tvheadend.org/issues/6272
 
     Co-authored-by: Dave Pickles
 
-[^155]: *   fixed bug with \_lang3\_to\_lang2()
+
+[^243]: - fixed bug with _lang3_to_lang2()
 
         Typo made using lang instead of lang3 in lookup map
-    * clean by running through autopep8
-    *   Add more exception handling to prevent it crashing
 
-        Still needs some improvements with exception types
-    * tidy up for pylint
-    * python 2 is deprecated - simplify for python 3
+     - clean by running through autopep8
 
-[^156]: update to ffmpeg 5.1.3
+     - Add more exception handling to prevent it crashing
+
+       Still needs some improvements with exception types
+
+     - tidy up for pylint
+
+     - python 2 is deprecated - simplify for python 3
+
+
+[^244]: update pict_type from AVPacket to AVFrame
+
+    - remove deprecated FF_API_CODED_FRAME
+
+    - remove pict_type from AVPacket_SideData
+
+    - use AVFrame->pict_type (same like ffmpeg 5.1.2 - ffprobe.c line 2595)
+
+    - remove patch for vaapi_encode
+
+
+[^245]: update to ffmpeg 5.1.3
 
     update to ffmpeg 5.1.3
 
-[^157]: update pict\_type from AVPacket to AVFrame
 
-    * remove deprecated FF\_API\_CODED\_FRAME
-    * remove pict\_type from AVPacket\_SideData
-    * use AVFrame->pict\_type (same like ffmpeg 5.1.2 - ffprobe.c line 2595)
-    * remove patch for vaapi\_encode
+[^246]: update to ffmpeg 5.1.2
 
-[^158]: tv\_meta\_tvdb.py: Fix 'language' typo.
+    - ffmpeg_static will always compile with ffmpeg 5.1.2
 
-    Typo 'language' prevents the script from fetching poster art.
+    - Makefile.ffmpeg added to 5.1.2
+
+    - src/muxer/muxer_libav.c: update 'AVOutputFrmat' to 'const AVOutputFrmat'
+
+    - src/transcoding/transcode/hwaccels/vaapi.c --> incorporated the struct from libavcodec/vaapi.h
+
+    - src/transcoding/transcode/video.c: update type for qdata_size
+
+
+[^247]: tv_meta_tvdb.py: Fix 'languague' typo.
+
+    Typo 'languague' prevents the script from fetching poster art.
 
     Fixes #6262.
 
-[^159]: update to ffmpeg 5.1.2
 
-    * ffmpeg\_static will always compile with ffmpeg 5.1.2
-    * Makefile.ffmpeg added to 5.1.2
-    * src/muxer/muxer\_libav.c: update 'AVOutputFrmat' to 'const AVOutputFrmat'
-    * src/transcoding/transcode/hwaccels/vaapi.c --> incorporated the struct from libavcodec/vaapi.h
-    * src/transcoding/transcode/video.c: update type for qdata\_size
-
-[^160]: tvhmeta: Fix tvhmeta authentication to the tvheadend API.
+[^248]: tvhmeta: Fix tvhmeta authentication to the tvheadend API.
 
     Construct and add an Authorization header to the request, when a
 
@@ -3082,37 +5632,25 @@
 
     This fixes #6260.
 
-[^161]: updated 'AVCodec' to 'const AVCodec'
 
-    * updated 'AVCodec' to 'const AVCodec'
-    * "avctx->refcounted\_frames = 1;" deprecated (not required with: avcodec\_receive\_frame())
+[^249]: updated 'AVCodec' to 'const AVCodec'
 
-[^162]: remove deprecate struct vaapi\_context and the vaapi.h
+    - updated 'AVCodec' to 'const AVCodec'
 
-    * remove deprecate struct vaapi\_context and the vaapi.h
+    - "avctx->refcounted_frames = 1;" deprecated (not required with: avcodec_receive_frame())
 
-[^163]: remove ffmpeg component avresample
 
-    * remove ffmpeg component avresample. Is deprecated and replaced by swresample. I verified that all functions from this component are not used in tvh (https://www.ffmpeg.org/doxygen/2.3/group\_\_lavr.html)
+[^250]: remove deprecate struct vaapi_context and the vaapi.h
 
-[^164]: update to ffmpeg codecpar
+    - remove deprecate struct vaapi_context and the vaapi.h
 
-    * update to ffmpeg codecpar
 
-[^165]: remove unused function and migrate from AVBitStreamFilterContext to AVBSFContext
+[^251]: remove ffmpeg component avresample
 
-    * migrate from AVBitStreamFilterContext to AVBSFContext
-    * update AVCodec to 'const AVCodec'
-    * remove unused function: libav\_is\_encoder()
-    * remove deprecated functions:
+    - remove ffmpeg component avresample. Is deprecated and replaced by swresample. I verified that all functions from this component are not used in tvh (https://www.ffmpeg.org/doxygen/2.3/group__lavr.html)
 
-    \-- AVFormatContext->filename
 
-    \-- av\_register\_all() --> https://github.com/FFmpeg/FFmpeg/blob/master/doc/APIchanges (2018-02-06 - 0694d87024 - lavf 58.9.100 - avformat.h)
-
-    \-- avfilter\_register\_all() --> https://github.com/FFmpeg/FFmpeg/blob/master/doc/APIchanges (2018-04-01 - f1805d160d - lavfi 7.14.100 - avfilter.h)
-
-[^166]: iconv: Allow using GNU libiconv
+[^252]: iconv: Allow using GNU libiconv
 
     TVHeadend has a hard-dependency on libiconv. Lets make this a little bit
 
@@ -3122,79 +5660,110 @@
 
     Contributes to #4940.
 
-    Signed-off-by: Olliver Schinagl [oliver@schinagl.nl](mailto:oliver@schinagl.nl)
+    Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>
 
-[^167]: Revert "fix for 64bit time\_t on 32bit systems"
+
+[^253]: remove unused function and migrate from AVBitStreamFilterContext to AVBSFContext
+
+    - migrate from AVBitStreamFilterContext to AVBSFContext
+
+    - update AVCodec to 'const AVCodec'
+
+    - remove unused function: libav_is_encoder()
+
+    - remove deprecated functions:
+
+    -- AVFormatContext->filename
+
+    -- av_register_all() --> https://github.com/FFmpeg/FFmpeg/blob/master/doc/APIchanges (2018-02-06 - 0694d87024 - lavf 58.9.100 - avformat.h)
+
+    -- avfilter_register_all() --> https://github.com/FFmpeg/FFmpeg/blob/master/doc/APIchanges (2018-04-01 - f1805d160d - lavfi 7.14.100 - avfilter.h)
+
+
+[^254]: update to ffmpeg codecpar
+
+    - update to ffmpeg codecpar
+
+
+[^255]: Revert "fix for 64bit time_t on 32bit systems"
 
     This reverts commit 76a6263f1be4e3ccff968b47155b050fcc15f042.
 
-[^168]: update vaapi
 
-    * update the code to match the format from vnenc.c (unify format)
-    * update the default value for level to match software encoding (3.0)
+[^256]: update NASM to 2.16.01
 
-[^169]: update NASM to 2.16.01
+    - update NASM to 2.16.01
 
-    * update NASM to 2.16.01
 
-[^170]: update ffmpeg from 4.4.1 to 4.4.3
+[^257]: update vaapi
 
-    * update ffmpeg from 4.4.1 to 4.4.3
+    - update the code to match the format from vnenc.c (unify format)
 
-[^171]: update vaapi
+    - update the default value for level to match software encoding (3.0)
 
-    * added denoise\_vaapi
-    * added sharpness\_vaapi
 
-[^172]: update vaapi
+[^258]: update to ffmpeg codecpar
 
-    * update libvpx to ver. 1.12.0
-    * replaced tvherror() with tvhinfo for bitrate report
-    * converted from bps to kbps
-    * reduced B frame to max 3 (4 is generating artifacts on my system)
-    * I had to set also bf otherwise will be set later in profile\_video\_class() with 3
-    * when low power is enabled max B frame will be disabled (because codec is not using B frames in low power mode)
-    * h264\_vaapi and hevc\_vaapi have also dynamic enable/disable for max B frame
-    * vp9 super frames can be enabled/disabled from the interface
-    * clean-up some javascript code
+    - update to ffmpeg codecpar
 
-[^173]: Revert "Update debian/compat to version 10"
+
+[^259]: update ffmpeg from 4.4.1 to 4.4.3
+
+    - update ffmpeg from 4.4.1 to 4.4.3
+
+
+[^260]: update vaapi
+
+    - added denoise_vaapi
+
+    - added sharpness_vaapi
+
+
+[^261]: update vaapi
+
+    - update libvpx to ver. 1.12.0
+
+    - replaced tvherror() with tvhinfo for bitrate report
+
+    - converted from bps to kbps
+
+    - reduced B frame to max 3 (4 is generating artifacts on my system)
+
+    - I had to set also bf otherwise will be set later in profile_video_class() with 3
+
+    - when low power is enabled max B frame will be disabled (because codec is not using B frames in low power mode)
+
+    - h264_vaapi and hevc_vaapi have also dynamic enable/disable for max B frame
+
+    - vp9 super frames can be enabled/disabled from the interface
+
+    - clean-up some javascript code
+
+
+[^262]: Fix Coverity-Build  (#1499)
+
+    * Add omx dependency for Coverity-Build
+
+    * Add libva-dev dependency for Coverity-Build
+
+    * Add nvidia-cuda-dev dependency for Coverity-Build
+
+    * Enable tvhcsa and memoryinfo for Coverity-Build
+
+    * Disable mmal due to unavailability for Coverity-Build
+
+
+[^263]: Revert "Update debian/compat to version 10"
 
     This reverts commit 2a370dd17fcac7e587d45fd9971e346536379ea3.
 
-[^174]: Fix Coverity-Build (#1499)
 
-    * Add omx dependency for Coverity-Build
-    * Add libva-dev dependency for Coverity-Build
-    * Add nvidia-cuda-dev dependency for Coverity-Build
-    * Enable tvhcsa and memoryinfo for Coverity-Build
-    * Disable mmal due to unavailability for Coverity-Build
-
-[^175]: Ignore title mismatch if dup checking by CRID
+[^264]: Ignore title mismatch if dup checking by CRID
 
     Some channels add "New: " to the title if this is the first showing, so a title match with repeats will fail.
 
-[^176]: Add configurable delays after Unicable operations
 
-    Allow user to adjust the length of time delays
-
-    after the Unicable device is powered up
-
-    and after a DiSEqC command is sent to it
-
-[^177]: Unify power up time range to 10-500 ms
-
-    Unify the allowed range of power up time
-
-    for rotors, switches and unicable devices.
-
-[^178]: Unify command time range to 10-300 ms
-
-    Unify the allowed range of command time
-
-    for rotors, switches and unicable devices.
-
-[^179]: Update debian/compat to version 10
+[^265]: Update debian/compat to version 10
 
     Compat version 10 was declared recommended in 2016.
 
@@ -3208,46 +5777,82 @@
 
     https://github.com/Debian/debhelper/blob/5d1bb29841043d8e47ebbdd043e6cd086cad508e/debhelper.pod#compatibility-levels
 
-[^180]: descrambler: cosmetic cleanups, more CAID logs
 
-    Signed-off-by: Jaroslav Kysela [perex@perex.cz](mailto:perex@perex.cz)
+[^266]: Add configurable delays after Unicable operations
 
-[^181]: descrambler: cclient: optimisation for multiple key clients
+    Allow user to adjust the length of time delays
+
+    after the Unicable device is powered up
+
+    and after a DiSEqC command is sent to it
+
+
+[^267]: Unify command time range to 10-300 ms
+
+    Unify the allowed range of command time
+
+    for rotors, switches and unicable devices.
+
+
+[^268]: Unify power up time range to 10-500 ms
+
+    Unify the allowed range of power up time
+
+    for rotors, switches and unicable devices.
+
+
+[^269]: update vaapi
+
+    - updated function _video_filters_get_filters() due to a bug hidden by previous bug (Bug #6247)
+
+    - fixed Decoder HW + Encoder HW --> was generating download / upload that increase CPU usage
+
+    - remove vp9 profile0 to 3 (ffmpeg vaapi is not supporting profiles for vp9)
+
+    - improve 'tier' and added: level, qmin, qmax, desired_b_depth
+
+    - printing Bitrate, Buffer size, Max bitrate (for each transcoding start)
+
+    - added superframe for vp9
+
+
+[^270]: descrambler: cccam: move send keepalive message to traces
+
+    Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+
+
+[^271]: descrambler: cccam - simplify cccam_handle_keys()
+
+    Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+
+
+[^272]: descrambler: cclient: optimization for multiple key clients
 
     Do not use client when other handles requests.
 
-    Signed-off-by: Jaroslav Kysela [perex@perex.cz](mailto:perex@perex.cz)
+    Signed-off-by: Jaroslav Kysela <perex@perex.cz>
 
-[^182]: descrambler: cccam - simplify cccam\_handle\_keys()
 
-    Signed-off-by: Jaroslav Kysela [perex@perex.cz](mailto:perex@perex.cz)
+[^273]: descrambler: cosmetic cleanups, more CAID logs
 
-[^183]: descrambler: cccam: move send keepalive message to traces
+    Signed-off-by: Jaroslav Kysela <perex@perex.cz>
 
-    Signed-off-by: Jaroslav Kysela [perex@perex.cz](mailto:perex@perex.cz)
 
-[^184]: update vaapi
+[^274]: descrambler: cwc: do not register bad provider numbers for betacrypt and irdeto
 
-    * updated function \_video\_filters\_get\_filters() due to a bug hidden by previous bug (Bug #6247)
-    * fixed Decoder HW + Encoder HW --> was generating download / upload that increase CPU usage
-    * remove vp9 profile0 to 3 (ffmpeg vaapi is not supporting profiles for vp9)
-    * improve 'tier' and added: level, qmin, qmax, desired\_b\_depth
-    * printing Bitrate, Buffer size, Max bitrate (for each transcoding start)
-    * added superframe for vp9
+    Signed-off-by: Jaroslav Kysela <perex@perex.cz>
 
-[^185]: descrambler: cwc: Fix the additional card registration (mgclient option in &#x6F;_&#x73;_&#x63;_&#x61;_&#x6D;)
+
+[^275]: descrambler: cwc: Fix the additional card registration (mgclient option in o*s*c*a*m)
 
     It's expected that new CAIDs and providers are added to the current list rather
 
     than to overwrite the previous fetched providers.
 
-    Signed-off-by: Jaroslav Kysela [perex@perex.cz](mailto:perex@perex.cz)
+    Signed-off-by: Jaroslav Kysela <perex@perex.cz>
 
-[^186]: descrambler: cwc: do not register bad provider numbers for betacrypt and irdeto
 
-    Signed-off-by: Jaroslav Kysela [perex@perex.cz](mailto:perex@perex.cz)
-
-[^187]: Preserve existing Unicable idnode during the set operation
+[^276]: Preserve existing Unicable idnode during the set operation
 
     Currently, the Unicable settings are always cleared
 
@@ -3267,36 +5872,48 @@
 
     related to LNB, switch and rotor.
 
-[^188]: profile video resize improvements
 
-    * provide the ability to specify if scaling should be performed Up and Down, Up (only) or Down (only)
+[^277]: updated function _video_filters_get_filters()
+
+    - fixed Decoder HW + Encoder SW --> not working (with VAAPI) - Bug #6247
+
+    - fixed resize and deinterlace (*_vaapi for hw and ffmpeg for sw)
+
+
+[^278]: profile video resize improvements
+
+    - provide the ability to specify if scaling should be performed Up and Down, Up (only) or Down (only)
 
     profile video resize improvements
 
-    * provide the ability to specify if scaling should be performed Up and Down, Up (only) or Down (only)
+    - provide the ability to specify if scaling should be performed Up and Down, Up (only) or Down (only)
 
-[^189]: updated function \_video\_filters\_get\_filters()
 
-    * fixed Decoder HW + Encoder SW --> not working (with VAAPI) - Bug #6247
-    * fixed resize and deinterlace (\*\_vaapi for hw and ffmpeg for sw)
-
-[^190]: update vaapi
-
-    * added new settings: platform, bitrate scale factor, low power, loop filter level, loop filter sharpness, async depth
-    * implemented new (dynamic) settings adjustment (in js)
-    * added new parameters: b, low\_power, loop\_filter\_level, loop\_filter\_sharpness, async\_depth
-    * tvhva\_context\_check\_profile() will change TVHVAContext->entrypoint from VAEntrypointEncSlice into VAEntrypointEncSliceLP if VAEntrypointEncSlice is not available for that CODEC (according to VAAPI info)
-    * moved low\_power to tvh\_codeo\_profile in order to initialise properly the entrypoint
-    * many error reporting improvements
-    * separated some bundled conditions
-
-[^191]: Add autorec duplicate handling default to dvr config.
+[^279]: Add autorec duplicate handling default to dvr config.
 
     Default will be applied to new autorecs unless overridden.
 
-    duplicate\_handling.md: Add details of "Record if Unique" option.
+    duplicate_handling.md: Add details of "Record if Unique" option.
 
-[^192]: Don't confuse GCC with zero-length array
+
+[^280]: update vaapi
+
+    - added new settings: platform, bitrate scale factor, low power, loop filter level, loop filter sharpness, async depth
+
+    - implemented new (dynamic) settings adjustment (in js)
+
+    - added new parameters: b, low_power, loop_filter_level, loop_filter_sharpness, async_depth
+
+    - tvhva_context_check_profile() will change TVHVAContext->entrypoint from VAEntrypointEncSlice into VAEntrypointEncSliceLP if VAEntrypointEncSlice is not available for that CODEC (according to VAAPI info)
+
+    - moved low_power to tvh_codeo_profile in order to initialize properly the entrypoint
+
+    - many error reporting improvements
+
+    - separated some bundled conditions
+
+
+[^281]: Don't confuse GCC with zero-length array
 
     Fix FTBFS introduced by 7b95ba4cf9113ae8808b3e4a9425010b607dbaca
 
@@ -3306,15 +5923,19 @@
 
     References: 7b95ba4cf9113ae8808b3e4a9425010b607dbaca
 
-    Signed-off-by: Cédric Schieli [cschieli@gmail.com](mailto:cschieli@gmail.com)
+    Signed-off-by: Cédric Schieli <cschieli@gmail.com>
 
-[^193]: Add South Africa to Countries list.
 
-    dtv-scan-tables commit 28414c7 added muxes for South Africa.
+[^282]: config: Enable HbbTV parser by default
 
-    Add the country to the country codes list.
+    It make sense to include it always when available
 
-[^194]: dvb\_psi\_pmt: Recognise AC-4 audio descriptor
+    Link: https://tvheadend.org/issues/6223
+
+    Signed-off-by: Kacper Michajłow <kasper93@gmail.com>
+
+
+[^283]: dvb_psi_pmt: Recognize AC-4 audio descriptor
 
     This allows pass-through of AC-4 audio stream.
 
@@ -3324,53 +5945,50 @@
 
     Link: https://tvheadend.org/issues/6222
 
-    Signed-off-by: Kacper Michajłow [kasper93@gmail.com](mailto:kasper93@gmail.com)
+    Signed-off-by: Kacper Michajłow <kasper93@gmail.com>
 
-[^195]: config: Enable HbbTV parser by default
 
-    It make sense to include it always when available
+[^284]: Add South Africa to Countries list.
 
-    Link: https://tvheadend.org/issues/6223
+    dtv-scan-tables commit 28414c7 added muxes for South Africa.
 
-    Signed-off-by: Kacper Michajłow [kasper93@gmail.com](mailto:kasper93@gmail.com)
+    Add the country to the country codes list.
 
-[^196]: Build various targets and prepare new repository (#1476)
+
+[^285]: Build various targets and prepare new repository  (#1476)
 
     Some builds still need a newer python version
 
-[^197]: Avoid breaking strict aliasing in IP\_AS\_V{4,6}
+
+[^286]: Avoid breaking strict aliasing in IP_AS_V{4,6}
 
     GCC complains (one example, more in tcp.h):
 
     In file included from src/main.c:41:
 
-    src/tcp.h: In function ‘ip\_check\_equal\_v4’:
+    src/tcp.h: In function ‘ip_check_equal_v4’:
 
-    src/tcp.h:29:31: error: dereferencing type-punned pointer will break strict-aliasing rules \[-Werror=strict-aliasing]
+    src/tcp.h:29:31: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
 
-    29 | #define IP\_AS\_V4(storage, f) ((struct sockaddr\_in \*)&(storage))->sin\_##f
+       29 | #define IP_AS_V4(storage, f) ((struct sockaddr_in *)&(storage))->sin_##f
 
-    ```
-      |                              ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    ```
+          |                              ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    src/tcp.h:67:14: note: in expansion of macro ‘IP\_AS\_V4’
+    src/tcp.h:67:14: note: in expansion of macro ‘IP_AS_V4’
 
-    67 | { return IP\_AS\_V4(a, addr).s\_addr == IP\_AS\_V4(b, addr).s\_addr; }
+       67 |     { return IP_AS_V4(a, addr).s_addr == IP_AS_V4(b, addr).s_addr; }
 
-    ```
-      |              ^~~~~~~~
-    ```
+          |              ^~~~~~~~
 
-    storage (a) here is a pointer to sockaddr\_storage which is either backed
+    storage (a) here is a pointer to sockaddr_storage which is either backed
 
-    by a sockaddr\_in or sockaddr\_in6 struct (here, it would be good if it is
+    by a sockaddr_in or sockaddr_in6 struct (here, it would be good if it is
 
-    the former, we decided based on sa\_family in ip\_check\_equal). Referencing
+    the former, we decided based on sa_family in ip_check_equal). Referencing
 
-    it means we have a pointer to a pointer to sockaddr\_storage here, which
+    it means we have a pointer to a pointer to sockaddr_storage here, which
 
-    we then cast to a pointer to sockaddr\_in. Our so type-punned pointer is
+    we then cast to a pointer to sockaddr_in. Our so type-punned pointer is
 
     then dereferenced breaking strict-aliasing as this pointer as well as
 
@@ -3382,11 +6000,11 @@
 
     is just casting a pointer to a different type (which in this case is
 
-    legal as storage is really a sockaddr\_in).
+    legal as storage is really a sockaddr_in).
 
     Removing the reference breaks users of the macro who do not feed it a
 
-    pointer to a sockaddr\_storage, so while the warnings were all produced
+    pointer to a sockaddr_storage, so while the warnings were all produced
 
     by tcp.h, we end up changing code everywhere else to resolve them –
 
@@ -3406,7 +6024,45 @@
 
     positive over the previous tcp change in c0f616e / #1473.
 
-[^198]: Use application/json instead of text/x-json as mimetype
+
+[^287]: Simplify IPv6 compare functions to unconfuse gcc compiler
+
+    In file included from src/tcp.c:32:
+
+    In function ‘ip_check_is_any_v6’,
+
+        inlined from ‘ip_check_is_any’ at src/tcp.h:110:46,
+
+        inlined from ‘ip_check_is_local_address’ at src/tcp.c:89:17:
+
+    src/tcp.h:105:57: warning: array subscript 1 is outside array bounds of ‘const struct sockaddr_storage[0]’ [-Warray-bounds]
+
+      105 |   { return ((uint64_t *)IP_AS_V6(address, addr).s6_addr)[0] == ((uint64_t *)(&in6addr_any.s6_addr))[0] &&
+
+          |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
+
+    src/tcp.h: In function ‘ip_check_is_local_address’:
+
+    src/tcp.h:108:19: note: at offset 8 into object ‘address’ of size 8
+
+      108 | static inline int ip_check_is_any(const struct sockaddr_storage *address)
+
+          |                   ^~~~~~~~~~~~~~~
+
+    And more for the other half of the function and its three-times more or
+
+    less copy-paste instances. sockaddr_storage is not an array, but what
+
+    we actually do here is access s6_addr – which is an array of uint8_t.
+
+    Accessing the 16 uint8_t as 2 uint64_t apparently works, but not doing
+
+    it results in hopefully simpler to understand code for both humans and
+
+    compilers alike.
+
+
+[^288]: Use application/json instead of text/x-json as mimetype
 
     The web has mostly agreed on this standardized mimetype and e.g.
 
@@ -3414,7 +6070,8 @@
 
     JSON viewer rather than downloaded.
 
-[^199]: Don't crash the wizard if tvh has no inputs
+
+[^289]: Don't crash the wizard if tvh has no inputs
 
     If you have e.g. all but dvb disabled and forgot to plug in your usb
 
@@ -3426,49 +6083,8 @@
 
     page is far better than a crash to discover your mistake.
 
-[^200]: Simplify IPv6 compare functions to unconfuse gcc compiler
 
-    In file included from src/tcp.c:32:
-
-    In function ‘ip\_check\_is\_any\_v6’,
-
-    ```
-    inlined from ‘ip_check_is_any’ at src/tcp.h:110:46,
-
-    inlined from ‘ip_check_is_local_address’ at src/tcp.c:89:17:
-    ```
-
-    src/tcp.h:105:57: warning: array subscript 1 is outside array bounds of ‘const struct sockaddr\_storage\[0]’ \[-Warray-bounds]
-
-    105 | { return ((uint64\_t \*)IP\_AS\_V6(address, addr).s6\_addr)\[0] == ((uint64\_t \*)(\&in6addr\_any.s6\_addr))\[0] &&
-
-    ```
-      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
-    ```
-
-    src/tcp.h: In function ‘ip\_check\_is\_local\_address’:
-
-    src/tcp.h:108:19: note: at offset 8 into object ‘address’ of size 8
-
-    108 | static inline int ip\_check\_is\_any(const struct sockaddr\_storage \*address)
-
-    ```
-      |                   ^~~~~~~~~~~~~~~
-    ```
-
-    And more for the other half of the function and its three-times more or
-
-    less copy-paste instances. sockaddr\_storage is not an array, but what
-
-    we actually do here is access s6\_addr – which is an array of uint8\_t.
-
-    Accessing the 16 uint8\_t as 2 uint64\_t apparently works, but not doing
-
-    it results in hopefully simpler to understand code for both humans and
-
-    compilers alike.
-
-[^201]: epgdb: Resolve symlinks before using file location
+[^290]: epgdb: Resolve symlinks before using file location
 
     The new epgdb is written to a temporary file and later renamed to
 
@@ -3488,13 +6104,13 @@
 
     doesn't exist we default to the old way of just taking the path
 
-    verbatim and let them be created by hts\_settings\_makedirs as before.
+    verbatim and let them be created by hts_settings_makedirs as before.
 
-    Note that this relies on the paths being sized PATH\_MAX, which as the
+    Note that this relies on the paths being sized PATH_MAX, which as the
 
-    manpage notes is POSIX.1-2001 conform, but broken by design as PATH\_MAX
+    manpage notes is POSIX.1-2001 conform, but broken by design as PATH_MAX
 
-    can't be relied upon, but the entire codebase makes heavy use of PATH\_MAX
+    can't be relied upon, but the entire codebase makes heavy use of PATH_MAX
 
     and there is a pre-existing usage of realpath() in this way so lets
 
@@ -3502,139 +6118,152 @@
 
     References: b23686a55323625b15d4f99fd7af55259fa21828
 
-[^202]: iptv\_auto: Add support for m3u "channel-number" tag
+
+[^291]: iptv_auto: Add support for m3u "channel-number" tag
 
     SiliconDust recently added m3u playlist generation support to the
 
-    HDHomeRun products. They use "channel-number" for the channel
+    HDHomeRun products.  They use "channel-number" for the channel
 
-    number, so add support for that value to TVHeadend. It is used as
+    number, so add support for that value to TVHeadend.  It is used as
 
     a fallback only if the previously-supported "tvh-chnum" and
 
-    "tvg-chno" tags aren't present. This should be particularly useful
+    "tvg-chno" tags aren't present.  This should be particularly useful
 
     for usage with ATSC 3.0 channels, as those aren't supported in the
 
     libhdhomerun library that TVHeadend normally uses for HDHomeRun
 
-    devices. Without this, the channel number for all channels
+    devices.  Without this, the channel number for all channels
 
     imported from the HDHomeRun m3u is "0".
 
-[^203]: Attempt to fix profile sharer memory leak
+
+[^292]: Attempt to fix profile sharer memory leak
 
     May or may not works, let's see....
 
-[^204]: Revert 4355488b8e1e868cb434bf95676c0944b44e88b3
+
+[^293]: Revert 4355488b8e1e868cb434bf95676c0944b44e88b3
 
     Better fix was implemented in previous commit
 
-[^205]: Ignore PCRE2 illegal accesses
+
+[^294]: Ignore PCRE2 illegal accesses
 
     See https://lists.exim.org/lurker/message/20160113.163710.006b34b9.en.html
 
-[^206]: Added support for ATSC text mode == 0x3F
+
+[^295]: Added support for ATSC text mode == 0x3F
 
     Added support for ATSC text mode == 0x3F
 
-    handling of ATSC text mode == 0x3F (Select Unicode, UTF-16 Form) is added by calling atsc\_utf16\_to\_utf8
+    handling of ATSC text mode == 0x3F (Select Unicode, UTF-16 Form) is added by calling atsc_utf16_to_utf8
 
-    * change to bytecount instead of srclen
+    + change to bytecount instead of  srclen
 
-[^207]: Added more 'text modes' to the ATSC Multiple String Structure decoder and convert text to UTF-8. (Fixes #5162)
 
-    * Added support for decoding ATSC's "Multiple String Structure" text modes 0x1-0x6, 0x9-0x10, 0x20-0x27, 0x30-0x33.
-    * Convert decoded text to UTF-8 instead of ISO-8859-1.
-    *   For unsupported 'compression types' or 'text modes' return a text string "\[comptype=0x??,mode=0x??]" indicating
+[^296]: Added more 'text modes' to the ATSC Multiple String Structure decoder and convert text to UTF-8. (Fixes #5162)
 
-        the attempted compression type and text mode instead of the text segment.
+     - Added support for decoding ATSC's "Multiple String Structure" text modes 0x1-0x6, 0x9-0x10, 0x20-0x27, 0x30-0x33.
+
+     - Convert decoded text to UTF-8 instead of ISO-8859-1.
+
+     - For unsupported 'compression types' or 'text modes' return a text string "[comptype=0x??,mode=0x??]" indicating
+
+       the attempted compression type and text mode instead of the text segment.
 
     Text output from ATSC's "Multiple String Structure" decoder should properly render in web browsers, specifically Unicode characters >= 0x80.
 
-[^208]: Allow network scan to modify muxes
+
+[^297]: Allow network scan to modify muxes
 
     When 'change muxes' option for network discovery is enabled, allow network scan to modify muxes rather than duplicate them on minor changes such as FEC
 
-[^209]: Fixed and cleanup the "PSIP: ATSC Grabber" module (Fixes #5610)
 
-    * Bumped up limit on number of supported EIT/ETT tables from 5 to 256 (this is the max number of EIT/ETT tables in the ATSC specification)
-    * Remove table type 4 as a valid ETT table, there is no support for this table here and table type 4 doesn't supply any EPG data--just long names for channels/services, etc.
-    * Removed the very rapid toggling between mpegts\_table\_{add,destroy}(...) calls on EIT/ETT tables that caused continuous enabling/disabling of EIT and ETT PIDs.
-    * Added an 'ETM Location' check to EIT table handling to ensure that an event's extra text is cleared in the EPG database if there is no matching ETT.
-    * Removed epg\_broadcast\_change\_finish(...) because it was erasing the extra text field in EPG database when updating title in EPG database (in EIT handler).
-    * Added the ability for receiving ETT tables with the same version ID. ETT tables use the same version ID for long runs of event IDs and 'Extra text's.
-    * Fix bug in retrieving the number of tables EIT/ETT tables listed in the MGT table.
-    *   Removed the psip\_{find,remove,add}\_desc(...) functions (and supporting code) that stored ETT extra texts before
+[^298]: Fixed and cleanup the "PSIP: ATSC Grabber" module (Fixes #5610)
 
-        there was a matching EIT event and then would try to match up the ETT extra texts when the EIT event showed up.
+     - Bumped up limit on number of supported EIT/ETT tables from 5 to 256 (this is the max number of EIT/ETT tables in the ATSC specification)
 
-        However, the psip\_\*\_desc(..) functions didn't keep track of the channel and would match up the ETT 'Extra text' with the wrong EIT event.
-    * Removed some non-functional code.
-    * Removed old commented out test code.
-    * Added placeholder support for 'stop' and 'done' functions of this module for future development.
+     - Remove table type 4 as a valid ETT table, there is no support for this table here and table type 4 doesn't supply any EPG data--just long names for channels/services, etc.
+
+     - Removed the very rapid toggling between mpegts_table_{add,destroy}(...) calls on EIT/ETT tables that caused continuous enabling/disabling of EIT and ETT PIDs.
+
+     - Added an 'ETM Location' check to EIT table handling to ensure that an event's extra text is cleared in the EPG database if there is no matching ETT.
+
+     - Removed epg_broadcast_change_finish(...) because it was erasing the extra text field in EPG database when updating title in EPG database (in EIT handler).
+
+     - Added the ability for receiving ETT tables with the same version ID.  ETT tables use the same version ID for long runs of event IDs and 'Extra text's.
+
+     - Fix bug in retrieving the number of tables EIT/ETT tables listed in the MGT table.
+
+     - Removed the psip_{find,remove,add}_desc(...) functions (and supporting code) that stored ETT extra texts before
+
+       there was a matching EIT event and then would try to match up the ETT extra texts when the EIT event showed up.
+
+       However, the psip_*_desc(..) functions didn't keep track of the channel and would match up the ETT 'Extra text' with the wrong EIT event.
+
+     - Removed some non-functional code.
+
+     - Removed old commented out test code.
+
+     - Added placeholder support for 'stop' and 'done' functions of this module for future development.
 
     The "Over-the-air: PSIP: ATSC Grabber" module now quickly and correctly populates 'Title', 'Extra text', 'Start time', 'End time', 'Duration', etc... fields in the EPG Database.
 
-[^210]: Regexps for the finnish EIT scraping
 
-    Changes to be committed:
+[^299]: Regexps for the finnish EIT scraping
 
-    ```
-    new file:   fi
-    ```
+     Changes to be committed:
 
-[^211]: Fix use-after-free
+    	new file:   fi
+
+
+[^300]: Fix use-after-free
 
     Building Tvheadend on Raspberry Pi with gcc 12 fails with this error
 
-    src/misc/json.c: In function ‘json\_parse\_string’:
+    src/misc/json.c: In function ‘json_parse_string’:
 
-    src/misc/json.c:120:31: error: pointer ‘r’ used after ‘free’ \[-Werror=use-after-free]
+    src/misc/json.c:120:31: error: pointer ‘r’ used after ‘free’ [-Werror=use-after-free]
 
-    120 | \*failp = (a - r) + start;
+      120 |                   *failp = (a - r) + start;
 
-    ```
-      |                            ~~~^~~~
-    ```
+          |                            ~~~^~~~
 
     src/misc/json.c:118:19: note: call to ‘free’ here
 
-    118 | free(r);
+      118 |                   free(r);
 
-    ```
-      |                   ^~~~~~~
-    ```
+          |                   ^~~~~~~
 
     This PR appears correct and fixes the gcc error but has not been tested as it is an error path.
 
-[^212]: Fix FTBFS in utils.c
+
+[^301]: Fix FTBFS in utils.c
 
     U+0020 SPACE and U+00A0 NO-BREAK SPACE look the same, but they
 
     aren't the same.
 
-[^213]: fix build with libressl
+
+[^302]: fix build with libressl
 
     Fix the following build failure with libressl raised since
 
     https://github.com/tvheadend/tvheadend/commit/e61acb8ad4a3411f4e7acfd8133d222299f6d47e:
 
-    utils.c:(.text+0x1614): undefined reference to \`EVP\_sha512\_256'
+    utils.c:(.text+0x1614): undefined reference to `EVP_sha512_256'
 
     Fixes:
 
-    * http://autobuild.buildroot.org/results/cb18f6533806f3729f9718bdcc719384be375b66
+     - http://autobuild.buildroot.org/results/cb18f6533806f3729f9718bdcc719384be375b66
 
-    Signed-off-by: Fabrice Fontaine [fontaine.fabrice@gmail.com](mailto:fontaine.fabrice@gmail.com)
+    Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
 
-[^214]: dvr\_disk\_space\_cleanup() - do not return error if called again too soon (#1)
 
-    * Rework disk space check and cleanup
-    * Update dvr.h
-    * Update dvr\_vfsmgr.c
-
-[^215]: Always parse 'src' in RTSP-requests
+[^303]: Always parse 'src' in RTSP-requests
 
     Originally, the code did not parse 'src' in RTSP-requests for
 
@@ -3642,13 +6271,23 @@
 
     allowing e.g. Plex and possibly other SAT>IP-clients to work.
 
-    Signed-off-by: Nita Vesa [werecatf@outlook.com](mailto:werecatf@outlook.com)
+    Signed-off-by: Nita Vesa <werecatf@outlook.com>
 
-[^216]: Update for VAAPI transcoding
+
+[^304]: dvr_disk_space_cleanup() - do not return error if called again too soon (#1)
+
+    * Rework disk space check and cleanup
+
+    * Update dvr.h
+
+    * Update dvr_vfsmgr.c
+
+
+[^305]: Update for VAAPI transcoding
 
     VAAPI: Buffer factor (buffersize manipulation) now configurable at WebUI.
 
-    VAAPI: Added rc\_mode (h264/hevc) and tier (hevc), both configurable via WebUI.
+    VAAPI: Added rc_mode (h264/hevc) and tier (hevc), both configurable via WebUI.
 
     VAAPI: Removed B-Frame workaround from the past at HEVC.
 
@@ -3656,15 +6295,29 @@
 
     VAAPI: Also updated VP8 and VP9 encoding.
 
-    VAAPI: VP8 and VP9 now also reacts on options for "Buffer factor" and "Ignore B-Frames" and got the "force\_key\_frames" expression to increase picture quality.
+    VAAPI: VP8 and VP9 now also reacts on options for "Buffer factor" and "Ignore B-Frames" and got the "force_key_frames" expression to increase picture quality.
 
     VAAPI: Added destroy option for h264 codec (might have created memory issues)
 
-[^217]: SAT>IP client: UPnP header field names are case insensitive
 
-    * SAT>IP Protocol Specification 1.2.2: 3.3.2 Server Advertisements
+[^306]: SAT>IP client: UPnP header field names are case insensitive
 
-[^218]: httpc: Fix multi-value "Connection" header checks
+    - SAT>IP Protocol Specification 1.2.2: 3.3.2 Server Advertisements
+
+
+[^307]: Update buffer size for h264 and hevc
+
+    Increased buffer for h264 and hevc transcoding (from ((self->bit_rate) * 1000) * 2 to ((self->bit_rate) * 1000) * 3). 
+
+    With bigger buffer picture creates less artefacts on lower bitrates.
+
+
+[^308]: Changed debian package version to 7
+
+    Debian Testing does not support versions <7
+
+
+[^309]: httpc: Fix multi-value "Connection" header checks
 
     Connection header was checked for exact "close" or "upgrade" values
 
@@ -3672,45 +6325,46 @@
 
     New function was added for checking such cases.
 
-    Code is based on kv\_find\_value() function from:
+    Code is based on kv_find_value() function from:
 
     https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.sbin/relayd/relayd.c
 
     This fixes #6090
 
-[^219]: Changed debian package version to 7
 
-    Debian Testing does not support versions <7
-
-[^220]: Update buffer size for h264 and hevc
-
-    Increased buffer for h264 and hevc transcoding (from ((self->bit\_rate) \* 1000) \* 2 to ((self->bit\_rate) \* 1000) \* 3).
-
-    With bigger buffer picture creates less artefacts on lower bitrates.
-
-[^221]: Episode number regexp
+[^310]: Episode number regexp
 
     Proposed change to get also episode numbers given like "EP. nnn" (italian channels like Rai Gulp, Rai YoYo)
 
-[^222]: configure: add execinfo option
 
-    Add execinfo option to allow the user to disable the feature even if
-
-    execinfo.h is found on the system
-
-    Signed-off-by: Fabrice Fontaine [fontaine.fabrice@gmail.com](mailto:fontaine.fabrice@gmail.com)
-
-[^223]: some changes to nvenc
-
-    -cleanup of profiles
-
-    -include level selection for nvenc
-
-[^224]: nvenc: Fix Werror=misleading-indentation FTBFS
+[^311]: nvenc: Fix Werror=int-conversion FTBFS (and likely bug)
 
     Commit 0165f365cd58bbcc3734e4ec9ce696b42870ff8e introduced an FTBFS
 
-    when -Werror=misleading-indentation is passed to the compiler. It
+    when -Werror=int-conversion is passed to the compiler.  For
+
+    reasons unknown to me, the "value" argument to AV_DICT_SET_INT was
+
+    written as a string (const char *) rather than the int64_t that
+
+    the function behind the macro was expecting in the "Set Defaults"
+
+    statements.  This was resulting in the value of the pointer to the
+
+    character array getting used as the argument rather than the
+
+    integer itself, which appears to be what was intended.  This
+
+    triggers the Werror=int-conversion error and also probably results
+
+    in unexpected behavior from passing the pointer values.
+
+
+[^312]: nvenc: Fix Werror=misleading-indentation FTBFS
+
+    Commit 0165f365cd58bbcc3734e4ec9ce696b42870ff8e introduced an FTBFS
+
+    when -Werror=misleading-indentation is passed to the compiler.  It
 
     appears from changes elsewhere in the file (around line 450) that
 
@@ -3720,79 +6374,34 @@
 
     also add curlybrackets as was done around 450.)
 
-[^225]: nvenc: Fix Werror=int-conversion FTBFS (and likely bug)
 
-    Commit 0165f365cd58bbcc3734e4ec9ce696b42870ff8e introduced an FTBFS
+[^313]: some changes to nvenc
 
-    when -Werror=int-conversion is passed to the compiler. For
+      -cleanup of profiles
 
-    reasons unknown to me, the "value" argument to AV\_DICT\_SET\_INT was
+      -include level selection for nvenc
 
-    written as a string (const char \*) rather than the int64\_t that
 
-    the function behind the macro was expecting in the "Set Defaults"
+[^314]: configure: add execinfo option
 
-    statements. This was resulting in the value of the pointer to the
+    Add execinfo option to allow the user to disable the feature even if
 
-    character array getting used as the argument rather than the
+    execinfo.h is found on the system
 
-    integer itself, which appears to be what was intended. This
+    Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
 
-    triggers the Werror=int-conversion error and also probably results
 
-    in unexpected behaviour from passing the pointer values.
+[^315]: iptv: Fix stream limit starting a new input on a running mux
 
-[^226]: Use clock\_gettime() instead of time() in epggrab.c
+    In iptv.c:iptv_input_is_free(), if all the conf arguments are 0
 
-    time() appears to return a slightly-rounded value as compared to
+    (when called from input_is_enabled()), return null if the mux
 
-    functions that return higher-precision time like gettimeofday() and
-
-    timespec\_get(). Specifically, when gettimeofday() would return a
-
-    value with a low number in tv\_usec, time() will return one fewer
-
-    seconds than tv\_sec from gettimeofday(). The difference is minute
-
-    and probably doesn't cause an issue in most cases, but here in
-
-    epggrab.c the time of the next cron run is calculated immediately
-
-    after the previous run fires. In this case, the value of time()
-
-    is actually one second lower than the specified cron run time. This
-
-    value is then passed into cron\_multi\_next(), which correctly sets
-
-    the next cron run to the current time. Therefore, as soon as the
-
-    EPG grab completes, cron triggers again and re-runs it. Using the
-
-    more precise values from gettimeofday() (by way of clock\_gettime())
-
-    solves this problem and ensures that cron runs only once.
-
-    This solves #5545 and #5364.
-
-[^227]: Check the return code of snprintf in utils.c:rmtree
-
-    And return -ENAMETOOLONG if the string overflowed. This fixes the
-
-    FTBFS on s390x with recent glibc/gcc versions.
-
-    This fixes #5949.
-
-[^228]: iptv: Fix stream limit starting a new input on a running mux
-
-    In iptv.c:iptv\_input\_is\_free(), if all the conf arguments are 0
-
-    (when called from input\_is\_enabled()), return null if the mux
-
-    associated with the input is already running. If the mux is
+    associated with the input is already running.  If the mux is
 
     already running, starting a new input on it isn't going to create
 
-    a new input stream or break any bandwidth limit. This fixes an
+    a new input stream or break any bandwidth limit.  This fixes an
 
     issue where starting a new channel/input on a mux that is already
 
@@ -3804,34 +6413,81 @@
 
     different functions depending on who called it, so I had a hard
 
-    time understanding exactly what is going on. Therefore, I made
+    time understanding exactly what is going on.  Therefore, I made
 
     this patch in a way to be sure that it wouldn't affect how it works
 
-    in other cases than input\_is\_enabled(). If there is a better way
+    in other cases than input_is_enabled().  If there is a better way
 
     to do this, please do tell me.
 
-[^229]: Improve the performance of updating the pid filter table in hdhomerun digital tuners.
 
-    * Construct the compact list of pids formatted for the hdhomerun and handle edge cases.
-    * For each call to tvhdhomerun\_frontend\_update\_pids(...), only issue one set\_tuner\_filter call to the hdhomerun.
-    * Turn off pids when done using them.
-    * Handle the rare case where the requested list of pids does not fit in to the fixed length buffer by enabling all pids, excluding the NULL pid.
+[^316]: Check the return code of snprintf in utils.c:rmtree
 
-    Previously, calls to update the pids would generate get\_tuner\_filter and set\_tuner\_filter calls for each individual pid.
+    And return -ENAMETOOLONG if the string overflowed.  This fixes the
 
-    Also, while a tuner was allocated, pids would never be freed up from the hdhomerun filter table even when they were no longer needed.
+    FTBFS on s390x with recent glibc/gcc versions.
 
-    And if the list of requested pids had exceeded the fixed length buffer, then not all the requested pids would be properly enabled.
+    This fixes #5949.
 
-    Very noticeably, in cases where the number of pids is large enough, very frequent pid updates would overload the hdhomerun causing it to
 
-    drop bursts of program data (mpegts broadcast packets) every several seconds on all tuners for the duration of the rapid pid updates
+[^317]: Use clock_gettime() instead of time() in epggrab.c
 
-    (reproducible on the HDHR4-2US model).
+    time() appears to return a slightly-rounded value as compared to
 
-[^230]: opentv: fix missing summary data on rescrape, #5995
+    functions that return higher-precision time like gettimeofday() and
+
+    timespec_get().  Specifically, when gettimeofday() would return a
+
+    value with a low number in tv_usec, time() will return one fewer
+
+    seconds than tv_sec from gettimeofday().  The difference is minute
+
+    and probably doesn't cause an issue in most cases, but here in
+
+    epggrab.c the time of the next cron run is calculated immediately
+
+    after the previous run fires.  In this case, the value of time()
+
+    is actually one second lower than the specified cron run time. This
+
+    value is then passed into cron_multi_next(), which correctly sets
+
+    the next cron run to the current time.  Therefore, as soon as the
+
+    EPG grab completes, cron triggers again and re-runs it.  Using the
+
+    more precise values from gettimeofday() (by way of clock_gettime())
+
+    solves this problem and ensures that cron runs only once.
+
+    This solves #5545 and #5364.
+
+
+[^318]: Improve the performance of updating the pid filter table in hdhomerun digital tuners.
+
+     - Construct the compact list of pids formatted for the hdhomerun and handle edge cases.
+
+     - For each call to tvhdhomerun_frontend_update_pids(...), only issue one set_tuner_filter call to the hdhomerun.
+
+     - Turn off pids when done using them.
+
+     - Handle the rare case where the requested list of pids does not fit in to the fixed length buffer by enabling all pids, excluding the NULL pid.
+
+     Previously, calls to update the pids would generate get_tuner_filter and set_tuner_filter calls for each individual pid.
+
+     Also, while a tuner was allocated, pids would never be freed up from the hdhomerun filter table even when they were no longer needed.
+
+     And if the list of requested pids had exceeded the fixed length buffer, then not all the requested pids would be properly enabled.
+
+     Very noticeably, in cases where the number of pids is large enough, very frequent pid updates would overload the hdhomerun causing it to
+
+     drop bursts of program data (mpegts broadcast packets) every several seconds on all tuners for the duration of the rapid pid updates
+
+     (reproducible on the HDHR4-2US model).
+
+
+[^319]: opentv: fix missing summary data on rescrape, #5995
 
     Chunks of events within the OpenTV data can contain blank summaries
 
@@ -3847,7 +6503,8 @@
 
     summary data.
 
-[^231]: opentv: fix incorrect summaries for skyuk epg, fixes #5995
+
+[^320]: opentv: fix incorrect summaries for skyuk epg, fixes #5995
 
     Events within the OpenTV SkyUK data can contain the same Event ID as
 
@@ -3857,75 +6514,93 @@
 
     based solely on the Event ID.
 
-    This commit adjusts the opentv \_entry\_cmp function to match based on a
+    This commit adjusts the opentv _entry_cmp function to match based on a
 
-    combination of Event ID and Channel ID. This enables the RB\_FIND &
+    combination of Event ID and Channel ID. This enables the RB_FIND &
 
-    RB\_INSERT\_SORTED functions used within the OpenTV module to reliably
+    RB_INSERT_SORTED functions used within the OpenTV module to reliably
 
     insert and uniquely find the correct entry.
 
-[^232]: Revert "Remove unnecessary conversion"
+
+[^321]: Revert "Remove unnecessary conversion"
 
     This reverts commit 7757f066582bdb244c56e658c4a99f8e1d5832cd.
 
-[^233]: Remove unnecessary conversion
+
+[^322]: Remove unnecessary conversion
 
     The conversion from unsigned long to long long is not necessary.
 
     Corrected the print statement uses the format code %lu.
 
-[^234]: Upgrade to libhdhomerun\_20210624
+
+[^323]: Upgrade to libhdhomerun_20210624
 
     There is a new version of libhdhomerun
 
-[^235]: Autobuild: Add arm64, armhf and armel for bullseye and buster.
+
+[^324]: Autobuild: Add arm64, armhf and armel for bullseye and buster.
 
     This is mainly for building packages on the Pi running plain-ol Debian and not Raspbian/Raspberry Pi OS, images are available at https://raspi.debian.net.
 
-[^236]: Allow PMT Parsing when PMT shares a PID with another table
+
+[^325]: Allow PMT Parsing when PMT shares a PID with another table
 
     As proposed in #1403
 
-[^237]: else is missing
+
+[^326]: seen is a unsigned type
+
+    Change the format string from d to u. seen is uint32_t -> line 1192
+
+
+[^327]: else is missing
 
     While locking into the code, there seems to miss an else statement. The indentation seems so.
 
-[^238]: seen is a unsigned type
 
-    Change the format string from d to u. seen is uint32\_t -> line 1192
-
-[^239]: Update profile.c
+[^328]: Update profile.c
 
     Added Rewrite MPEG-TS SI settings to the MPEG-TS SPAWN profile panel.
 
-[^240]: Add pid file hint for systemd-sysv-generator
+
+[^329]: Add pid file hint for systemd-sysv-generator
 
     So that for systemd users, systemd-sysv-generator can work out where the pid file is located. And restart on detection that the process has died.
 
-[^241]: Upgrade to libhdhomerun\_20210224
+
+[^330]: Upgrade to libhdhomerun_20210224
 
     There is a new version of libhdhomerun
 
-[^242]: iptv: new features for multicast, rtsp & rtcp
 
-    *   Implement RTCP Negative Acknowledge (a.k.a. Retransmission) support for RTP streams.
+[^331]: iptv: new features for multicast, rtsp & rtcp
+
+    - Implement RTCP Negative Acknowledge (a.k.a. Retransmission) support for RTP streams.
 
         When packet loss is detected the client will send a RTCP Generic Feedback report to the server. The server can than resend these lost packets.
 
         Retransmitted packets are send through a second connection or as part of the main stream, both cases are supported.
 
         For Multicast manual setup of the RTCP server is required, for RTSP automatic setup (was already implemented for Receiver Reports) or manual override is possible.
-    * General clean-up of unused RTCP code and restructure to allow for easy implementation of different types of RTCP messages.
-    * Make RTCP Receiver Reports optional.
-    * RTSP start session with DESCRIBE and parse response content.
-    * RTSP DESCRIBE redirect support.
-    * Parse DESCRIBE response for AVPF support (required for Retransmission).
-    *   Implement remote time shift support for RTSP streams.
+
+    - General clean-up of unused RTCP code and restructure to allow for easy implementation of different types of RTCP messages.
+
+    - Make RTCP Receiver Reports optional.
+
+    - RTSP start session with DESCRIBE and parse response content.
+
+    - RTSP DESCRIBE redirect support.
+
+    - Parse DESCRIBE response for AVPF support (required for Retransmission).
+
+    - Implement remote time shift support for RTSP streams.
 
         This option can be enabled for a channel to pass-through time shift commands to the RTSP server, the internal time shift buffer is then disabled.
 
-[^243]: EMM patch
+
+[^332]: EMM patch
 
     EMM patch, TVheadend stopped sending shared EMM's to OScam.
 
@@ -3935,70 +6610,112 @@
 
     Tested on dvb-c provider nl-Delta.
 
-[^244]: Several coverity fixes, year updated, map muxes between DVB Types
+
+[^333]: Several coverity fixes, year updated, map muxes between DVB Types
 
     * Fix potential double-free
+
     * Add Option to Map Muxes between different DVB-Types
+
     * Fix potential endless loop in RTSP code
+
     * Change years from 2020
+
     * Rewrite scanfile.c for dynamic memory allocation
+
     * More coverity fixes
 
-[^245]: Several enhancements
+
+[^334]: Several enhancements
 
     * Fix potential double-free
+
     * Add Option to Map Muxes between different DVB-Types
+
     * Fix potential endless loop in RTSP code
+
     * Change years from 2020
 
-[^246]: Fix uninitialised memory access for several ioctl commands (#1382)
 
-    * Fix uninitialised memory access in linuxdvb\_frontend.c
-    * FIx unitialized memory access in linuxdvb\_satconf.c
+[^335]: Fix uninitialized memory access for several ioctl commands (#1382)
 
-[^247]: Upgrade to libhdhomerun\_20200907
+    * Fix uninitialized memory access in linuxdvb_frontend.c
+
+    * FIx unitialized memory access in linuxdvb_satconf.c
+
+
+[^336]: fix vaapi-profiles (#1366)
+
+    - remove "Basline" h264 Profil (not exist)
+
+    - include "Main10" and "Rext" in hevc Profiles
+
+    Co-authored-by: fatfred <iphone@fatfred.net>
+
+
+[^337]: Upgrade to libhdhomerun_20200907
 
     There is a new version of libhdhomerun on the home page (also available under Fedora 33)
 
-[^248]: fix vaapi-profiles (#1366)
 
-    * remove "Basline" h264 Profil (not exist)
-    * include "Main10" and "Rext" in hevc Profiles
+[^338]: Fix possible deadlock when using tvh_mutex_trylock()
 
-    Co-authored-by: fatfred [iphone@fatfred.net](mailto:iphone@fatfred.net)
+    Fixes possible deadlock when using tvh_mutex_trylock() macro in thread non-debug mode.
 
-[^249]: Fix possible deadlock when using tvh\_mutex\_trylock()
-
-    Fixes possible deadlock when using tvh\_mutex\_trylock() macro in thread non-debug mode.
-
-    The macro expands to call pthread\_mutex\_lock() instead of pthread\_mutex\_trylock(),
+    The macro expands to call pthread_mutex_lock() instead of pthread_mutex_trylock(),
 
     which most likely is a result of copy/paste.
 
-[^250]: docs: fix simple typo, separately -> separately
+
+[^339]: docs: fix simple typo, seperately -> separately
 
     There is a small typo in src/descrambler/capmt.c.
 
-    Should read `separately` rather than `separately`.
+    Should read `separately` rather than `seperately`.
 
-[^251]: in python 3, dict.has\_key() has been removed
+
+[^340]: in python 3, dict.has_key() has been removed
 
     Ased in operator instead.
 
     Also, added check for empty string.
 
-    Signed-off-by: Christian Eiden [christian@eiden.ch](mailto:christian@eiden.ch)
+    Signed-off-by: Christian Eiden <christian@eiden.ch>
 
-[^252]: Changed shebang of tvhmeta to python
+
+[^341]: Changed shebang of tvhmeta to python
 
     So it should support python 2 and 3
 
-[^253]: Silence x265 warnings (#1368)
+
+[^342]: Silcence x265 warnings (#1368)
 
     * Add patch
+
     * Add patch to Makefile
 
-[^254]: update Makefile.ffmpeg (#1359)
+
+[^343]: Remove wrong test in nvenc.c
+
+    As proposed in #1362
+
+
+[^344]: Fix NVENC
+
+    - corrected "Rate Control" Settings:
+
+       - removed Deprecated Settings
+
+       - include new Settings
+
+    - corrected "Profile":
+
+       - include missing hevc profile "Rext"
+
+       - fixed profile selection: before we always had a profile higher as we choose (order is different then in other h264/hevc encoder)
+
+
+[^345]: update Makefile.ffmpeg (#1359)
 
     -Include NASM 2.15.05
 
@@ -4020,22 +6737,15 @@
 
     -edited libx265.pie.diff for newer x265
 
-    Co-authored-by: fatfred [iphone@fatfred.net](mailto:iphone@fatfred.net)
+    Co-authored-by: fatfred <iphone@fatfred.net>
 
-[^255]: Fix NVENC
 
-    * corrected "Rate Control" Settings:
-      * removed Deprecated Settings
-      * include new Settings
-    * corrected "Profile":
-      * include missing hevc profile "Rext"
-      * fixed profile selection: before we always had a profile higher as we choose (order is different then in other h264/hevc encoder)
+[^346]: Revert dca46eedd9653b90d2722e67281eed0b35740730
 
-[^256]: Remove wrong test in nvenc.c
+    Reverts dca46eedd9653b90d2722e67281eed0b35740730 as it's broken anyways.
 
-    As proposed in #1362
 
-[^257]: Fix scraping 'new' flag from UK EIT.
+[^347]: Fix scraping 'new' flag from UK EIT.
 
     1. The regular expression must contain a subgroup match to be recognised
 
@@ -4043,11 +6753,8 @@
 
     2. Follow xmltv.c and set flag to 1.
 
-[^258]: Revert dca46eedd9653b90d2722e67281eed0b35740730
 
-    Reverts dca46eedd9653b90d2722e67281eed0b35740730 as it's broken anyways.
-
-[^259]: Fix escape code '\&quote;' should be '"'. (#1355)
+[^348]: Fix escape code '&quote;' should be '&quot;'. (#1355)
 
     For example S3.2.4:
 
@@ -4057,33 +6764,36 @@
 
     https://dev.w3.org/html5/html-author/charref
 
-    The browsers I tested displayed '\&quote;' as
+    The browsers I tested displayed '&quote;' as
 
     double quote marks followed by "e;".
 
-[^260]: Revert "HTSP v35: Add support for recording file size" (#1352)
 
-    This reverts commit 8d43c6600cf8fec2879a9d1f9633d7f70ba90bed as dataSize is already a property.
-
-[^261]: HTSP v35: Add support for recording file size
+[^349]: HTSP v35: Add support for recording file size
 
     As proposed in #1332
 
-[^262]: Handle bad UTF-8 in xmltv (#5909)
+
+[^350]: Revert "HTSP v35: Add support for recording file size" (#1352)
+
+    This reverts commit 8d43c6600cf8fec2879a9d1f9633d7f70ba90bed as dataSize is already a property.
+
+
+[^351]: Handle bad UTF-8 in xmltv (#5909)
 
     We had a string where we had a rogue byte (0x8a) which was not part of
 
-    a UTF-8 string. This then caused some downstream parsers to abort
+    a UTF-8 string.  This then caused some downstream parsers to abort
 
     processing the document; other parsers ignored the bad character.
 
     As an interim fix, we now parse the individual characters and filter
 
-    out invalid characters. We replace such characters with a space
+    out invalid characters.  We replace such characters with a space
 
     character (instead of a U+FFFD replacement character) since this
 
-    is typically user presentable data on a "10ft interface". An
+    is typically user presentable data on a "10ft interface".  An
 
     alternative would be to completely discard the character, but the
 
@@ -4091,31 +6801,35 @@
 
     character used to be.
 
-[^263]: CSS: general improvements
 
-    * Unify css code; spaces, commas...
-    * Fix multiple paddings for progress bar (SNR/Signal Strenght).
-    * Slightly increase 'TVadapters' width (design collision).
-    * Slightly increase 'SAT>IP Servers' width (design collision).
-    * ACCESS: Fix width for spinner arrows (image was repeated).
-    * ACCESS: Fix transparent line at bottom of not filled progress bar (SNR/Signal Strenght).
+[^352]: Attempt to fix doozer builds (#1340)
 
-[^264]: Makefile.ffmpeg: update almost all upstream packages
+    * Update lib.sh
 
-    * Updated x264 to its the latest snapshot 20191216 as their
+    * Install python3 requirements
+
+
+[^353]: Makefile.ffmpeg: update almost all upstream packages
+
+    - Updated x264 to its the latest snapshot 20191216 as their
 
     snapshotting service was discontinued.
 
-    * Updated x265 to version 3.2.
-    * Updated libvpx to version 1.8.2.
-    * Updated libogg to version 1.3.4
-    * Updated fdk-aac to version 0.1.6
+    - Updated x265 to version 3.2.
+
+    - Updated libvpx to version 1.8.2.
+
+    - Updated libogg to version 1.3.4
+
+    - Updated fdk-aac to version 0.1.6
 
     There is version 2.0.x, but let's leave it for later.
 
-    * Updated opus to version 1.3.1
-    * Updated nv-codec-headers to version 8.2.15.10
-    * Updated ffmpeg to version 4.1.5
+    - Updated opus to version 1.3.1
+
+    - Updated nv-codec-headers to version 8.2.15.10
+
+    - Updated ffmpeg to version 4.1.5
 
     Fixes CVEs:
 
@@ -4135,44 +6849,102 @@
 
     Misc changes:
 
-    *   Changed url for libogg, libtheora, libvorbis to use HTTPS and previous
+    - Changed url for libogg, libtheora, libvorbis to use HTTPS and previous
 
-        site points to new one
-    * FFmpeg now uses HTTPS
+      site points to new one
 
-[^265]: Attempt to fix doozer builds (#1340)
+    - FFmpeg now uses HTTPS
 
-    * Update lib.sh
-    * Install python3 requirements
 
-[^266]: Remove dead assignment
+[^354]: CSS: general improvements
+
+    * Unify css code; spaces, commas...
+
+    * Fix multiple paddings for progress bar (SNR/Signal Strenght).
+
+    * Slightly increase 'TVadapters' width (design collision).
+
+    * Slightly increase 'SAT>IP Servers' width (design collision).
+
+    * ACCESS: Fix width for spinner arrows (image was repeated).
+
+    * ACCESS: Fix transparent line at bottom of not filled progress bar (SNR/Signal Strenght).
+
+
+[^355]: Remove dead assignment
 
     variable `channel` is assigned conditionally in line 997.
 
-[^267]: Webui: minimal reworks for access theme
+
+[^356]: Webui: minimal reworks for access theme
 
     * Edit the help image to reduce the white saw edges.
+
     * Use white images for tvdb and tmdb when using access.
 
-[^268]: access: added missing break for connection limit type
 
-    Before update aa\_conn\_limit\_streaming was always set to ae\_conn\_limit, if limit type was set to ALL in gui.
+[^357]: access: added missing break for connection limit type
 
-    Now aa\_conn\_limit\_dvr and aa\_conn\_limit\_streaming is set correctly
+    Before update aa_conn_limit_streaming was always set to ae_conn_limit, if limit type was set to ALL in gui.
+
+    Now aa_conn_limit_dvr and aa_conn_limit_streaming is set correctly
 
     Ticket: https://tvheadend.org/issues/5692
 
-[^269]: bugfix for autorecs duplicate episode number detection in autorecs
 
-    "record if different episode number" doesn't work as expected in the master branch:
+[^358]: Avoid configure checks being optimized away with LTO
 
-    see https://tvheadend.org/issues/5632
+    In case the checks are compiled with CFLAGS including "-O1 -flto" (or any
 
-    With this modification, the season will be taken into account,
+    other optimization level), a "test()" function not referenced by by main
 
-    as it was before, in order to determine if two episodes have different episode numbers or not.
+    will be optimized away and discarded prior to the final linking step, and
 
-[^270]: xmltv: Allow sending basic xmltv format, fixes #5630
+    there will be no undefined symbols, thus the checks always succeeds.
+
+    This at least affects the "strlcpy"/"strlcat" checks, but may affects other
+
+    checks as well.
+
+
+[^359]: systemd service file: remove wildcard mounts preventing startup - replace with a note
+
+    fixes #5678
+
+
+[^360]: tvhcsa.c: include stdio.h
+
+    Fixes uclibc build error:
+
+    CC              src/descrambler/tvhcsa.o
+
+    In file included from /home/buildroot/autobuild/instance-0/output/build/tvheadend-8f1de1621d78c91431238176bf4f6290870a031a/src/tvhlog.h:30:0,
+
+                     from src/descrambler/tvhcsa.h:30,
+
+                     from src/descrambler/tvhcsa.c:19:
+
+    /home/buildroot/autobuild/instance-0/output/build/tvheadend-8f1de1621d78c91431238176bf4f6290870a031a/src/tvh_thread.h:163:25:
+
+     error: unknown type name '__do_not_use_pthread_mutex_t'
+
+     #define pthread_mutex_t __do_not_use_pthread_mutex_t
+
+    detected by buildroot autobuilder:
+
+    http://autobuild.buildroot.net/results/627/627e7080e655005d6724b9977670cc73059d6281/
+
+
+[^361]: xmltv: Avoid outputting lang tags in xmltv for only one language, fixes #5630
+
+    For most sources of guide information, we only have one language.
+
+    If we output xmltv with language tags just makes the xmltv output
+
+    larger with no benefit.
+
+
+[^362]: xmltv: Allow sending basic xmltv format, fixes #5630
 
     Some devices have very limited memory and can not handle our full
 
@@ -4192,7 +6964,8 @@
 
     (broken) TVs require this.
 
-[^271]: htsp: Allow basic htsp format, fixes #5630
+
+[^363]: htsp: Allow basic htsp format, fixes #5630
 
     The tvguide can be very large for very low memory devices. So allow
 
@@ -4200,105 +6973,65 @@
 
     reducing memory overhead.
 
-[^272]: xmltv: Avoid outputting lang tags in xmltv for only one language, fixes #5630
 
-    For most sources of guide information, we only have one language.
+[^364]: bugfix for autorecs duplicate episode number detection in autorecs
 
-    If we output xmltv with language tags just makes the xmltv output
+    "record if different episode number" doesn't work as expected in the master branch:
 
-    larger with no benefit.
+    see https://tvheadend.org/issues/5632
 
-[^273]: tvhcsa.c: include stdio.h
+    With this modification, the season will be taken into account,
 
-    Fixes uclibc build error:
+    as it was before, in order to determine if two episodes have different episode numbers or not.
 
-    CC src/descrambler/tvhcsa.o
 
-    In file included from /home/buildroot/autobuild/instance-0/output/build/tvheadend-8f1de1621d78c91431238176bf4f6290870a031a/src/tvhlog.h:30:0,
-
-    ```
-                 from src/descrambler/tvhcsa.h:30,
-
-                 from src/descrambler/tvhcsa.c:19:
-    ```
-
-    /home/buildroot/autobuild/instance-0/output/build/tvheadend-8f1de1621d78c91431238176bf4f6290870a031a/src/tvh\_thread.h:163:25:
-
-    error: unknown type name '\_\_do\_not\_use\_pthread\_mutex\_t'
-
-    \#define pthread\_mutex\_t \_\_do\_not\_use\_pthread\_mutex\_t
-
-    detected by buildroot autobuilder:
-
-    http://autobuild.buildroot.net/results/627/627e7080e655005d6724b9977670cc73059d6281/
-
-[^274]: systemd service file: remove wildcard mounts preventing startup - replace with a note
-
-    fixes #5678
-
-[^275]: Avoid configure checks being optimised away with LTO
-
-    In case the checks are compiled with CFLAGS including "-O1 -flto" (or any
-
-    other optimisation level), a "test()" function not referenced by main
-
-    will be optimised away and discarded prior to the final linking step, and
-
-    there will be no undefined symbols, thus the checks always succeeds.
-
-    This at least affects the "strlcpy"/"strlcat" checks, but may affects other
-
-    checks as well.
-
-[^276]: bouquet: fix overflow when building for 32-bit system On 32-bit system hash value from service can be truncated.
+[^365]: bouquet: fix overflow when building for 32-bit system On 32-bit system hash value from service can be truncated.
 
     For example with #SERVICE 1:0:1:835:3EA:2174:EEEE0000:0:0:0
 
-    hash value EEEE0000 become 7FFFFFFF and there is no match in function mpegts\_service\_find\_e2().
+    hash value EEEE0000 become 7FFFFFFF and there is no match in function mpegts_service_find_e2().
 
-[^277]: Include stdio.h before tvheadend headers
+
+[^366]: Include stdio.h before tvheadend headers
 
     Fixes build error with uClibc: https://www.tvheadend.org/issues/5667
 
-[^278]: Makefile: fix -pie linking according to --disable-pie
 
-    Only compilation follows './configure --disable-pie', linking instead
-
-    doesn't, because '-pie' flag is passed to LDFLAGS uncoditionally.
-
-    So add '-pie' flag only if CONFIG\_PIE=yes.
-
-    Signed-off-by: Giulio Benetti [giulio.benetti@micronovasrl.com](mailto:giulio.benetti@micronovasrl.com)
-
-[^279]: Fix compilation with libhdhomerun 20190621
-
-    They renamed the symbol that was used to determine whether the
-
-    "hdhomerun\_discover\_find\_devices\_custom" needed to be aliased,
-
-    causing an FTBFS. Instead, recognize both the old and new symbols.
-
-[^280]: revert bogus ONID and TSID remapping
+[^367]: revert bogus ONID and TSID remapping
 
     ONID and TSID values of 65535 (0xFFFF) are used and valid values.
 
     This fix allows the proper reception of streams with this value.
 
-[^281]: capmt: fix for the oscam r11520+, fixes #5649
 
-    * allow to force the PMT composing, too
+[^368]: Fix compilation with libhdhomerun 20190621
 
-[^282]: fanart: Fix decode error.
+    They renamed the symbol that was used to determine whether the
 
-    The text returned from the server is utf-8 so needs an explicit
+    "hdhomerun_discover_find_devices_custom" needed to be aliased,
 
-    decode otherwise it defaults to ASCII and fails for programmes
+    causing an FTBFS.  Instead, recognize both the old and new symbols.
 
-    with non-ASCII titles.
 
-[^283]: en50221: fix invalid htsmsg manipulation
+[^369]: Makefile: fix -pie linking according to --disable-pie
 
-    htsmsg\_add\_msg() frees the provided submsg and returns a new pointer to
+    Only compilation follows './configure --disable-pie', linking instead
+
+    doesn't, because '-pie' flag is passed to LDFLAGS uncoditionally.
+
+    So add '-pie' flag only if CONFIG_PIE=yes.
+
+    Signed-off-by: Giulio Benetti <giulio.benetti@micronovasrl.com>
+
+
+[^370]: capmt: fix for the oscam r11520+, fixes #5649
+
+    - allow to force the PMT composing, too
+
+
+[^371]: en50221: fix invalid htsmsg manipulation
+
+    htsmsg_add_msg() frees the provided submsg and returns a new pointer to
 
     it.
 
@@ -4306,9 +7039,10 @@
 
     now invalid original pointer.
 
-[^284]: en50221: fix menu text decoding
 
-    getmenutext() checks that dvb\_get\_string() returns greater than 0, but
+[^372]: en50221: fix menu text decoding
+
+    getmenutext() checks that dvb_get_string() returns greater than 0, but
 
     that function returns 0 on success.
 
@@ -4316,19 +7050,66 @@
 
     texts.
 
-    Fix the check to match dvb\_get\_string() behaviour.
+    Fix the check to match dvb_get_string() behavior.
 
-[^285]: Freesat\_huffman: Suppress characters < 0x20 except \n.
+
+[^373]: fanart: Fix decode error.
+
+    The text returned from the server is utf-8 so needs an explicit
+
+    decode otherwise it defaults to ASCII and fails for programmes
+
+    with non-ASCII titles.
+
+
+[^374]: Freesat_huffman: Suppress characters < 0x20 except \n.
 
     Bug #5366 reported control codes appearing in EPG data on UK Freeview; this was fixed in commit 3ae6d947a4d074b3498e59f82d5a860273b0ae7f. However the same issue affects DVB-T2 channels where the EPG is Huffman coded.
 
-    freesat\_huffman.c already has code to suppress these control codes, however the decoding is stopped when one is encountered and so the text is truncated. This patch drops the control codes but continues to decode the remaining text.
+    freesat_huffman.c already has code to suppress these control codes, however the decoding is stopped when one is encountered and so the text is truncated. This patch drops the control codes but continues to decode the remaining text.
 
-[^286]: Update to newest ffmpeg to fix libX11 compile issue "DSO missing from commandline"
+
+[^375]: Update to newest ffmpeg to fix libX11 compile issue "DSO missing from commandline"
 
     Fixes #5504
 
-[^287]: dvr: Only check minseason/maxseason/minyear/maxyear if EPG has these values, fixes #5479
+
+[^376]: dvr: New fmt spec for per-dir seasons and one movie per dir. (#4667)
+
+    Previously the $q format specifier would only output movies as:
+
+    	tvmovies/title (yyyy).ts
+
+    However, a common alternative is to store each movie in its
+
+    own sub-directory:
+
+    	tvmovies/title1 (yyyy)/title1 (yyyy).ts
+
+    	tvmovies/title2 (yyyy)/title2 (yyyy).ts
+
+    Similarly for episodes we output:
+
+    	tvshows/title/title - SxxEyy.ts
+
+    But a common alternative is to have one directory per season:
+
+    	tvshows/title/Season 1/title - S01Eyy.ts
+
+    	tvshows/title/Season 2/title - S02Eyy.ts
+
+    So we now add a "$3q" to output these common alternatives, as requested
+
+    in the forums.
+
+    Also add equivalent "$3Q" to output without the "genre" prefix
+
+    i.e., without "tvshows/" or "tvmovies/".
+
+    Issue: #4667
+
+
+[^377]: dvr: Only check minseason/maxseason/minyear/maxyear if EPG has these values, fixes #5479
 
     Previously if user specified a minseason=5 then we'd only record episodes that have
 
@@ -4346,65 +7127,13 @@
 
     Issue: 5479
 
-[^288]: dvr: New fmt spec for per-dir seasons and one movie per dir. (#4667)
 
-    Previously the $q format specifier would only output movies as:
+[^378]: ui: Make dialogs slightly bigger.
 
-    ```
-    tvmovies/title (yyyy).ts
-    ```
+    Some text is getting truncated so make the dialogs bigger.
 
-    However, a common alternative is to store each movie in its
 
-    own sub-directory:
-
-    ```
-    tvmovies/title1 (yyyy)/title1 (yyyy).ts
-
-    tvmovies/title2 (yyyy)/title2 (yyyy).ts
-    ```
-
-    Similarly for episodes we output:
-
-    ```
-    tvshows/title/title - SxxEyy.ts
-    ```
-
-    But a common alternative is to have one directory per season:
-
-    ```
-    tvshows/title/Season 1/title - S01Eyy.ts
-
-    tvshows/title/Season 2/title - S02Eyy.ts
-    ```
-
-    So we now add a "$3q" to output these common alternatives, as requested
-
-    in the forums.
-
-    Also add equivalent "$3Q" to output without the "genre" prefix
-
-    i.e., without "tvshows/" or "tvmovies/".
-
-    Issue: #4667
-
-[^289]: main: Replace deprecated ERR\_remove\_state
-
-    ERR\_remove\_thread\_state has been the successor since version 1.0.0.
-
-    Fixes compilation without deprecated APIs on 1.0.0 and above.
-
-[^290]: Fix several errors detected by w3c css validator
-
-    2234 .x-grid3-header-title Value Error : padding auto is not a padding value : auto 1px
-
-    5792 Parse Error }
-
-    5798 \* Parse Error \*/ .x-grid3-hd-row td.ux-filtered-column { font-style:italic; font-weight:bold }
-
-    6529 .dvr-details-dialog Property postition doesn't exist. The closest matching property name is position : relative
-
-[^291]: api: Alternative showings match on title if no series link, fixes #5402
+[^379]: api: Alternative showings match on title if no series link, fixes #5402
 
     Some broadcasts do not have series link, so alternative showings returned
 
@@ -4416,31 +7145,47 @@
 
     Fixes: #5402
 
-[^292]: ui: Make dialogs slightly bigger.
 
-    Some text is getting truncated so make the dialogs bigger.
+[^380]: Fix several errors detected by w3c css validator
 
-[^293]: Revert "dvr: move dvr\_notify() call to the global\_lock using timers, fixes #5437"
+    2234 	.x-grid3-header-title 	Value Error : padding auto is not a padding value : auto 1px
+
+    5792 		Parse Error }
+
+    5798 	* 	Parse Error */ .x-grid3-hd-row td.ux-filtered-column { font-style:italic; font-weight:bold }
+
+    6529 	.dvr-details-dialog 	Property postition doesn't exist. The closest matching property name is position : relative
+
+
+[^381]: main: Replace deprecated ERR_remove_state
+
+    ERR_remove_thread_state has been the successor since version 1.0.0.
+
+    Fixes compilation without deprecated APIs on 1.0.0 and above.
+
+
+[^382]: Revert "dvr: move dvr_notify() call to the global_lock using timers, fixes #5437"
 
     This reverts commit 91f6de4437f13d51a854ffe999cca63ff2ef503c.
 
-[^294]: webui, htsbuf: Content-Disposition escape chars are not correct.
+
+[^383]: webui, htsbuf: Content-Disposition escape chars are not correct.
 
     When attempting to download a recording with a comma Google Chrome will
 
-    fail with ERR\_RESPONSE\_HEADERS\_MULTIPLE\_CONTENT\_DISPOSITION. This is
+    fail with ERR_RESPONSE_HEADERS_MULTIPLE_CONTENT_DISPOSITION. This is
 
-    because the comma ',' in the filename\*=UTF-8'' field was not escaped.
+    because the comma ',' in the filename*=UTF-8'' field was not escaped.
 
     This commit implements the defined list of non-escape characters from
 
-    RFC8187 based on htsbuf\_append\_and\_escape\_url.
+    RFC8187 based on htsbuf_append_and_escape_url.
 
     The same problem occurs in issue #2086. Fixed in 2fdfe4836 "webui: fix the
 
     attachment; filename encoding, fixes #2086" and broken again in ab9fc249a
 
-    "fix htsbuf\_append\_and\_escape\_url() - don't escape more allowed characters,
+    "fix htsbuf_append_and_escape_url() - don't escape more allowed characters,
 
     fixes #3721".
 
@@ -4448,33 +7193,42 @@
 
     https://bugs.chromium.org/p/chromium/issues/detail?id=454165
 
-[^295]: epggrab: run internal grabbers only when wanted, fixes #5421
 
-    * remove the forced internal grabber run when the config is updated
+[^384]: epggrab: run internal grabbers only when wanted, fixes #5421
 
-    \-- users can trigger the run manually
+    - remove the forced internal grabber run when the config is updated
 
-    * add possibility to disable the initial internal grabbers run
+    -- users can trigger the run manually
 
-[^296]: imagecache: big cleanups
+    - add possibility to disable the initial internal grabbers run
 
-    * let imagecache work also for fanart / recording specific images
-    * let imagecache work for EPG entries
-    * global cleanups (try to have only one function for duplicate things)
-    * fix the local file handling when imagecache is not enabled for external URLs
-    * imagecache code is part of the tvh's core code (cannot be ommited from compilation)
 
-[^297]: ui: Enable scrollbar for dialog info, fixes #5405
+[^385]: imagecache: big cleanups
+
+    - let imagecache work also for fanart / recording specific images
+
+    - let imagecache work for EPG entries
+
+    - global cleanups (try to have only one function for duplicate things)
+
+    - fix the local file handling when imagecache is not enabled for external URLs
+
+    - imagecache code is part of the tvh's core code (cannot be ommited from compilation)
+
+
+[^386]: ui: Enable scrollbar for dialog info, fixes #5405
 
     When the dvr info dialog has a lot of text it was overflowing
 
     on to the buttons in the bbar.
 
-[^298]: dvr: move the initial dvr\_autorec\_purge\_obsolete\_timers() call to better place, fixes #5406
 
-    * dvr\_entry\_set\_timer() must be called before
+[^387]: dvr: move the initial dvr_autorec_purge_obsolete_timers() call to better place, fixes #5406
 
-[^299]: dvr: Autorec rules must still match event after update. (#4760).
+    - dvr_entry_set_timer() must be called before
+
+
+[^388]: dvr: Autorec rules must still match event after update. (#4760).
 
     We now check the autorec rule matches an event following an
 
@@ -4522,19 +7276,22 @@
 
     Issue: #4299.
 
-[^300]: http: forbidden status / access\_verify2() cleanups, fixes #5391
+
+[^389]: http: forbidden status / access_verify2() cleanups, fixes #5391
 
     Return also forbidden status when the client is authenticated, but there
 
     are not permissions for the requested operation.
 
-[^301]: api: Fix NULL blank argument.
+
+[^390]: api: Fix NULL blank argument.
 
     The blank argument is NULL on several paths, so fix this to
 
     reference a local variable so we can lookup channel name properly.
 
-[^302]: ui: Add alternative/similar broadcast buttons, fixes #5335, #5336
+
+[^391]: ui: Add alternative/similar broadcast buttons, fixes #5335, #5336
 
     Add two buttons to EPG and DVR info dialogs, one to show related
 
@@ -4552,17 +7309,16 @@
 
     Issue: #5335, #5336.
 
-[^303]: webui: epg: fix compatibility issue for FreeBSD
+
+[^392]: webui: epg: fix compatibility issue for FreeBSD
 
     The EPG screen serviced by FreeBSD port of tvheadend has two abnormal control
 
-    behaviours:
+    behaviors:
 
-    ```
-    Reset All button makes the list empty
+        Reset All button makes the list empty
 
-    Typing and then deleting any search string also makes the list empty.
-    ```
+        Typing and then deleting any search string also makes the list empty.
 
     This patch fixes the symptoms above.
 
@@ -4570,57 +7326,20 @@
 
     Changes since v1:
 
-    * call reset only if required
+    - call reset only if required
 
-[^304]: main: Fix OpenSSL 1.1 compilation without deprecated APIs
+
+[^393]: main: Fix OpenSSL 1.1 compilation without deprecated APIs
 
     Also fixed compilation for OpenSSL without ENGINE support.
 
-[^305]: dvr: Fix season/episode unique test when recording.
 
-    The test for season/episode numbers the same has become broken during
+[^394]: webui: access theme - color correction for EPG count info
 
-    the changeover of types from string to int. So it was only checking
+    EPG events count was black so we can't see it with access theme.
 
-    episode numbers, meaning that S02E01 would not record if S01E01 was
 
-    available.
-
-[^306]: dvr: Alter test for season/episode on unique path.
-
-    If we have an episode number and it differs from the other side
-
-    then we know it is not a dup. Similarly with a season number.
-
-[^307]: updated nginx example
-
-    the tvheadend no longer seems to like the = sign in the option
-
-    \--http\_root /my/tvh/server (working)
-
-    \--http\_root=/my/tvh/server (doesnt work)
-
-    nginx config updated to include the Connection "upgrade" to deal with the WS: /comet/ws traffic
-
-[^308]: Need to delete files on complex scheduling when replacing timer after crash.
-
-    Scenario: Complex scheduling enabled. Recording ok, then crash and restart.
-
-    In this case, the recording is not currently running, so we can find a
-
-    better recording. If there is a better recording later in the week,
-
-    that show will get preference (since complex recording states we don't
-
-    want a partial recording so prefer a later date for a full recording).
-
-    But, we used to destroy the dvr\_entry, but this does not delete its
-
-    associated files so they would be left on disk as orphans/unreferenced
-
-    from any dvr/log file.
-
-[^309]: dvr: Add option to automatically delete recording after playback.
+[^395]: dvr: Add option to automatically delete recording after playback.
 
     Previously when watching a programme, the user usually has to then
 
@@ -4650,19 +7369,61 @@
 
     file will be marked as watched near the end of the show.
 
-[^310]: webui: access theme - colour correction for EPG count info
 
-    EPG events count was black so we can't see it with access theme.
+[^396]: Need to delete files on complex scheduling when replacing timer after crash.
 
-[^311]: Update server.c
+    Scenario: Complex scheduling enabled. Recording ok, then crash and restart.
+
+    In this case, the recording is not currently running, so we can find a
+
+    better recording.  If there is a better recording later in the week,
+
+    that show will get preference (since complex recording states we don't
+
+    want a partial recording so prefer a later date for a full recording).
+
+    But, we used to destroy the dvr_entry, but this does not delete its
+
+    associated files so they would be left on disk as orphans/unreferenced
+
+    from any dvr/log file.
+
+
+[^397]: updated nginx example
+
+    the tvheadend no longer seems to like the = sign in the option 
+
+    --http_root /my/tvh/server (working)
+
+    --http_root=/my/tvh/server (doesnt work)
+
+    nginx config updated to include the Connection "upgrade" to deal with the WS: /comet/ws traffic
+
+
+[^398]: dvr: Fix season/episode unique test when recording.
+
+    The test for season/episode numbers the same has become broken during
+
+    the changeover of types from string to int. So it was only checking
+
+    episode numbers, meaning that S02E01 would not record if S01E01 was
+
+    available.
+
+
+[^399]: dvr: Alter test for season/episode on unique path.
+
+    If we have an episode number and it differs from the other side
+
+    then we know it is not a dup. Similarly with a season number.
+
+
+[^400]: Update server.c
 
     fix small typo
 
-[^312]: Revert "FreeBSD: Fix recv problem if no data received."
 
-    This reverts commit 3895c923a3a959da05080831b8146c09ed143b00.
-
-[^313]: FreeBSD: kevent is not a bitmask.
+[^401]: FreeBSD: kevent is not a bitmask.
 
     The kevent does not take a bitmask. So if you register for READ|WRITE
 
@@ -4674,24 +7435,31 @@
 
     So we need to register these separately.
 
-[^314]: **github\_repo:** /home/dmc/development/TVH/changelog/tvheadend
 
-    **output\_file:** /home/dmc/development/TVH/changelog/tvheadend/changelog.md
+[^402]: Revert "FreeBSD: Fix recv problem if no data received."
 
-    **output\_json:** None
+    This reverts commit 3895c923a3a959da05080831b8146c09ed143b00.
 
-    **input\_json:** None
 
-    **ignore\_new:** False
+[^403]: **github_repo:**  /home/runner/work/tvheadend-test/tvheadend-test
 
-    **skip\_cs:** True
+    **output_file:**  /tmp/release-change-log.md
 
-    **skip\_latest:** True
+    **output_rolling:**  None
 
-    **skip\_recent:** True
+    **output_json:**  None
 
-    **skip\_changelog:** False
+    **input_json:**  None
+
+    **ignore_new:**  False
+
+    **skip_latest:**  True
+
+    **skip_recent:**  True
+
+    **skip_changelog:**  False
 
     **First date fetched:** 2018-10-16
 
-    **Records found:** 953
+    **Records found:** 1228
+


### PR DESCRIPTION
This pull request updates `introduction/release-change-log.md`
using the latest output from `support/create_changelog.py` in
the tvheadend source repository after a PR merge to `master`.