### PR TITLE
installation: tell users to install the package after adding the repo

### DIFF
--- a/installation/linux.md
+++ b/installation/linux.md
@@ -10,12 +10,26 @@ Run the following shell command to setup a local `apt` repo:
 curl -1sLf 'https://dl.cloudsmith.io/public/tvheadend/tvheadend/setup.deb.sh' | sudo -E bash
 ```
 
+Then install Tvheadend:
+
+```
+sudo apt-get install tvheadend
+```
+
+During installation you will be prompted to create an administrator account; enter a username and password. When it finishes, Tvheadend is reachable on port `9981` (for example `http://localhost:9981/`).
+
 ## RPM Packages (Fedora, RedHat)
 
 Run the following shell command to setup a local `dnf` or `yum` repo:
 
 ```
 curl -1sLf 'https://dl.cloudsmith.io/public/tvheadend/tvheadend/setup.rpm.sh' | sudo -E bash
+```
+
+Then install Tvheadend:
+
+```
+sudo dnf install tvheadend
 ```
 
 > Tvheadend aims to provide installable packages for as long as possible to extend the usable life of server and tuner hardware. In practice this means if we can still automate regular build testing for popular distributions and versions we will have binaries available.


### PR DESCRIPTION
## installation: tell users to install the package after adding the repo

  ### Problem

  The Linux install page lists the Cloudsmith repo-setup command and then stops:

  ```
  curl -1sLf 'https://dl.cloudsmith.io/public/tvheadend/tvheadend/setup.deb.sh' | sudo -E bash
  ```

  That only configures the `apt`/`dnf` repository — it doesn't install Tvheadend.
  A new user following the page is left at a working repo with nothing installed
  and no indication of the next step.

  ### Change

  Add the explicit install step after each repo-setup command:

  - **DEB** (Debian/Ubuntu/RaspiOS): `sudo apt-get install tvheadend`, plus a note
    that installation prompts for an administrator account and that the web UI is
    on port `9981`.
  - **RPM** (Fedora/RedHat): `sudo dnf install tvheadend`.

  Only `installation/linux.md` is touched.

  ### Result

  ```markdown
  ## DEB Packages (Debian, Ubuntu, RaspiOS)

  Run the following shell command to setup a local `apt` repo:

      curl -1sLf 'https://dl.cloudsmith.io/public/tvheadend/tvheadend/setup.deb.sh' | sudo -E bash

  Then install Tvheadend:

      sudo apt-get install tvheadend

  During installation you will be prompted to create an administrator account;
  enter a username and password. When it finishes, Tvheadend is reachable on
  port 9981 (for example http://localhost:9981/).
  ```
